### PR TITLE
[UP-3315] Fix some XSS issue around inputting usernames.  The issue was ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>jasig-parent</artifactId>
         <version>35</version>
     </parent>
-    
+
     <prerequisites>
         <maven>3.0.0</maven>
     </prerequisites>
@@ -20,19 +20,19 @@
     <name>uPortal Parent</name>
     <description>The root project definition for the uPortal project.</description>
     <url>${jasig-site-base}/uportal/${project.version}</url>
-    
+
     <scm>
         <connection>scm:git:git://github.com/Jasig/uPortal.git</connection>
         <developerConnection>scm:git:git@github.com:Jasig/uPortal.git</developerConnection>
         <url>https://github.com/Jasig/uPortal</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <issueManagement>
         <url>${jasig-issues-base}/UP</url>
         <system>${jasig-issues-system}</system>
     </issueManagement>
-    
+
     <ciManagement>
         <system>bamboo</system>
         <url>http://developer.jasig.org/bamboo/browse/UP</url>
@@ -49,14 +49,14 @@
     </ciManagement>
 
     <repositories>
-        <repository>            
+        <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
             <url>http://oss.sonatype.org/content/repositories/snapshots</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
-        <repository>            
+        <repository>
             <id>apache-snapshots</id>
             <name>Apache Snapshots</name>
             <url>http://repository.apache.org/snapshots</url>
@@ -66,14 +66,14 @@
     </repositories>
 
     <pluginRepositories>
-        <pluginRepository>            
+        <pluginRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
             <url>http://oss.sonatype.org/content/repositories/snapshots</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
-        <pluginRepository>            
+        <pluginRepository>
             <id>apache-snapshots</id>
             <name>Apache Snapshots</name>
             <url>http://repository.apache.org/snapshots</url>
@@ -118,7 +118,7 @@
         <jasig-widget-portlets.version>2.0.1</jasig-widget-portlets.version>
         <NewsReaderPortlet.version>3.0.7</NewsReaderPortlet.version>
         <NotificationPortlet.version>2.0.3</NotificationPortlet.version>
-        <SimpleContentPortlet.version>1.0.7</SimpleContentPortlet.version>
+        <SimpleContentPortlet.version>1.0.9</SimpleContentPortlet.version>
         <WeatherPortlet.version>1.1.0</WeatherPortlet.version>
         <WebProxyPortlet.version>1.1.8</WebProxyPortlet.version>
 
@@ -216,7 +216,7 @@
          | they log in. 
          +-->
         <mobile.user.agent.regex>(.*iPhone.*)|(.*Android.*)|(.*IEMobile.*)|(.*Safari.*Pre.*)|(.*Nokia.*AppleWebKit.*)|(.*Black[Bb]erry.*)|(.*Opera Mobile.*)|(.*Windows Phone.*)|(.*Fennec.*)|(.*Minimo.*)</mobile.user.agent.regex>
-        
+
         <project.build.sourceVersion>1.6</project.build.sourceVersion>
         <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -494,7 +494,7 @@
                 <groupId>javax.servlet.jsp</groupId>
                 <artifactId>jsp-api</artifactId>
                 <version>${jsp-api.version}</version>
-            </dependency> 
+            </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
@@ -765,8 +765,8 @@
                 <version>${jasig-portlet-utils.version}</version>
                 <exclusions>
                     <exclusion>
-                      <artifactId>jcl-over-slf4j</artifactId>
-                      <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
                     </exclusion>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -780,8 +780,8 @@
                 <version>${resource-server.version}</version>
                 <exclusions>
                     <exclusion>
-                         <groupId>org.slf4j</groupId>
-                         <artifactId>jcl-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -791,8 +791,8 @@
                 <version>${resource-server.version}</version>
                 <exclusions>
                     <exclusion>
-                         <groupId>org.slf4j</groupId>
-                         <artifactId>jcl-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -802,8 +802,8 @@
                 <version>${resource-server.version}</version>
                 <exclusions>
                     <exclusion>
-                         <groupId>org.slf4j</groupId>
-                         <artifactId>jcl-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -835,11 +835,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency> 
-                <groupId>org.jasypt</groupId> 
-                <artifactId>jasypt</artifactId> 
-                <version>${jasypt.version}</version> 
-            </dependency> 
+            <dependency>
+                <groupId>org.jasypt</groupId>
+                <artifactId>jasypt</artifactId>
+                <version>${jasypt.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jadira.usertype</groupId>
                 <artifactId>usertype.core</artifactId>
@@ -1094,7 +1094,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -1122,12 +1122,12 @@
                         </goals>
                         <configuration>
                             <rules>
-                              <requireMavenVersion>
-                                <version>2.2</version>
-                              </requireMavenVersion>
-                              <requireJavaVersion>
-                                <version>1.6</version>
-                              </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>2.2</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.6</version>
+                                </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>
@@ -1315,7 +1315,7 @@
                     <groupId>org.apache.portals.pluto</groupId>
                     <artifactId>maven-pluto-plugin</artifactId>
                     <version>${pluto.version}</version>
-                </plugin>  
+                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>

--- a/uportal-war/src/main/java/org/jasig/portal/utils/jsp/Util.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/jsp/Util.java
@@ -20,14 +20,16 @@
 package org.jasig.portal.utils.jsp;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.Map;
-
-import org.jasig.portal.spring.beans.factory.ObjectMapperFactoryBean;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jasig.portal.spring.beans.factory.ObjectMapperFactoryBean;
+import org.springframework.web.util.UriUtils;
+
 
 /**
  * JSP Static utility functions
@@ -73,5 +75,46 @@ public class Util {
 
     public static String json(Object obj) throws JsonGenerationException, JsonMappingException, IOException {
         return OBJECT_MAPPER.writeValueAsString(obj);
+    }
+
+
+    /**
+     * URL encode a path segment.  This is just a thin wrapper around UriUtils.encodePathSegment.  It is intended
+     * for the case where you are building URLs in JS.  c:url + escapeBody doesn't correctly escape
+     * the contents (especially "</script>"), and fn:escapeXml incorrectly encodes the URL (it escapes chars
+     * like '<' as &lt; instead of %3C).  It should help avoid XSS attacks when building RESTful
+     * URLS in js.  Example:
+     *
+     * Given:  ${userId} -> "<script>alert('test')</script>
+     *
+     * ...
+     * <script>
+     *     $.ajax({ url: <c:url value='/users/${up:encodePathSegment(userId)}'/> });
+     * </script>
+     *
+     * Will encode the URL as:
+     *
+     * /users/%3Cscript%3Ealert('test%')%3C%2Fscript%3E
+     *
+     * IMPORTANT:
+     * Note that this encodes the '/' in </script>  to %2F.  Unfortunately, tomcat
+     * still does not interpret %2F correctly unless you relax some security
+     * settings (@see tomcat.apache.org/tomcat-7.0-doc/config/systemprops.html#Security,
+     * the ALLOW_ENCODED_SLASH property).  So, while this method does a better job
+     * at avoiding XSS issues than c:url, it's still not ideal.  Unless the
+     * input is whitelisted to avoid invalid input chars, it's still possible to
+     * end up with REST URLs that won't work correctly (like the one above), but at
+     * least this will protect you from XSS attacks on the front end.
+     *
+     * @param val the path segment to encode
+     * @return the encoded path segment
+     */
+    public static String encodePathSegment(String val) {
+        try {
+            return UriUtils.encodePathSegment(val, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // should be unreachable...
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
@@ -163,8 +163,8 @@ up.jQuery(function() {
 
     var pager;
     var editUrl = "${editUrl}";
-    var targetUrl = "<c:url value="/api/assignments/target/${ principalString }.json?includeInherited=true"/>";
-    var principalUrl = "<c:url value="/api/assignments/principal/${ principalString }.json?includeInherited=true"/>";
+    var targetUrl = "<c:url value="/api/assignments/target/${ up:encodePathSegment(principalString) }.json?includeInherited=true"/>";
+    var principalUrl = "<c:url value="/api/assignments/principal/${ up:encodePathSegment(principalString) }.json?includeInherited=true"/>";
 
     var getPermissionAssignments = function(url) {
         var rslt;

--- a/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
@@ -178,8 +178,8 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
         var $ = up.jQuery;
 
         var pager;
-        var targetUrl = "<c:url value="/api/assignments/target/${ personEntity.principalString }.json?includeInherited=true"/>";
-        var principalUrl = "<c:url value="/api/assignments/principal/${ personEntity.principalString }.json?includeInherited=true"/>";
+        var targetUrl = "<c:url value="/api/assignments/target/${ up:encodePathSegment(personEntity.principalString) }.json?includeInherited=true"/>";
+        var principalUrl = "<c:url value="/api/assignments/principal/${ up:encodePathSegment(personEntity.principalString) }.json?includeInherited=true"/>";
         var editUrl = "${editUrl}";
         var deleteUrl = "${deleteUrl}";
 

--- a/uportal-war/src/main/webapp/WEB-INF/tag/uportal.tld
+++ b/uportal-war/src/main/webapp/WEB-INF/tag/uportal.tld
@@ -115,4 +115,16 @@
             ${up:json(obj)}
         </example>
     </function>
+    <function>
+        <description>
+            URL encodes a single path segment.  Intended for building RESTful URLs where
+            variable values may contain illegal characters.
+        </description>
+        <name>encodePathSegment</name>
+        <function-class>org.jasig.portal.utils.jsp.Util</function-class>
+        <function-signature>java.lang.String encodePathSegment(java.lang.String)</function-signature>
+        <example>
+            ${up:urlEncode("www.example.com/image.png")}
+        </example>
+    </function>
 </taglib>


### PR DESCRIPTION
...occurring because "</script>" always terminates the

JS block -- even if that's inside a string.  The JS interpreter would terminate the block and then misinterpret the unterminated
contents of the string as executable code.  The *right* solution for this is probably to start whitelisting the
input characters for every input field. Any field that will be part of a RESTful URL should not be allowed to contain the '/'
character.  The "solution" in this commit is intended as a stop-gap.  It solves this biggest issue -- the XSS vulnerability --
but it doesn't fully solve the issues caused by invalid chars in the input.  IMO, this is better than what we had, but
still not great.
(cherry picked from commit b034dec)