### PR TITLE
UP-4372 Invoke mvn with -q for quieter and slightly faster builds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1623,6 +1623,11 @@ IMPORTANT: The '-Dpattern=' property is no longer a regular expression and is a 
         </condition>
         <property name="filters.arg" value="-Djasig.ignore" />
 
+        <condition property="maven.verbosity" value="-q">
+            <isset property="maven.quiet" />
+        </condition>
+        <property name="maven.verbosity" value="-Djasig.ignore" />
+
         <!--
          | Shell to execute maven.  Do not use mvn ant task.  See http://jira.codehaus.org/browse/MANTTASKS-246.
          | Setup parameters for mac/linux/unix vs. windows.  For windows, run cmd /c mvn.bat.
@@ -1644,6 +1649,7 @@ IMPORTANT: The '-Dpattern=' property is no longer a regular expression and is a 
         </condition>
         <property name="windowsCmdArg2" value="-Djasig.ignore"/>
 
+        <echo message="Running mvn in ${pomDir} for goals: ${goal} ${goal1} ${goal2}"/>
         <exec executable="${mvnExecutable}" dir="${pomDir}" failonerror="true">
             <arg value="${windowsCmdArg1}"/>
             <arg value="${windowsCmdArg2}"/>
@@ -1654,6 +1660,7 @@ IMPORTANT: The '-Dpattern=' property is no longer a regular expression and is a 
             <arg value="${offline}" />
             <arg value="${env.arg}" />
             <arg value="${filters.arg}" />
+            <arg value="${maven.verbosity}" />
             <arg value="${goal}" />
             <arg value="${goal1}" />
             <arg value="${goal2}" />

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -827,7 +827,7 @@
             <plugin>
                 <groupId>org.bsc.maven</groupId>
                 <artifactId>maven-processor-plugin</artifactId>
-                <version>2.0.5</version>
+                <version>2.2.4</version>
                 <executions>
                     <execution>
                         <id>process</id>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4372

Quiet's maven builds slightly by removing the INFO logs lines from maven output.  Changes build from 157Kb output (https://issues.jasig.org/secure/attachment/14704/build-initial.txt) to around 37Kb output (https://issues.jasig.org/secure/attachment/14705/build-q.txt).

Invoke with -Dmaven.quiet=true; e.g.
ant -Dmaven.quiet=true clean deploy-ear

When there is a compilation error, you'll see something like:

     [echo] Running mvn in /home/jwennmacher/projects/uPortal/uportal-war for goals: install -Djasig.ignore -Djasig.ignore
     [exec] [ERROR] diagnostic: /home/jwennmacher/projects/uPortal/uportal-war/src/main/java/org/jasig/portal/rest/ImportExportController.java:94: error: ';' expected
     [exec]         final PortalDataKey portalDataKey = bob getPortalDataKey(bufferedXmlEventReader);
     [exec]                                                ^
     [exec] [ERROR] error on execute: error during compilation

Oddly test execution is not an INFO so it is still present in the console output.  Not really a big deal since logging it to console adds almost no time to build and does let you know whether you are running the tests (useful for people like me that have shell scripts to build with the tests normally disabled -- reminds us that they are not running).