### PR TITLE
UP-4414 handle guest access no cookie support in browser

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
@@ -94,7 +94,7 @@ public class UrlCanonicalizingFilter extends OncePerRequestFilter {
             // If cookies are disabled and Tomcat has appended the sessionId to the URL, remove the
             // jsessionid for the purposes of comparing the request URI to the canonical URI.  This
             // allows a search indexing engine such as Googlebot to access the guest view of a uportal
-            // page which typically renders OK (not guaranteed depending upon content).
+            // page which typically renders OK (not guaranteed depending upon content).  See UP-4414.
             if (requestURI.contains(";jsessionid")) {
                 requestURI = requestURI.substring(0, requestURI.indexOf(";"));
             }

--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
@@ -90,7 +90,14 @@ public class UrlCanonicalizingFilter extends OncePerRequestFilter {
                 canonicalUri = canonicalUrl.substring(0, queryStringIndex);
             }
 
-            final String requestURI = request.getRequestURI();
+            String requestURI = request.getRequestURI();
+            // If cookies are disabled and Tomcat has appended the sessionId to the URL, remove the
+            // jsessionid for the purposes of comparing the request URI to the canonical URI.  This
+            // allows a search indexing engine such as Googlebot to access the guest view of a uportal
+            // page which typically renders OK (not guaranteed depending upon content).
+            if (requestURI.contains(";jsessionid")) {
+                requestURI = requestURI.substring(0, requestURI.indexOf(";"));
+            }
 
             final int redirectCount = this.getRedirectCount(request);
             if (!canonicalUri.equals(requestURI)) {

--- a/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
@@ -34,9 +34,9 @@
     <bean id="createPortletCookieFilter" class="org.jasig.portal.utils.web.CreatePortletCookieFilter"/>
 
     <bean id="remoteCookieCheckFilter" class="org.jasig.portal.utils.web.RemoteCookieCheckFilter">
-        <property name="ignoredUserAgents">
+        <property name="regexIgnoredUserAgents">
             <set>
-                <value>Googlebot</value>  <!-- Allow Google to index the guest page -->
+                <value>.*Googlebot.*</value>  <!-- Allow Google to index the guest page.  See https://support.google.com/webmasters/answer/1061943?hl=en -->
             </set>
         </property>
     </bean>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4414

Found that disabling cookies in the browser when user agent is set for Googlebot gets into an infinite HTTP 302 loop.  This change allows for cookies disabled in browser when user-agent is Googlebot or other configured user agent that skips cookie checks to render the guest page, at least with the default data set on my local desktop.  TBD if this actually allows googlebot to work properly.