### PR TITLE
UP-4431 Search auto-suggest defaults to portlet list

### DIFF
--- a/uportal-war/src/main/data/default_entities/portlet-definition/search.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/search.portlet-definition.xml
@@ -45,21 +45,21 @@
         <value>/uPortal/media/skins/icons/mobile/search.png</value>
     </parameter>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>autoSuggestResultsProcessor</name>
         <readOnly>false</readOnly>
         <value>portletListProcessor</value>
     </portlet-preference>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>prepopulateAutoSuggestUrl</name>
         <readOnly>false</readOnly>
         <value>/api/portletList</value>
     </portlet-preference>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>prepopulateUrlPattern</name>
         <readOnly>false</readOnly>

--- a/uportal-war/src/main/data/default_entities/portlet-definition/search.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/search.portlet-definition.xml
@@ -44,4 +44,25 @@
         <name>mobileIconUrl</name>
         <value>/uPortal/media/skins/icons/mobile/search.png</value>
     </parameter>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>autoSuggestResultsProcessor</name>
+        <readOnly>false</readOnly>
+        <value>portletListProcessor</value>
+    </portlet-preference>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>prepopulateAutoSuggestUrl</name>
+        <readOnly>false</readOnly>
+        <value>/api/portletList</value>
+    </portlet-preference>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>prepopulateUrlPattern</name>
+        <readOnly>false</readOnly>
+        <value>/p/$fname/max</value>
+    </portlet-preference>
 </portlet-definition>

--- a/uportal-war/src/main/data/default_entities/portlet-definition/searchlauncher.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/searchlauncher.portlet-definition.xml
@@ -58,21 +58,21 @@
         <value>search</value>   <!-- Value must match the fname of the search portlet a user may have on their page -->
     </portlet-preference>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>autoSuggestResultsProcessor</name>
         <readOnly>false</readOnly>
         <value>portletListProcessor</value>
     </portlet-preference>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>prepopulateAutoSuggestUrl</name>
         <readOnly>false</readOnly>
         <value>/api/portletList</value>
     </portlet-preference>
     <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
-         to slow in returning search results for auto-suggest. -->
+         too slow in returning search results for auto-suggest. -->
     <portlet-preference>
         <name>prepopulateUrlPattern</name>
         <readOnly>false</readOnly>

--- a/uportal-war/src/main/data/default_entities/portlet-definition/searchlauncher.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/searchlauncher.portlet-definition.xml
@@ -57,4 +57,25 @@
         <readOnly>true</readOnly>
         <value>search</value>   <!-- Value must match the fname of the search portlet a user may have on their page -->
     </portlet-preference>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>autoSuggestResultsProcessor</name>
+        <readOnly>false</readOnly>
+        <value>portletListProcessor</value>
+    </portlet-preference>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>prepopulateAutoSuggestUrl</name>
+        <readOnly>false</readOnly>
+        <value>/api/portletList</value>
+    </portlet-preference>
+    <!-- By default the search auto-suggest should use the pre-populated portlet list since uPortal is currently
+         to slow in returning search results for auto-suggest. -->
+    <portlet-preference>
+        <name>prepopulateUrlPattern</name>
+        <readOnly>false</readOnly>
+        <value>/p/$fname/max</value>
+    </portlet-preference>
 </portlet-definition>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4431

Pre-populating the search auto-suggest with the portlet list gives a much better user experience.  Suggest including in uPortal 4.2.0.

![admin tools uportal by jasig - chromium_101](https://cloud.githubusercontent.com/assets/1479823/6817741/3003366c-d262-11e4-9d9e-306abc5dce4d.png)
