### PR TITLE
UP-4424: Changed footer to be sticky; added top padding to header; removed styles from skin.less

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -744,10 +744,12 @@
                     </div>
                 </div>
                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
-                <xsl:call-template name="footer.nav" />
-                <xsl:call-template name="region.footer.second" />
-                <xsl:call-template name="region.page-bottom" />
-                <xsl:call-template name="region.hidden-bottom" />
+                <div id="footer-container">
+                    <xsl:call-template name="footer.nav" />
+                    <xsl:call-template name="region.footer.second" />
+                    <xsl:call-template name="region.page-bottom" />
+                    <xsl:call-template name="region.hidden-bottom" />
+                </div>
                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
             </div>
 

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -67,11 +67,8 @@
 }
 
 .portlet-title {
+
     .border-radiuses-top(5px);
-
-    .btn-group {
-
-    }
 }
 
 .portlet-content {
@@ -259,8 +256,11 @@ section.emergency-alert {
         display: block;
     }
 
+/** padding-bottom needs to be adjusted to the absolute height of the footer in order
+ ** to maintain it's "stickiness". This value is set in defaultSkin/less/variables.less
+ ** (Current default is 200px) **/
     .portal-content {
-        padding: 0 0 0 20px;
+        padding: 0 0 @footer-height 20px;
     }
 
     .portlet {

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/footer.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/footer.less
@@ -22,6 +22,11 @@
    Footer Nav
    ========================================================================== */
 
+#footer-container {
+    width: 100%;
+    bottom: 0;
+    position: absolute;
+
     .portal-footer-nav {
         background: @footer-background-color;
         color: @footer-text-color;
@@ -59,9 +64,9 @@
         }
     }
 
-/* ==========================================================================
-   Footer Legal
-   ========================================================================== */
+    /* ==========================================================================
+       Footer Legal
+       ========================================================================== */
 
     #region-footer-second {
         background: @footer-secondary-background-color;
@@ -83,21 +88,22 @@
     }
 
 
-/* ==========================================================================
-   Responsive Design
-   ========================================================================== */
-/*
- * Breakpoints: 240px, 320px, 480px, 600px, 769px, and 992px.
- */
+    /* ==========================================================================
+       Responsive Design
+       ========================================================================== */
+    /*
+     * Breakpoints: 240px, 320px, 480px, 600px, 769px, and 992px.
+     */
 
-@media only screen and (min-width: 769px) {
-    .portal-footer-legal, .portal-footer-nav {
-        padding: 20px 0;
-    }
+    @media only screen and (min-width: 769px) {
+        .portal-footer-legal, .portal-footer-nav {
+            padding: 20px 0;
+        }
 
-    .portal-footer-nav {
-        ul {
-            display: block;
+        .portal-footer-nav {
+            ul {
+                display: block;
+            }
         }
     }
 }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -20,6 +20,7 @@
 .portal-header {
     background: @header-background-color;
     color: @header-text-color;
+    padding-top: 6px;
 
     a {
         color: @header-link-color;

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/layout-portal.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/layout-portal.less
@@ -16,8 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+html, body {
+    height: 100%;
+}
+
 .portal-page-column {
     .portal-page-column-inner {
         min-height: 100px;
     }
+}
+
+#wrapper {
+    min-height: 100%;
+    position: relative;
 }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -17,6 +17,18 @@
  * under the License.
  */
 
+// Link color - uses defaultSkin/less/variables.less, not common/bootstrap/variables.less
+a {
+    color: @portal-link-color;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        color: @portal-link-hover-color;
+        text-decoration: underline;
+    }
+}
+
 .portal-nav {
     background: @navbar-background-color;
 

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/skin.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/skin.less
@@ -25,14 +25,3 @@
   position: initial;
 }
 
-// Link color - uses defaultSkin/less/variables.less, not common/bootstrap/variables.less
-a {
-  color: @portal-link-color;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    color: @portal-link-hover-color;
-    text-decoration: underline;
-  }
-}

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
@@ -143,6 +143,7 @@
 @footer-text-color: @color4;
 @footer-link-color: @color4-light;
 @footer-link-hover-color: @color4-lighter;
+@footer-height: 200px;
 
 /**
  * User bar styles


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4424

A number of small UI changes:

* Made the footer sticky (so if content height is less than the height of the viewport, the footer will always remain at the bottom of the viewport) (screenshot below)
* Moved anchor styles from styles.less into navigation.less
* Added top padding to portal-header (to pull notifications icon down from the edge) 

![screenshot 2015-03-16 16 47 22](https://cloud.githubusercontent.com/assets/3999821/6678792/3e4b3a9c-cbfc-11e4-8398-f862ea6bdfae.png)