### PR TITLE
[UP-4331]  Add ability to print errors to the console (stderr).

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -530,6 +530,12 @@
 
                             <java fork="true" failonerror="true" dir="${basedir}" classname="org.jasig.portal.shell.PortalShell">
                             	<jvmarg value="-XX:MaxPermSize=256m"/>
+                                <!--
+                                <jvmarg value="-Xnoagent"/>
+                                <jvmarg value="-Djava.compiler=NONE"/>
+                                <jvmarg value="-Xdebug"/>
+                                <jvmarg value="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"/>
+                                -->
                                 <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
                                 <sysproperty key="java.awt.headless" value="true"/>
                                 <classpath refid="uportal-war-full.classpath" />
@@ -573,18 +579,21 @@
 
         <property name="type" value=" " />
         <property name="sysid" value=" " />
+        <property name="showErrors" value="false"/>
 
         <groovy-safe-path property="dirFullEscaped" input="${dir}" />
         <groovy-safe-path property="targetDirEscaped" input="${targetdir}" />
 
         <echo>Creating Data Export Script</echo>
         <echo file="${portal-shell-script}" append="true">
-            //dataExport(String target, String dataDir, String type, String sysid, String logDir)
+            def printErrors = /${showErrors}/.toBoolean();
+            //dataExport(String target, String dataDir, String type, String sysid, String logDir, boolean printErrorsToStderr)
             portalShellBuildHelper.dataExport("data-export", 
                 /${dirFullEscaped}/,
                 '${type}',
                 '${sysid}',
-                /${targetDirEscaped}/);
+                /${targetDirEscaped}/,
+                printErrors);
         </echo>
 
         <antcall target="up-shell">
@@ -627,6 +636,7 @@
         <property name="file" value=" " />
         <property name="dir" value=" " />
     	<property name="archive" value=" " />
+        <property name="showErrors" value="false"/>
 
         <groovy-safe-path property="dirFullEscaped" input="${dir}" />
         <groovy-safe-path property="fileFullEscaped" input="${file}" />
@@ -636,13 +646,15 @@
 
         <echo>Creating Data Import Script</echo>
         <echo file="${portal-shell-script}" append="true">
-            //dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir)
+            def printErrors = /${showErrors}/.toBoolean();
+            //dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir, boolean printErrors)
             portalShellBuildHelper.dataImport("data-import", 
                 /${dirFullEscaped}/,
                 /${pattern}/,
                 /${fileFullEscaped}/,
                 /${archiveFullEscaped}/,
-                /${targetDirEscaped}/);
+                /${targetDirEscaped}/,
+                printErrors);
         </echo>
 
         <antcall target="up-shell">

--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/IPortalDataHandlerService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/IPortalDataHandlerService.java
@@ -40,7 +40,7 @@ public interface IPortalDataHandlerService {
     public class BatchImportOptions extends BatchOptions {
         private boolean recursive = true;
         private boolean ignoreNonDataFiles = true;
-        
+
         
         public BatchImportOptions setRecursive(boolean recursive) {
             this.recursive = recursive;
@@ -78,6 +78,12 @@ public interface IPortalDataHandlerService {
         public final boolean isIngoreNonDataFiles() {
             return this.ignoreNonDataFiles;
         }
+
+        @Override
+        public BatchImportOptions setPrintErrorsToStderr(boolean printErrorsToStderr) {
+            super.setPrintErrorsToStderr(printErrorsToStderr);
+            return this;
+        }
     }
     /**
      * Options that control behavior of batch export operations
@@ -98,6 +104,13 @@ public interface IPortalDataHandlerService {
             super.setLogDirectoryParent(logDirectoryParent);
             return this;
         }
+
+
+        @Override
+        public BatchExportOptions setPrintErrorsToStderr(boolean printErrorsToStderr) {
+            super.setPrintErrorsToStderr(printErrorsToStderr);
+            return this;
+        }
     }
     /**
      * Options that control behavior of batch operations
@@ -105,7 +118,8 @@ public interface IPortalDataHandlerService {
     public class BatchOptions {
         private boolean failOnError = true;
         private File logDirectoryParent = null;
-        
+        private boolean printErrorsToStderr = false;
+
         public BatchOptions setFailOnError(boolean failOnError) {
             this.failOnError = failOnError;
             return this;
@@ -130,6 +144,22 @@ public interface IPortalDataHandlerService {
          */
         public final File getLogDirectoryParent() {
             return logDirectoryParent;
+        }
+
+        /**
+         * Should errors be printed to stderr.
+         * @return defaults to false
+         */
+        public boolean getPrintErrorsToStderr() {
+            return printErrorsToStderr;
+        }
+
+        /**
+         * Set whether errors should print to stderr.
+         */
+        public BatchOptions setPrintErrorsToStderr(boolean printErrorsToStderr) {
+            this.printErrorsToStderr = printErrorsToStderr;
+            return this;
         }
     }
     

--- a/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelper.java
@@ -33,15 +33,15 @@ public interface PortalShellBuildHelper {
 
     void dataList(String target, String type);
 
-    void dataExport(String target, String dataDir, String type, String sysid, String logDir);
+    void dataExport(String target, String dataDir, String type, String sysid, String logDir, boolean printErrors);
 
     /**
      * @deprecated use {@link #dataImport(String, String, String, String, String, String)}
      */
     @Deprecated
-    void dataImport(String target, String dataDir, String pattern, String file, String logDir);
+    void dataImport(String target, String dataDir, String pattern, String file, String logDir, boolean printErrors);
 
-    void dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir);
+    void dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir, boolean printErrors);
 
     void dataDelete(String target, String type, String sysid);
 

--- a/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelperImpl.java
@@ -227,7 +227,7 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
     }
 
     @Override
-    public void dataExport(String target, String dataDir, String type, String sysid, String logDir) {
+    public void dataExport(String target, String dataDir, String type, String sysid, String logDir, boolean printErrors) {
         PortalShell.LOGGER.info("");
         PortalShell.LOGGER.info("");
 
@@ -256,7 +256,9 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
 
                 portalDataHandlerService.exportAllDataOfType(types,
                         dataDirFile,
-                        new IPortalDataHandlerService.BatchExportOptions().setLogDirectoryParent(logDir));
+                        new IPortalDataHandlerService.BatchExportOptions()
+                                .setLogDirectoryParent(logDir)
+                                .setPrintErrorsToStderr(printErrors));
             }
             catch (Exception e) {
                 throw new RuntimeException(target + " to " + dataDir + " of " + type + " failed", e);
@@ -266,7 +268,9 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
             try {
                 PortalShell.LOGGER.info("Exporting All Data to: " + dataDir);
                 portalDataHandlerService.exportAllData(dataDirFile,
-                        new IPortalDataHandlerService.BatchExportOptions().setLogDirectoryParent(logDir));
+                        new IPortalDataHandlerService.BatchExportOptions()
+                                .setLogDirectoryParent(logDir)
+                                .setPrintErrorsToStderr(printErrors));
             }
             catch (Exception e) {
                 throw new RuntimeException(target + " to " + dataDir + " failed", e);
@@ -275,12 +279,12 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
     }
     
     @Override
-    public void dataImport(String target, String dataDir, String pattern, String file, String logDir) {
-        dataImport(target, dataDir, pattern, file, null, logDir);
+    public void dataImport(String target, String dataDir, String pattern, String file, String logDir, boolean printErrors) {
+        dataImport(target, dataDir, pattern, file, null, logDir, printErrors);
     }
 
     @Override
-    public void dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir) {
+    public void dataImport(String target, String dataDir, String pattern, String file, String archive, String logDir, boolean printErrors) {
         PortalShell.LOGGER.info("");
         PortalShell.LOGGER.info("");
 
@@ -297,7 +301,9 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
             PortalShell.LOGGER.info("Importing Data from: " + archive);
             try {
                 portalDataHandlerService.importDataArchive(new FileSystemResource(archive),
-                        new IPortalDataHandlerService.BatchImportOptions().setLogDirectoryParent(logDir));
+                        new IPortalDataHandlerService.BatchImportOptions()
+                                .setLogDirectoryParent(logDir)
+                                .setPrintErrorsToStderr(printErrors));
             }
             catch (Exception e) {
                 throw new RuntimeException(target + " for " + archive + " failed", e);
@@ -311,7 +317,9 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
             try {
                 portalDataHandlerService.importData(new File(dataDir),
                         pattern,
-                        new IPortalDataHandlerService.BatchImportOptions().setLogDirectoryParent(logDir));
+                        new IPortalDataHandlerService.BatchImportOptions()
+                                .setLogDirectoryParent(logDir)
+                                .setPrintErrorsToStderr(printErrors));
             }
             catch (Exception e) {
                 if (pattern != null) {


### PR DESCRIPTION
Adds the ability to optionally print the import/export stack traces to stderr.  To use, add the -DprintErrors=true option to the ant build command line.   Example:

```
ant data-import -Ddir=uportal-war/src/main/data/quickstart_entities/portlet-definition -DshowErrors=true
```


https://issues.jasig.org/browse/UP-4331