### PR TITLE
UP-4410 Don't query ldap for user attribute names in permissions check f...

### DIFF
--- a/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
+++ b/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
@@ -45,7 +45,7 @@
         <name>Edit user attribute</name>
         <fname>EDIT_USER_ATTRIBUTE</fname>
         <desc>Edit a specific user attribute.  This permission applies to that attribute for all editable users</desc>
-        <targetProvider>peopleAndGroupsTargetProvider</targetProvider>
+        <targetProvider>userAttributesTargetProvider</targetProvider>
     </activity>
     <activity>
         <name>Edit users</name>

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/SimpleStringTargetProviderImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/SimpleStringTargetProviderImpl.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * SimpleStringTargetProviderImpl provides a basic target provider implementation
  * capable of registering static strings as targets.  This implementation is
  * appropriate for permission owners for which targets are simple static 
- * strings that are well-defeined and known in advance.
+ * strings that are well-defined and known in advance.
  * 
  * @author Jen Bourey, jbourey@unicon.net
  * @version $Revision$

--- a/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
@@ -166,6 +166,23 @@
         <!--<value>${org.jasig.portal.portlets.directory.search.result.type}</value>-->
     </util:set>
 
+
+    <bean id="authorizationService" class="org.jasig.portal.security.provider.AuthorizationImpl">
+        <!-- Set of permissionTargetProviders that are not entities and permission checks on a target
+             string value do not need to search through groups or group member target names for a match.
+             See bean permissionTargetProviderRegistry. -->
+        <property name="nonEntityPermissionTargetProviders">
+            <set>
+                <value>errorChannelTargetProvider</value>
+                <value>portalSystemTargetProvider</value>
+                <value>userAttributesTargetProvider</value>
+            </set>
+        </property>
+    </bean>
+    <!--
+    | The permissionTargetProvider key names must be synchronized between src/main/data/default_entities/permission_owner/*.xml
+    | files, here, and authorizationService.
+    +-->
     <bean id="permissionTargetProviderRegistry" class="org.jasig.portal.permission.target.PermissionTargetProviderRegistryImpl">
         <property name="providers">
             <map>


### PR DESCRIPTION
...or personDir search

https://issues.jasig.org/browse/UP-4410

Previously all possible person directory attribute values resulted in searches of groups and group membership for the permissions target. The latter resulted in a query of person directory per possible attribute to figure out what PAGS groups a target was in.  If the permissions target is not an entity, this is a waste of time.  Uses the PermissionsActivity entries (src/main/data/default_entities/permission_owner/* files) to filter out those targets that aren't entities and therefore can't be in groups.