### PR TITLE
UP-3546:  This commit effectively reverts a commit from 2003 that introd...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/ChainingSecurityContext.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/ChainingSecurityContext.java
@@ -92,7 +92,6 @@ public abstract class ChainingSecurityContext implements ISecurityContext
   public synchronized void authenticate()  throws PortalSecurityException {
     int i;
     Enumeration e = mySubContexts.elements();
-    boolean error = false;
 
     while (e.hasMoreElements()) {
       ISecurityContext sctx = ((Entry) e.nextElement()).getCtx();
@@ -102,9 +101,8 @@ public abstract class ChainingSecurityContext implements ISecurityContext
               ((IParentAwareSecurityContext) sctx).authenticate(this);
           } else {
               sctx.authenticate();
-          }        
+          }
       } catch (Exception ex) {
-        error = true;
         log.error("Exception authenticating subcontext " + sctx, ex);
       }
       // Stop attempting to authenticate if authenticated and if the property flag is set
@@ -119,7 +117,7 @@ public abstract class ChainingSecurityContext implements ISecurityContext
          this.myOpaqueCredentials.credentialstring[i] = 0;
        myOpaqueCredentials.credentialstring = null;
     }
-    if (error && !this.isauth) throw new PortalSecurityException("One of the security subcontexts threw an exception");
+
     return;
   }
 


### PR DESCRIPTION
...uced a regression.  That regression sometimes prevents other SecurityContext impls from succeeding when another SecurityContext throws an exception

https://issues.jasig.org/browse/UP-3546

Original commit:  https://github.com/Jasig/uPortal/commit/a63dd7eb07c4e953688834fad950fe0475cdc8c9

Some IRC conetxt...

so with that line, you can succeed at local AuthN but still fail to get in because another context threw an error — say you can't resolve the IP of the ldap server
3:04 the exception would be logged — like it always does, and if you don't succeed at AuthN with any context you won't get in
3:05 i don't know that the exception needs to percolate up to the next caller… if you can't AuthN (due to exception), you won't get in
3:07 i'm having trouble — and I've hit this before — because (for this portal) valid AuthN strategies are LDAP & Simple, but the LDAP server isn't available off-network (even VPN) so I can't AuthN at all
3:08 also — the behavior is non-deterministic
3:08 normally stopWhenAuthenticated=true, so if the first context (of 2) succeeds, you'll get in
3:09 if the 1st throws an Ex (but the second would succeed), you won't get in
3:09 and the contexts are held in a Map, so the order of iteration is not something you can choose