### PR TITLE
UP-4209 require Servlet3 / Tomcat 7+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ uPortal uses Travis-CI for lightweight continuous integration.  You can see buil
 
 ## Requirements
 * JDK 1.7 or later - Just a JRE is not sufficient, a full JDK is required
-* Servlet 2.5 Container - Tomcat 7.0 is recommended, there some configuration changes that must be made for Tomcat which are documented in the [uPortal manual](https://wiki.jasig.org/display/UPM41/Installing+Tomcat).
+* Servlet 3.0 Container - Tomcat 7.0 or later is required. There some configuration changes that
+must be made for Tomcat which are documented in the [uPortal manual](https://wiki.jasig.org/display/UPM41/Installing+Tomcat).
 * Maven 3.0.3 or later
 * Ant 1.8.2 or 1.9.3 or later.
 

--- a/releaseNotes.html
+++ b/releaseNotes.html
@@ -32,7 +32,8 @@ will be less than what is discovered about the release over time.</p>
 <h2>Requirements:</h2>
 <ul>
 <li>JDK 1.7 or later</li>
-<li>Tomcat 7.x is recommended.  (Servlet 2.5 is required.) Other servlet containers may work. YMMV.</li>
+<li>Tomcat 7.x or later is required.  (Servlet 3.0 is required.) Other servlet containers may work.
+    YMMV.</li>
 <li>Database (Oracle, Postgres, MySQL are commonly used in production; 
 these and HSQLDB are commonly used in development; specific vendors and
 versions are supported via declaration in the rdbm.properties file)</li>


### PR DESCRIPTION
[UP-4209](https://issues.jasig.org/browse/UP-4209) : Updates `README.md` and release notes documentation to state requirement of Servlet v3 / Tomcat 7 (rather than stating support for Servlet 2.5 which implies Tomcat 6.)

This requirement is only documentation-deep at this point.  This updates the documentation so that the project can confidently not worry about Servlet 2.5 / Tomcat 6 support for uPortal 4.2 and beyond.  Presumably future opportunities will arise to do servlet-spec-y things that benefit from that Servlet 3 version.