### PR TITLE
UP-4414 Allow Google to index the guest page

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/utils/web/RemoteCookieCheckFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/web/RemoteCookieCheckFilter.java
@@ -21,7 +21,10 @@ package org.jasig.portal.utils.web;
 /**
  * @author Chris Waymire <cwaymire@unicon.net>
  */
-import org.jasig.portal.rest.RemoteCookieCheckController;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -29,16 +32,19 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import java.io.IOException;
+import org.jasig.portal.rest.RemoteCookieCheckController;
 
 public class RemoteCookieCheckFilter implements Filter {
     public static final String COOKIE_NAME = "JSESSIONID";
     public static final String REFERER_ATTRIBUTE = "COOKIE_CHECK_REFERER";
+
+    // Set of User-Agent header values that will not be forced through the cookie check.
+    private Set<String> ignoredUserAgents = new HashSet<>();
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -60,7 +66,8 @@ public class RemoteCookieCheckFilter implements Filter {
                 }
             }
 
-            if (!cookieFound) {
+            String userAgent = ((HttpServletRequest) request).getHeader("User-Agent");
+            if (!cookieFound && !ignoredUserAgents.contains(userAgent)) {
                 final HttpSession session = httpServletRequest.getSession(true);
                 
                 String requestURI = httpServletRequest.getRequestURI();
@@ -81,5 +88,9 @@ public class RemoteCookieCheckFilter implements Filter {
 
     @Override
     public void destroy() {
+    }
+
+    public void setIgnoredUserAgents(Set<String> ignoredUserAgents) {
+        this.ignoredUserAgents = ignoredUserAgents;
     }
 }

--- a/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
@@ -32,7 +32,14 @@
     <bean id="requireValidSessionFilter" class="org.jasig.portal.url.RequireValidSessionFilter" />
     <bean id="urlCanonicalizingFilter" class="org.jasig.portal.url.UrlCanonicalizingFilter" />
     <bean id="createPortletCookieFilter" class="org.jasig.portal.utils.web.CreatePortletCookieFilter"/>
-    <bean id="remoteCookieCheckFilter" class="org.jasig.portal.utils.web.RemoteCookieCheckFilter"/>
+
+    <bean id="remoteCookieCheckFilter" class="org.jasig.portal.utils.web.RemoteCookieCheckFilter">
+        <property name="ignoredUserAgents">
+            <set>
+                <value>Googlebot</value>  <!-- Allow Google to index the guest page -->
+            </set>
+        </property>
+    </bean>
     <bean id="multipartResolver"
         class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
     


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4414

Added ignoring configured User-Agent strings to the cookie check process so Universities desiring to have their guest pages indexed so their portal site shows up in Google can do so.

Defaults to allow Google to bypass the cookie check.