### PR TITLE
UP-4370 ignore IntelliJ-generated overlays directories on license check.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1289,7 +1289,7 @@
                         <exclude>**/src/main/webapp/media/skins/universality/hc/jquery-ui-1.7.2.custom/**</exclude>
                         <exclude>**/src/test/resources/org/jasig/portal/io/xml/**/*expected.*.xml</exclude>
                         <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
-                        <exclude>overlays/**</exclude>  <!-- for intelliJ Idea -->
+                        <exclude>**/overlays/**</exclude>  <!-- for intelliJ Idea -->
                     </excludes>
                     <mapping>
                         <crn>XML_STYLE</crn>


### PR DESCRIPTION
[UP-4370](https://issues.jasig.org/browse/UP-4370) : widen the exclusion match in the licensing plugin configuration in `pom.xml` to ignore the IntelliJ-generated `overlays` directories when applying license check.

This issue tripped up the uPortal `4.2.0-M1` release process momentarily.