### PR TITLE
UP-4407 Add region mezzanine below customize

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -176,6 +176,27 @@
         </xsl:if>
     </xsl:template>
 
+    <!-- ========== TEMPLATE: MEZZANINE ========== -->
+    <!-- ======================================== -->
+    <!--
+     | This template renders portlets prior to the content across the entire width.
+    -->
+    <xsl:template name="region.mezzanine">
+        <xsl:if test="//region[@name='mezzanine']/channel">
+            <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
+            <div id="region-mezzanine" class="container-fluid">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <xsl:for-each select="//region[@name='mezzanine']/channel">
+                            <xsl:call-template name="regions.portlet.decorator" />
+                        </xsl:for-each>
+                    </div>
+                </div>
+            </div>
+            <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
+        </xsl:if>
+    </xsl:template>
+
     <!-- ========== TEMPLATE: SIDEBAR-LEFT ========== -->
     <!-- =========================================== -->
     <!--

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -676,6 +676,7 @@
                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                 <div id="portalPageBody" class="portal-content" role="main"><!-- #portalPageBody selector is used with BackgroundPreference framework portlet -->
                     <xsl:call-template name="region.customize" />
+                    <xsl:call-template name="region.mezzanine" />
                     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                     <div class="container-fluid">
                         <div class="row"><!-- Fixed-grid row containing content (pre-, regular, and post-), plus optionally sidebar-left, sidebar-right, or both -->


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4407

Adds a new full-width region called mezzanine between customize and the sidebar/pre-content/content areas.  See https://wiki.jasig.org/display/UPC/Respondr+Regions+Feature
