### PR TITLE
UP-4439 - Updated mobile background container to point to Respondr

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/portlet.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/portlet.xml
@@ -937,7 +937,7 @@
             <!-- HTML element or class to apply background image to -->
             <preference>
                 <name>mobileBackgroundContainerSelector</name>
-                <value>#page-inner</value>
+                <value>#portalPageBody</value>
             </preference>
             <preference>
                 <name>mobileBackgroundImages</name>


### PR DESCRIPTION
The background changing portlet broke for mobile devices using Respondr, it was using older muniversality settings.