### PR TITLE
UP-4371 wrap Cobertura <excludes> in <instrumentation>.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1559,13 +1559,13 @@
                         <maxmem>256m</maxmem>
                         <!-- aggregated reports for multi-module projects -->
                         <aggregate>true</aggregate>
-
-                        <excludes>
-                            <!-- Exclude generated classes -->
-                            <exclude>**/*_.class</exclude>
-                            <exclude>**/*_.java</exclude>
-                        </excludes>
-
+                        <instrumentation>
+                            <excludes>
+                                <!-- Exclude generated classes -->
+                                <exclude>**/*_.class</exclude>
+                                <exclude>**/*_.java</exclude>
+                            </excludes>
+                        </instrumentation>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
[UP-4371](https://issues.jasig.org/browse/UP-4371): As [documented](http://mojo.codehaus.org/cobertura-maven-plugin/usage.html), the `<excludes>` Cobertura configuration ought to be wrapped in an `<instrumentation>`.