### PR TITLE
UP-4419: Moved the favorites portlet into a collapsible Bootstrap navbar for mobile view

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Favorites/view.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Favorites/view.jsp
@@ -20,36 +20,49 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 
-<c:set var="n"><portlet:namespace/></c:set>
+    <c:set var="n"><portlet:namespace/></c:set>
 
-<c:if test="${not empty marketplaceFname}">
-    <c:set var="marketplaceUrl">${renderRequest.contextPath}/p/${marketplaceFname}/max/render.uP</c:set>
-</c:if>
+    <c:if test="${not empty marketplaceFname}">
+        <c:set var="marketplaceUrl">${renderRequest.contextPath}/p/${marketplaceFname}/max/render.uP</c:set>
+    </c:if>
 
-<div>
-<ul class="list-group">
-  <c:forEach var="collection" items="${collections}">
-    <li class="list-group-item">
-      <span class="glyphicon glyphicon-chevron-right pull-right"></span>
-      <a href="${renderRequest.contextPath}/f/${collection.id}/render.uP">${collection.name}</a>
-    </li>
-  </c:forEach>
+    <nav class="navbar navbar-default" id="${n}">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#fav-portlet-${n}">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="#"><spring:message code="favorites"/></a>
+        </div>
 
-  <c:forEach var="favorite" items="${favorites}">
-    <li class="list-group-item">
-      <span class="glyphicon glyphicon-star pull-right"></span>
-      <a href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP">${favorite.name}</a>
-    </li>
-  </c:forEach>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="fav-portlet-${n}">
+            <ul class="list-group">
+                <c:forEach var="collection" items="${collections}">
+                    <li class="list-group-item">
+                        <span class="glyphicon glyphicon-chevron-right pull-right"></span>
+                        <a href="${renderRequest.contextPath}/f/${collection.id}/render.uP">${collection.name}</a>
+                    </li>
+                </c:forEach>
 
-</ul>
+                <c:forEach var="favorite" items="${favorites}">
+                    <li class="list-group-item">
+                        <span class="glyphicon glyphicon-star pull-right"></span>
+                        <a href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP">${favorite.name}</a>
+                    </li>
+                </c:forEach>
+            </ul>
 
-  <%-- Display link to Marketplace if available, suppress otherwise --%>
-  <c:if test="${not empty marketplaceUrl}">
-  <span class="pull-right">
-    <a href="${marketplaceUrl}">
-      <spring:message code="favorites.invitation.to.marketplace.short" text="Visit Marketplace"/>
-    </a>
-  </span>
-  </c:if>
-</div>
+            <%-- Display link to Marketplace if available, suppress otherwise --%>
+            <c:if test="${not empty marketplaceUrl}">
+                <span class="pull-right">
+                    <a href="${marketplaceUrl}">
+                    <spring:message code="favorites.invitation.to.marketplace.short" text="Visit Marketplace"/>
+                    </a>
+                </span>
+            </c:if>
+        </div><!-- /.navbar-collapse -->
+    </nav>

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/portlet.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/portlet.less
@@ -129,6 +129,7 @@
 @media only screen and (min-width: 769px) {
     .favorites {
 
+        /* Hide the navbar-brand text */
         .navbar-brand {
             display: none;
         }
@@ -139,6 +140,7 @@
 @media only screen and (max-width: 769px) {
     .favorites {
 
+        /* Show a border around the navbar */
         .navbar {
             border: 1px solid #e7e7e7;
         }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/portlet.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/portlet.less
@@ -107,3 +107,40 @@
     }
 }
 
+/* Favorites Portlet */
+.favorites {
+
+    .navbar {
+        background: none;
+        border: none;
+        margin: 0;
+
+        .navbar-collapse {
+            padding: 0;
+
+            .list-group {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+/* Display only for desktop */
+@media only screen and (min-width: 769px) {
+    .favorites {
+
+        .navbar-brand {
+            display: none;
+        }
+    }
+}
+
+/* Display only for mobile */
+@media only screen and (max-width: 769px) {
+    .favorites {
+
+        .navbar {
+            border: 1px solid #e7e7e7;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4419

Folded the favorites portlet into a collapsible navbar for easier navigation in mobile view:

Desktop view:
![favorites-desktop](https://cloud.githubusercontent.com/assets/3999821/6599298/44430d2e-c7c6-11e4-8964-8c69e6e454fd.png)

Mobile view (navbar open):
![favorites-mobile](https://cloud.githubusercontent.com/assets/3999821/6599297/4440ab6a-c7c6-11e4-8341-116cb582d16e.png)
