### PR TITLE
UP-4404 : Add in fetch single portlet

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rest/LayoutRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/LayoutRESTController.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.rest;
 
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import java.util.List;
 
 import javax.portlet.WindowState;
 import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portal.IUserPreferencesManager;
@@ -32,6 +34,7 @@ import org.jasig.portal.layout.dlm.DistributedUserLayout;
 import org.jasig.portal.portlet.dao.IPortletDefinitionDao;
 import org.jasig.portal.portlet.om.IPortletDefinition;
 import org.jasig.portal.portlet.om.IPortletDefinitionParameter;
+import org.jasig.portal.portlet.om.IPortletPreference;
 import org.jasig.portal.portlet.om.IPortletWindowId;
 import org.jasig.portal.rest.layout.LayoutPortlet;
 import org.jasig.portal.rest.layout.TabListOfNodes;
@@ -135,27 +138,12 @@ public class LayoutRESTController {
             for (int i = 0; i < portletNodes.getLength(); i++) {
                 try {
                     
-                    LayoutPortlet portlet = new LayoutPortlet();
+                    
                     NamedNodeMap attributes = portletNodes.item(i).getAttributes();
-                    portlet.setTitle(attributes.getNamedItem("title").getNodeValue());
-                    portlet.setDescription(attributes.getNamedItem("description").getNodeValue());
-                    portlet.setNodeId(attributes.getNamedItem("ID").getNodeValue());
-                    portlet.setFname(attributes.getNamedItem("fname").getNodeValue());
-                    
                     IPortletDefinition def = portletDao.getPortletDefinitionByFname(attributes.getNamedItem("fname").getNodeValue());
+                    LayoutPortlet portlet = new LayoutPortlet(def);
                     
-                    //get icons
-                    IPortletDefinitionParameter iconParam = def.getParameter("iconUrl");
-                    if (iconParam != null) {
-                        portlet.setIconUrl(iconParam.getValue());
-                    }
-                    
-                    IPortletDefinitionParameter faIconParam = def.getParameter("faIcon");
-                    if(faIconParam != null) {
-                        portlet.setFaIcon(faIconParam.getValue());
-                    }
-                    
-                    portlet.setTarget(def.getTarget());
+                    portlet.setNodeId(attributes.getNamedItem("ID").getNodeValue());
                     
                     //get alt max URL
                     String alternativeMaximizedLink = def.getAlternativeMaximizedLink();

--- a/uportal-war/src/main/java/org/jasig/portal/rest/LayoutRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/LayoutRESTController.java
@@ -94,6 +94,7 @@ public class LayoutRESTController {
         this.portletDao = portletDao;
     }
     
+    
     /**
      * A REST call to get a json feed of the current users layout
      * @param request The servlet request. Utilized to get the users instance and eventually there layout
@@ -160,15 +161,17 @@ public class LayoutRESTController {
                     String alternativeMaximizedLink = def.getAlternativeMaximizedLink();
                     if( alternativeMaximizedLink != null) {
                     	portlet.setUrl(alternativeMaximizedLink);
+                    	portlet.setAltMaxUrl(true);
                     } else {
-	                    // get the maximized URL for this portlet
-	                    final IPortalUrlBuilder portalUrlBuilder = urlProvider.getPortalUrlBuilderByLayoutNode(request, attributes.getNamedItem("ID").getNodeValue(), UrlType.RENDER);
-	                    final IPortletWindowId targetPortletWindowId = portalUrlBuilder.getTargetPortletWindowId();
-	                    if (targetPortletWindowId != null) {
-	                        final IPortletUrlBuilder portletUrlBuilder = portalUrlBuilder.getPortletUrlBuilder(targetPortletWindowId);
-	                        portletUrlBuilder.setWindowState(WindowState.MAXIMIZED);
-	                    }
-	                    portlet.setUrl(portalUrlBuilder.getUrlString());
+                        // get the maximized URL for this portlet
+                        final IPortalUrlBuilder portalUrlBuilder = urlProvider.getPortalUrlBuilderByLayoutNode(request, attributes.getNamedItem("ID").getNodeValue(), UrlType.RENDER);
+                        final IPortletWindowId targetPortletWindowId = portalUrlBuilder.getTargetPortletWindowId();
+                        if (targetPortletWindowId != null) {
+                            final IPortletUrlBuilder portletUrlBuilder = portalUrlBuilder.getPortletUrlBuilder(targetPortletWindowId);
+                            portletUrlBuilder.setWindowState(WindowState.MAXIMIZED);
+                        }
+                        portlet.setUrl(portalUrlBuilder.getUrlString());
+                        portlet.setAltMaxUrl(false);
                     }
                     portlets.add(portlet);
 

--- a/uportal-war/src/main/java/org/jasig/portal/rest/PortletsRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/PortletsRESTController.java
@@ -103,9 +103,9 @@ public class PortletsRESTController {
         LayoutPortlet portlet = new LayoutPortlet(portletDef);
         return new ModelAndView("json", "portlet", portlet);
       } else {
-        //throw some error code back to web call
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        return new ModelAndView("json");
       }
-      return new ModelAndView("json", "portlet", null);
     }
 
     private Set<String> getPortletCategories(IPortletDefinition pdef) {

--- a/uportal-war/src/main/java/org/jasig/portal/rest/PortletsRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/PortletsRESTController.java
@@ -33,12 +33,14 @@ import org.jasig.portal.portlet.om.IPortletDefinition;
 import org.jasig.portal.portlet.om.PortletCategory;
 import org.jasig.portal.portlet.registry.IPortletCategoryRegistry;
 import org.jasig.portal.portlet.registry.IPortletDefinitionRegistry;
+import org.jasig.portal.rest.layout.LayoutPortlet;
 import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IPerson;
 import org.jasig.portal.security.IPersonManager;
 import org.jasig.portal.services.AuthorizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -89,6 +91,21 @@ public class PortletsRESTController {
 
         return new ModelAndView("json", "portlets", rslt);
 
+    }
+    
+    @RequestMapping(value="/portlet/{fname}.json", method = RequestMethod.GET)
+    public ModelAndView getPortlet(HttpServletRequest request, HttpServletResponse response, @PathVariable String fname) throws Exception {
+      IPerson user = personManager.getPerson(request);
+      EntityIdentifier ei = user.getEntityIdentifier();
+      IAuthorizationPrincipal ap = AuthorizationService.instance().newPrincipal(ei.getKey(), ei.getType());
+      IPortletDefinition portletDef = portletDefinitionRegistry.getPortletDefinitionByFname(fname);
+      if(portletDef != null && ap.canRender(portletDef.getPortletDefinitionId().getStringId())) {
+        LayoutPortlet portlet = new LayoutPortlet(portletDef);
+        return new ModelAndView("json", "portlet", portlet);
+      } else {
+        //throw some error code back to web call
+      }
+      return new ModelAndView("json", "portlet", null);
     }
 
     private Set<String> getPortletCategories(IPortletDefinition pdef) {

--- a/uportal-war/src/main/java/org/jasig/portal/rest/layout/LayoutPortlet.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/layout/LayoutPortlet.java
@@ -18,7 +18,17 @@
  */
 package org.jasig.portal.rest.layout;
 
+import java.util.Arrays;
+
+import org.apache.commons.lang.StringUtils;
+import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.portlet.om.IPortletDefinitionParameter;
+import org.jasig.portal.portlet.om.IPortletPreference;
+
 public class LayoutPortlet {
+    private static final String CONTENT_PORTLET_PREFERENCE = "content";
+    private static final String PITHY_CONTENT_PORTLET_PREFERENCE = "pithyContent";
+    private static final String STATIC_CONTENT_PORTLET_WEBAPP_NAME = "/SimpleContentPortlet";
     private String nodeId;
     private String title;
     private String description;
@@ -27,6 +37,61 @@ public class LayoutPortlet {
     private String faIcon;
     private String fname;
     private String target;
+    private boolean isAltMaxUrl = false;
+
+    /**
+     * Fuller static content that you might display in a lightbox or so.
+     */
+    private String staticContent;
+
+    /**
+     * Pithy static content that you might display on a dashboard mosaic view or so.
+     */
+    private String pithyStaticContent;
+    
+    public LayoutPortlet() {
+      
+    }
+
+    public LayoutPortlet(IPortletDefinition portletDef) {
+      if(portletDef != null) {
+        
+        nodeId = "-1";
+        title = portletDef.getTitle();
+        description = portletDef.getDescription();
+        fname = portletDef.getFName();
+        url = portletDef.getAlternativeMaximizedLink(); //todo get normal URL if alt is missing
+        target = portletDef.getTarget();
+        isAltMaxUrl = StringUtils.isNotBlank(url);
+        IPortletDefinitionParameter iconParam = portletDef.getParameter("iconUrl");
+        if (iconParam != null) {
+            this.setIconUrl(iconParam.getValue());
+        }
+        
+        IPortletDefinitionParameter faIconParam = portletDef.getParameter("faIcon");
+        if(faIconParam != null) {
+            this.setFaIcon(faIconParam.getValue());
+        }
+        
+        boolean[] efficencyFlag = {false, false};
+        efficencyFlag[0] = !STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(portletDef.getPortletDescriptorKey().getWebAppName());
+        for(IPortletPreference pref : portletDef.getPortletPreferences()) {
+          if(!efficencyFlag[0] && CONTENT_PORTLET_PREFERENCE.equals(pref.getName()) && pref.getValues().length == 1) {
+              this.setStaticContent(pref.getValues()[0]);
+              efficencyFlag[0] = true;
+          } else if (PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
+              && 1 == pref.getValues().length) {
+              this.setPithyStaticContent(pref.getValues()[0]);
+              efficencyFlag[1] = true;
+          }
+          
+          if(efficencyFlag[0] && efficencyFlag[1]) {
+            break;
+          }
+      }
+        
+      }
+    }
 
     public String getNodeId() {
         return nodeId;
@@ -90,6 +155,30 @@ public class LayoutPortlet {
 
     public void setTarget(String target) {
       this.target = target;
+    }
+
+    public String getStaticContent() {
+      return staticContent;
+    }
+
+    public void setStaticContent(String staticContent) {
+      this.staticContent = staticContent;
+    }
+
+    public String getPithyStaticContent() {
+        return this.pithyStaticContent;
+    }
+
+    public void setPithyStaticContent(final String pithyStaticContent) {
+      this.pithyStaticContent = pithyStaticContent;
+    }
+
+    public boolean isAltMaxUrl() {
+      return isAltMaxUrl;
+    }
+
+    public void setAltMaxUrl(boolean isAltMaxUrl) {
+      this.isAltMaxUrl = isAltMaxUrl;
     }
 
 }


### PR DESCRIPTION
+ Adds 3 new fields to a `LayoutPortlet` object. staticContent, pithyContent, and isAltMaxUrl. We are using static content to display simple content portlets in an Angular display. We are using pithy content to display on a dashboard view. The Alt max URL flag is used to determine some behavior. See [our AngularJS usage](https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js#L17) for more details.
+ Created new call `/api/portlet/{fname}.json` that returns a `LayoutPortlet` JSON object.
+ Permission on this is based on if the user can render that portlet.