### PR TITLE
UP-4273 Search replaces ${portlet.title} with portlet's title in search results

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlets/search/SearchPortletController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/search/SearchPortletController.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -732,8 +733,9 @@ public class SearchPortletController {
             final SpELEnvironmentRoot spelEnvironment = new SpELEnvironmentRoot(portletDefinition);
             try {
                 result.setTitle(spELService.getValue(result.getTitle(), spelEnvironment));
-            } catch (SpelParseException e) {
-                result.setTitle("Invalid Spring EL expression '" + result.getTitle()+"'");
+            } catch (SpelParseException | SpelEvaluationException e) {
+                result.setTitle("(Invalid portlet title) - see details in log file");
+                logger.error("Invalid Spring EL expression {} in search result portlet title", result.getTitle(), e);
             }
         }
     }

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/search/SearchPortletController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/search/SearchPortletController.java
@@ -68,6 +68,7 @@ import org.jasig.portal.search.SearchConstants;
 import org.jasig.portal.search.SearchRequest;
 import org.jasig.portal.search.SearchResult;
 import org.jasig.portal.search.SearchResults;
+import org.jasig.portal.spring.spel.IPortalSpELService;
 import org.jasig.portal.url.IPortalRequestUtils;
 import org.jasig.portal.url.IPortalUrlBuilder;
 import org.jasig.portal.url.IPortalUrlProvider;
@@ -77,7 +78,9 @@ import org.jasig.portal.utils.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.expression.spel.SpelParseException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -124,7 +127,7 @@ public class SearchPortletController {
     // > 0 is higher priority, < 0 is lower priority.
     private Map<String, Integer> autocompleteResultTypeToPriorityMap = new HashMap<String, Integer>();
 
-    private Set<String> searchResultsLinkTextPortletTitleSubstitutionSet = new HashSet<>();
+    private IPortalSpELService spELService;
 
     // TODO: It would be better to revise the search event to have a set of ignored types and expect the
     // search event listeners to voluntarily ignore the search event if they are one of the ignored types (and
@@ -179,9 +182,10 @@ public class SearchPortletController {
         this.autocompleteIgnoreResultTypes = autocompleteIgnoreResultTypes;
     }
 
-    @Resource(name = "searchResultsLinkNamePortletTitleSubstitutionSet")
-    public void setSearchResultsLinkTextPortletTitleSubstitutionSet(Set<String> portletTypeSet) {
-        this.searchResultsLinkTextPortletTitleSubstitutionSet = portletTypeSet;
+    @Autowired
+    @Qualifier(value = "portalSpELServiceImpl")
+    public void setSpELService(IPortalSpELService spELService) {
+        this.spELService = spELService;
     }
 
     /**
@@ -719,12 +723,18 @@ public class SearchPortletController {
      */
     protected void modifySearchResultLinkTitle(SearchResult result, final HttpServletRequest httpServletRequest,
                                                final IPortletWindowId portletWindowId) {
-        if (result.getType().size() > 0 && searchResultsLinkTextPortletTitleSubstitutionSet.contains(result.getType().get(0))) {
-            final IPortletWindow portletWindow = this.portletWindowRegistry.getPortletWindow(httpServletRequest, portletWindowId);
+        // If the title contains a SpEL expression, parse it with the portlet definition in the evaluation context.
+        if (result.getType().size() > 0 && result.getTitle().contains("${")) {
+            final IPortletWindow portletWindow = this.portletWindowRegistry.getPortletWindow(httpServletRequest,
+                    portletWindowId);
             final IPortletEntity portletEntity = portletWindow.getPortletEntity();
             final IPortletDefinition portletDefinition = portletEntity.getPortletDefinition();
-            String portletTitle = portletDefinition.getTitle();
-            result.setTitle(portletTitle);
+            final SpELEnvironmentRoot spelEnvironment = new SpELEnvironmentRoot(portletDefinition);
+            try {
+                result.setTitle(spELService.getValue(result.getTitle(), spelEnvironment));
+            } catch (SpelParseException e) {
+                result.setTitle("Invalid Spring EL expression '" + result.getTitle()+"'");
+            }
         }
     }
     
@@ -786,5 +796,32 @@ public class SearchPortletController {
     public boolean isMobile(PortletRequest request) {
         String themeName = request.getProperty(ThemeNameRequestPropertiesManager.THEME_NAME_PROPERTY);
         return "UniversalityMobile".equals(themeName);
+    }
+
+    /**
+     * Limited-use POJO representing the root of a SpEL environment.  For Search we're only using
+     * the portlet object in the evaluation context.
+     */
+    @SuppressWarnings("unused")
+    private class SpELEnvironmentRoot {
+
+        private final IPortletDefinition portlet;
+
+        /**
+         * Create a new SpEL environment root for use in a SpEL evaluation context.
+         *
+         * @param portletDefinition  portlet definition
+         */
+        private SpELEnvironmentRoot(IPortletDefinition portletDefinition) {
+            this.portlet = portletDefinition;
+        }
+
+        /**
+         * Get the portlet associated with this environment root.
+         */
+        public IPortletDefinition getPortlet() {
+            return portlet;
+        }
+
     }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/spring/spel/IPortalSpELService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/spring/spel/IPortalSpELService.java
@@ -90,6 +90,7 @@ public interface IPortalSpELService {
      * @param expressionString SpEL expression string to parse
      * @param spelEnvironment environment context object with getter methods matching SpEL expression object names
      * @return value of parsed expression
+     * @since 4.2.0
      */
     public String getValue(String expressionString, Object spelEnvironment);
 }

--- a/uportal-war/src/main/java/org/jasig/portal/spring/spel/IPortalSpELService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/spring/spel/IPortalSpELService.java
@@ -81,4 +81,15 @@ public interface IPortalSpELService {
      * @see #getValue(Expression, WebRequest, Class)
      */
     public <T> T getValue(String expressionString, WebRequest request, Class<T> desiredResultType);
+
+    /**
+     * Parses an expression string against a provided SpEL environment.  The environment object should be a simple
+     * class that has objects and getXXXX methods where XXXX is the name of the object in the expression.
+     * For instance, to handle SpEL expressions of ${portlet.title} and ${user.name} you pass in an object
+     * that has getPortlet() and getUser() methods, assuming ${} is your expression token prefix and suffix.
+     * @param expressionString SpEL expression string to parse
+     * @param spelEnvironment environment context object with getter methods matching SpEL expression object names
+     * @return value of parsed expression
+     */
+    public String getValue(String expressionString, Object spelEnvironment);
 }

--- a/uportal-war/src/main/java/org/jasig/portal/spring/spel/PortalSpELServiceImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/spring/spel/PortalSpELServiceImpl.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
-
 import org.apache.commons.lang.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -150,6 +149,14 @@ public class PortalSpELServiceImpl implements IPortalSpELService, BeanFactoryAwa
     public Object getValue(Expression expression, WebRequest request) {
         final EvaluationContext evaluationContext = this.getEvaluationContext(request);
         return expression.getValue(evaluationContext);
+    }
+
+    @Override
+    public String getValue(String expressionString, Object spelEnvironment) {
+        final StandardEvaluationContext context = new StandardEvaluationContext(spelEnvironment);
+        context.setBeanResolver(this.beanResolver);
+        final Expression expression = this.parseCachedExpression(expressionString, TemplateParserContext.INSTANCE);
+        return expression.getValue(context, String.class);
     }
 
     /**

--- a/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
@@ -150,15 +150,6 @@
     </util:map>
 
     <!--
-     | For search results create a set of search result types that will have the link text substituted with the
-     | search match's portlet title.  Allows changing static text such as "cms" to the portlet definition title
-     | so the results are more meaningful to the user.  UP-4266.
-     +-->
-    <util:set id="searchResultsLinkNamePortletTitleSubstitutionSet" value-type="java.lang.String">
-        <value>Portlet Content</value>  <!-- For SimpleCMS v1.08+ -->
-    </util:set>
-
-    <!--
      | Set of the search result types to exclude from search autocompletion.  The value is the set by the
      | various Search services in the SearchResult.type field.
      +-->

--- a/uportal-war/src/test/resources/org/jasig/portal/rendering/renderingPipelineTestContext.xml
+++ b/uportal-war/src/test/resources/org/jasig/portal/rendering/renderingPipelineTestContext.xml
@@ -174,7 +174,7 @@
     
     <bean class="org.jasig.portal.utils.cache.resource.CachingResourceLoaderImpl" />
     
-    <bean class="org.jasig.portal.spring.spel.PortalSpELServiceImpl" />
+    <bean id="testSpelService" class="org.jasig.portal.spring.spel.PortalSpELServiceImpl" />
     
     <bean class="org.jasig.portal.url.PortalRequestUtilsImpl" />
     


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4273

Allows search results in the title from portlets to include SpEL expression to replace the search result title with values from the portlet definition.  Primary use case is https://issues.jasig.org/browse/CMSPLT-52 so search results in CMS portlet have a title of the portlet definition, not "cms" as it previously was.  Works with earlier versions of SimpleCMSPortlet but does title substitution with v1.2.0-M3.

![selection_114](https://cloud.githubusercontent.com/assets/1479823/6931572/9d9c91bc-d7c3-11e4-9684-4f9895a9bc2a.png)
