### PR TITLE
UP-4380 Updating Less code so that portlet-options-link-color works

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -123,13 +123,13 @@ section h4 {
     .border-radiuses-top(@portlet-border-radius);
     position: relative;
 
-    h2 {
+    > h2 {
         font-size: 14px;
         padding: 7px 7px;
         margin: 0;
         list-style: none;
         line-height: 20px;
-        a {
+        > a {
             color: @portlet-titlebar-link-color;
             &:hover {
                 color: darken(@portlet-titlebar-link-color, 20%)


### PR DESCRIPTION
By changing the portal-titlebar color in Less it would also update the portal-options-links color. This patch makes it so the two variables can work independently. 