### PR TITLE
UP-4320 Demonstrate BROWSE permission filtering

### DIFF
--- a/uportal-war/src/main/data/quickstart_entities/group_membership/Instructors-Not-Students.group-membership.xml
+++ b/uportal-war/src/main/data/quickstart_entities/group_membership/Instructors-Not-Students.group-membership.xml
@@ -20,11 +20,11 @@
 
 -->
 <group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
-  <name>Instructors</name>
+  <name>Instructors-Not-Students</name>
+    <!-- Demonstrates that a group can be DENYed permission on a subcategory of a category on which
+    they enjoy the permission.  Namely, Students are not permitted to BROWSE this sub-category. -->
   <entity-type>org.jasig.portal.portlet.om.IPortletDefinition</entity-type>
   <creator>system</creator>
-  <description>Instructor Portlets</description>
-  <children>
-      <group>Instructors-Not-Students</group>
-  </children>
+  <description>Instructor Portlets that Students are not permitted to BROWSE.</description>
+  <children/>
 </group>

--- a/uportal-war/src/main/data/quickstart_entities/permissions_set/Everyone_BROWSE_SpecificPortlets-permission-set.xml
+++ b/uportal-war/src/main/data/quickstart_entities/permissions_set/Everyone_BROWSE_SpecificPortlets-permission-set.xml
@@ -46,4 +46,10 @@
     <target permission-type="GRANT">
         <group>News</group>
     </target>
+    <target permission-type="GRANT">
+        <group>uPortal</group>
+    </target>
+    <target permission-type="GRANT">
+        <group>Featured</group>
+    </target>
 </permission-set>

--- a/uportal-war/src/main/data/quickstart_entities/permissions_set/Everyone_BROWSE_SpecificPortlets-permission-set.xml
+++ b/uportal-war/src/main/data/quickstart_entities/permissions_set/Everyone_BROWSE_SpecificPortlets-permission-set.xml
@@ -41,9 +41,6 @@
         <group>Information</group>
     </target>
     <target permission-type="GRANT">
-        <group>Instructors</group>
-    </target>
-    <target permission-type="GRANT">
         <group>Library</group>
     </target>
     <target permission-type="GRANT">

--- a/uportal-war/src/main/data/quickstart_entities/permissions_set/Staff_BROWSE_Instructors-permission-set.xml
+++ b/uportal-war/src/main/data/quickstart_entities/permissions_set/Staff_BROWSE_Instructors-permission-set.xml
@@ -19,12 +19,19 @@
     under the License.
 
 -->
-<group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
-  <name>Instructors</name>
-  <entity-type>org.jasig.portal.portlet.om.IPortletDefinition</entity-type>
-  <creator>system</creator>
-  <description>Instructor Portlets</description>
-  <children>
-      <group>Instructors-Not-Students</group>
-  </children>
-</group>
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <!-- need to grant this directly to Staff rather than Everyone because Students
+        have another path to Everyone than their Students group membership and that would break
+        the Students deny on browsing Instructors-Not-Students. -->
+        <group>Staff</group>
+    </principal>
+    <activity>BROWSE</activity>
+    <!-- Enumerates the categories that staff and students
+        may browse in the Marketplace. -->
+    <target permission-type="GRANT">
+        <group>Instructors</group>
+    </target>
+</permission-set>

--- a/uportal-war/src/main/data/quickstart_entities/permissions_set/Students_BROWSE_Instructors-permission-set.xml
+++ b/uportal-war/src/main/data/quickstart_entities/permissions_set/Students_BROWSE_Instructors-permission-set.xml
@@ -19,12 +19,19 @@
     under the License.
 
 -->
-<group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
-  <name>Instructors</name>
-  <entity-type>org.jasig.portal.portlet.om.IPortletDefinition</entity-type>
-  <creator>system</creator>
-  <description>Instructor Portlets</description>
-  <children>
-      <group>Instructors-Not-Students</group>
-  </children>
-</group>
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <!-- need to grant this directly to Students rather than Everyone because Students
+        have another path to Everyone than their Students group membership and that would break
+        the Students deny on browsing Instructors-Not-Students. -->
+        <group>Students</group>
+    </principal>
+    <activity>BROWSE</activity>
+    <!-- Enumerates the categories that staff and students
+        may browse in the Marketplace. -->
+    <target permission-type="GRANT">
+        <group>Instructors</group>
+    </target>
+</permission-set>

--- a/uportal-war/src/main/data/quickstart_entities/permissions_set/Students_BROWSE_deny_Instructors-Not-Students_permission-set.xml
+++ b/uportal-war/src/main/data/quickstart_entities/permissions_set/Students_BROWSE_deny_Instructors-Not-Students_permission-set.xml
@@ -19,12 +19,15 @@
     under the License.
 
 -->
-<group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
-  <name>Instructors</name>
-  <entity-type>org.jasig.portal.portlet.om.IPortletDefinition</entity-type>
-  <creator>system</creator>
-  <description>Instructor Portlets</description>
-  <children>
-      <group>Instructors-Not-Students</group>
-  </children>
-</group>
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>Students</group>
+    </principal>
+    <activity>BROWSE</activity>
+    <!-- Students may not browse the not-browseable-by-students portlet. -->
+    <target permission-type="DENY">
+        <group>Instructors-Not-Students</group>
+    </target>
+</permission-set>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/not-browseable-by-students.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/not-browseable-by-students.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+
+    <!-- This is an example of a portlet definition that is in the Instructor category but is
+    nonetheless not BROWSEable by Students.  It demonstrates that non-BROWSE-able portlet
+    definitions are suppressed when viewing Related Portlets of the "Faculty Welcome" example
+    portlet in the default data set. -->
+
+    <title>Students Cannot Browse This</title>
+    <name>Students Cannot Browse This</name>
+    <fname>not-browseable-by-students</fname>
+    <desc>An example portlet definition not browseable by Students.</desc>
+    <type>CMS</type>
+    <timeout>10000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/SimpleContentPortlet</ns2:webAppName>
+        <ns2:portletName>cms</ns2:portletName>
+    </portlet-descriptor>
+    <!-- this category is browsable by Instructors but not by Students. -->
+    <category>Instructors-Not-Students</category>
+    <group>Everyone</group>
+    <parameter>
+        <name>configurable</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
+        <name>iconUrl</name>
+        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png</value>
+    </parameter>
+    <portlet-preference>
+        <name>content</name>
+        <readOnly>false</readOnly>
+        <value>
+            
+                &lt;h2&gt;Not browseable by students.&lt;/h2&gt;
+                
+                &lt;p&gt;
+                    While this portlet can be rendered by Students, it cannot be BROWSEed by
+                    students, and so the student example user view on Marketplace, related
+                    portlets, etc. demonstrates Marketplace filtering away items the user
+                    cannot BROWSE.
+                &lt;/p&gt;
+            
+        </value>
+    </portlet-preference>
+</portlet-definition>


### PR DESCRIPTION
Adds an example portlet definition and example `BROWSE` permissions configuration to demonstrate that the student user does not see a related portlet that the staff user does see, due to the student user lacking a BROWSE permission ( [UP-4320](https://issues.jasig.org/browse/UP-4320) ).

This demonstrates that `BROWSE` permission filtering on related portlets works and sets the stage to validate that Marketplace (and other?) search filters on `BROWSE` when that feature is implemented in the future.