### PR TITLE
UP-4369 Respondr: Focus on portlet also present in region displays same portlet twice

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -322,12 +322,34 @@
    | These two templates render the focused portlet content.
   -->
   <xsl:template match="focused">
+    <!--
+        Check for the existance of the "focused" portlet in a region.  If one is found, prevent the portlet from rendering
+        in the content portion of the layout.  Test for a match against the fname, ID, and channel ID.
+    -->
+    <xsl:variable name="focusedFname">
+        <xsl:value-of select="//focused/channel/@fname"/>
+    </xsl:variable>  
+
+    <xsl:variable name="focusedChannelID">
+        <xsl:value-of select="//focused/channel/@chanID"/>
+    </xsl:variable>
+
+    <xsl:variable name="focusedID">
+        <xsl:value-of select="//focused/channel/@ID"/>
+    </xsl:variable>
+
+    <xsl:variable name="focusedMatchTest">
+        <xsl:value-of select="not(((//region/channel[@fname=$focusedFname]) and (//region/channel/@chanID=$focusedChannelID)) and (//region/channel[@ID=$focusedID]))"/>
+    </xsl:variable> 
+    
     <div class="fluid-row">
         <div class="col-md-12">
             <div id="portalPageBodyColumns" class="columns-1">
                 <div class="portal-page-column column-1">
                     <div class="portal-page-column-inner"> <!-- Column inner div for additional presentation/formatting options.  -->
-                    <xsl:apply-templates select="channel|blocked-channel"/>
+                        <xsl:if test="not($focusedMatchTest = 'false')">
+                            <xsl:apply-templates select="channel|blocked-channel"/>
+                        </xsl:if>
                   </div>
                 </div>
             </div>

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -323,8 +323,9 @@
   -->
   <xsl:template match="focused">
     <!--
-        Check for the existance of the "focused" portlet in a region.  If one is found, prevent the portlet from rendering
+        Check for the existence of the "focused" portlet in a region.  If one is found, prevent the portlet from rendering
         in the content portion of the layout.  Test for a match against the fname, ID, and channel ID.
+        See UP-4369 for additional information.
     -->
     <xsl:variable name="focusedFname">
         <xsl:value-of select="//focused/channel/@fname"/>
@@ -338,8 +339,8 @@
         <xsl:value-of select="//focused/channel/@ID"/>
     </xsl:variable>
 
-    <xsl:variable name="focusedMatchTest">
-        <xsl:value-of select="not(((//region/channel[@fname=$focusedFname]) and (//region/channel/@chanID=$focusedChannelID)) and (//region/channel[@ID=$focusedID]))"/>
+    <xsl:variable name="focusedPortletPresentInRegion">
+        <xsl:value-of select="(((//region/channel[@fname=$focusedFname]) and (//region/channel/@chanID=$focusedChannelID)) and (//region/channel[@ID=$focusedID]))"/>
     </xsl:variable> 
     
     <div class="fluid-row">
@@ -347,7 +348,7 @@
             <div id="portalPageBodyColumns" class="columns-1">
                 <div class="portal-page-column column-1">
                     <div class="portal-page-column-inner"> <!-- Column inner div for additional presentation/formatting options.  -->
-                        <xsl:if test="not($focusedMatchTest = 'false')">
+                        <xsl:if test="$focusedPortletPresentInRegion = 'false'">
                             <xsl:apply-templates select="channel|blocked-channel"/>
                         </xsl:if>
                   </div>


### PR DESCRIPTION
Altered the Respondr content.xsl to determine if the the focused portlet exists in a region.  If it exists, then there is no need to display it again in the main content area.  Particularly problematic for the Notification portlet when it is added to the sidebar along with having the Notification Icon.

![before](https://cloud.githubusercontent.com/assets/1420340/5589436/0d159c20-90dc-11e4-940c-23460589e8e0.png)
![after](https://cloud.githubusercontent.com/assets/1420340/5589437/0f6d669c-90dc-11e4-8542-48411b8d39a0.png)


