### PR TITLE
UP-4403 : Adds json export feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
         <mockito.version>1.9.5</mockito.version>
         <net.oauth.version>20100527</net.oauth.version>
         <objenesis.version>2.1</objenesis.version>
+        <org.json.version>20090211</org.json.version>
         <org.springframework.webflow.version>2.3.2.RELEASE</org.springframework.webflow.version>
         <oro.version>2.0.8</oro.version>
         <persistence-api.version>1.0</persistence-api.version>
@@ -444,6 +445,11 @@
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
                 <version>${tomcat-jdbc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${org.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>dom4j</groupId>

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -621,6 +621,11 @@
 
 
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.lesscss</groupId>
             <artifactId>lesscss</artifactId>
             <exclusions>


### PR DESCRIPTION
With this you can now do `/api/{entity-type}/{entity-id}?format=JSON` (example `/api/portlet-definition/portal-activity?format=JSON`) which will return a JSON representation of the entity file.  Import may come in the future, but this is a step in that direction. By not passing in a format it will give you XML (just like it is today).