### PR TITLE
UP-4411 optimize person dir search

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlets/lookup/PersonLookupHelperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/lookup/PersonLookupHelperImpl.java
@@ -230,7 +230,12 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
         // To improve efficiency and not do as many permission checks or person directory searches,
         // if we have too many results and all people in the returned set of personAttributes have
         // a displayName, pre-sort the set and limit it to maxResults. The typical use case is that
-        // LDAP returns results that have the displayName populated.
+        // LDAP returns results that have the displayName populated.  Note that a disadvantage of this
+        // approach is that the smaller result set may have entries that permissions prevent the
+        // current users from viewing the person and thus reduce the number of final results, but
+        // that is rare (typical use case is users can't view administrative internal accounts or the
+        // system account, none of which tend to be in LDAP).  We could retain a few more than maxResults
+        // to offset that chance, but IMHO not worth the cost of extra external queries.
 
         List<IPersonAttributes> peopleList = new ArrayList<>(people);
         if (peopleList.size() > maxResults && allListItemsHaveDisplayName(peopleList)) {


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4411

When directory search gets results from a person directory search (primarily LDAP in most instances), code used to loop through all returned results and fetch each result from personDir.  If you searched for Thomas you may get several hundred results from LDAP and if you are not an admin user (so permission checks apply), each LDAP result is re-queried from personDir which would go out to LDAP or other external sources to get all the attributes associated with an entity prior to displaying.  Now:

1. limits the amount of re-querying personDir (to get all the attributes that are associated with an entity) to the search result max if displayName is present in all the search results (because the code wanted to display n results of a sorted list).  As I'm writing this I just realized that if users are initially found but dropped out because permission checks indicate you cannot view the user, the final end result may be fewer than the configured maxResults size.  However its a rare case and IMHO not worth worrying about.  Added comments accordingly.

2. For the remaining results, determines the list of visible users and attributes in a parallel fashion.  

It would be nice to do something different, such as don't check for permission to view a user if the principal doesn't have any DENY on VIEW_USER, but the default data set does have DENY on Fragment Owners and the system account so I don't see a good way around running each user through the permission check on whether to view a user (which causes PersonDirectory to do an LDAP or other query).