### PR TITLE
UP-4412: Fixed issue with links in portal-global not being clickable in ...

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -667,13 +667,11 @@
                 <xsl:call-template name="region.hidden-top" />
                 <xsl:call-template name="region.page-top" />
                 <header class="portal-header" role="banner">
-                    <div class="portal-global">
-                        <div class="container-fluid">
+                    <div class="container-fluid">
+                        <div class="portal-global row">
                             <xsl:call-template name="region.pre-header" />
                         </div>
-                    </div>
-                    <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
-                    <div class="container-fluid">
+                        <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                         <div class="row">
                             <xsl:call-template name="region.header-left" />
                             <xsl:call-template name="region.header-right" />

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -32,9 +32,8 @@
 }
 
 .portal-global {
-    position: absolute;
     padding-top: 10px;
-    right: 0;
+    text-align: right;
 
 }
 

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -22,18 +22,20 @@
 
     .menu-toggle {
         position: absolute;
-        top: 40px;
+        top: 100px;
         right: 20px;
         padding: 0.5rem 1rem;
         background: @menu-toggle-background-color;
-        .border-radius;
-        font-weight: inherit;
+        border: 1px solid @menu-toggle-border-color;
         color: @menu-toggle-text-color;
+        font-weight: inherit;
         text-decoration: none;
+        .border-radius;
 
         &:hover, &:focus {
             background: @menu-toggle-hover-background-color;
             color: @menu-toggle-hover-text-color;
+            border: 1px solid @menu-toggle-hover-border-color;
         }
 
         i {

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
@@ -185,10 +185,12 @@
 @navbar-controls-color: @grayscale10;
 @navbar-controls-hover-color: @white;
 
-@menu-toggle-background-color: @color2;
+@menu-toggle-background-color: @color1-dark;
+@menu-toggle-border-color: @color1-darker;
 @menu-toggle-text-color: @white;
 
-@menu-toggle-hover-background-color: @color3;
+@menu-toggle-hover-background-color: @color1-light;
+@menu-toggle-hover-border-color: @color1-lighter;
 @menu-toggle-hover-text-color: @white;
 
 /**


### PR DESCRIPTION
When uPortal is in mobile Bootstrap view (viewport < 768px), any links in the portal-global div is no longer clickable. This is because the div is floating and "hides" behind any other div that is absolute (such as Bootstrap rows and columns).

I added appropriate Bootstrap classes to make portal-global a row and removed absolute styling so when it collapses, links don't fold under other rows.

![uportal-header-link-issue](https://cloud.githubusercontent.com/assets/3999821/6197583/2a01e4e2-b3a5-11e4-8e9c-9f130b3e47ca.gif)
