### PR TITLE
UP-4438: Created '/layout/v2/layout.json' endpoint that returns the layo...

### DIFF
--- a/uportal-war/src/main/data/default_entities/stylesheet-descriptor/DLMTabsColumnsJS.stylesheet-descriptor.xml
+++ b/uportal-war/src/main/data/default_entities/stylesheet-descriptor/DLMTabsColumnsJS.stylesheet-descriptor.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<stylesheet-descriptor xmlns="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns2="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns4="https://source.jasig.org/schemas/uportal" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor/stylesheet-descriptor-4.0.xsd">
+    <name>DLMTabsColumnsJS</name>
+    <description>Presents the DLM layout in terms of tabs and columns for use with Javascript-driven UI rendering.</description>
+    <uri>classpath:/layout/structure/columns/columns-js.xsl</uri>
+    <url-syntax-helper>SingleTabUrlNodeSyntaxHelper</url-syntax-helper>
+    <stylesheet-parameter>
+        <name>userLayoutRoot</name>
+        <scope>REQUEST</scope>
+        <description>The id of the focused layout element</description>
+    </stylesheet-parameter>
+    <stylesheet-parameter>
+        <name>defaultTab</name>
+        <default-value>1</default-value>
+        <scope>PERSISTENT</scope>
+        <description>The number of the DLM tab that is initially active</description>
+    </stylesheet-parameter>
+    <stylesheet-parameter>
+        <name>focusedTabID</name>
+        <scope>REQUEST</scope>
+        <description>The number of the DLM tab that is currently active</description>
+    </stylesheet-parameter>
+    <stylesheet-parameter>
+        <name>detached</name>
+        <default-value>false</default-value>
+        <scope>REQUEST</scope>
+        <description>If the request is for a detached portlet</description>
+    </stylesheet-parameter>
+    <layout-attribute>
+        <name>name</name>
+        <scope>SESSION</scope>
+        <description>Allow renaming a folder without having to reload the underlying layout DOM (this seems like a hack)</description>
+        <targetElement>folder</targetElement>
+    </layout-attribute>
+    <layout-attribute>
+        <name>width</name>
+        <default-value>100%</default-value>
+        <scope>PERSISTENT</scope>
+        <description>Width of a DLM column</description>
+        <targetElement>folder</targetElement>
+    </layout-attribute>
+    <layout-attribute>
+        <name>externalId</name>
+        <scope>PERSISTENT</scope>
+        <description>Identifier used to reference a tab externally, such as within a URL</description>
+        <targetElement>folder</targetElement>
+    </layout-attribute>
+    <layout-attribute>
+        <name>tabGroup</name>
+        <default-value>DEFAULT_TABGROUP</default-value>
+        <scope>PERSISTENT</scope>
+        <description>Allows the theme to sort tabs into groups (optional feature)</description>
+        <targetElement>folder</targetElement>
+    </layout-attribute>
+</stylesheet-descriptor>

--- a/uportal-war/src/main/data/default_entities/stylesheet-descriptor/JsonLayoutV2.stylesheet-descriptor.xml
+++ b/uportal-war/src/main/data/default_entities/stylesheet-descriptor/JsonLayoutV2.stylesheet-descriptor.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<stylesheet-descriptor xmlns="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns2="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns4="https://source.jasig.org/schemas/uportal" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor/stylesheet-descriptor-4.0.xsd">
+    <name>JsonLayoutV2</name>
+    <description>Renders the user layout as JSON (version 2)</description>
+    <uri>classpath:/layout/theme/json/json-v2.xsl</uri>
+</stylesheet-descriptor>

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonStructureAttributeSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonStructureAttributeSource.java
@@ -18,27 +18,64 @@
  */
 package org.jasig.portal.json.rendering;
 
-
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portal.layout.IStylesheetUserPreferencesService.PreferencesScope;
 import org.jasig.portal.layout.om.IStylesheetDescriptor;
 import org.jasig.portal.rendering.StylesheetAttributeSource;
 
 /**
  * Returns structure stylesheet descriptor and preferences data
+ *
+ * {@link StylesheetAttributeSource} specific to stylesheets used to produce layout data in JSON 
+ * format.  This class originally hardcoded the stylesheet name as "DLMMobileColumns" and was used 
+ * to support the "/uPortal/layout.json" call (used for mobile layout rendering).  This class has 
+ * been updated to support new layout JSON endpoints that will be versioned.  For the newer 
+ * endpoints, this class is now able to use any stylesheet specified.  This class now looks for a 
+ * request attribute that specifies the stylesheet.  The stylesheet will typically be specified in 
+ * the controller class for the endpoint.  For backwards compatibility, if no stylesheet request 
+ * attribute is found, the default stylesheet used will be the original "DLMMobileColumns".
  * 
+ * Note that the only difference in the rendering pipeline between the original endpoint and the 
+ * new versioned endpoints are the stylesheets used.  Because of the number of beans required to 
+ * set up the pipeline (due to the deep chaining of {@link PipelineComponents}), it is desireable 
+ * to reuse the Spring Framework configuration that sets this up rather than duplicating it for 
+ * each endpoint.  Using a request attribute to specify the stylesheet (instead of using a 
+ * configured value) allows us to do this as each endpoint class or method can specify a different 
+ * stylesheet.
+ * 
+ * @see {@link LayoutJsonV1RenderingController}
+ * @see {@link LayoutJsonV2RenderingController}
+ * @see {@link JsonStructureTransformerSource}
  * @author Eric Dalquist
  * @version $Revision$
  */
 public class JsonStructureAttributeSource extends StylesheetAttributeSource {
+
+    public static final String DEFAULT_STYLESHEET_NAME = "DLMMobileColumns";
+    public static final String STYLESHEET_NAME_REQUEST_ATTRIBUTE =
+            JsonStructureAttributeSource.class.getCanonicalName() + ".STYLESHEET_NAME";
+
     @Override
     public IStylesheetDescriptor getStylesheetDescriptor(HttpServletRequest request) {
-        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName("DLMMobileColumns");
+        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                this.getStyleSheetName(request));
+    }
+
+    protected String getStyleSheetName(final HttpServletRequest request) {
+        final String stylesheetNameFromRequest =
+                (String)request.getAttribute(STYLESHEET_NAME_REQUEST_ATTRIBUTE);
+        if (StringUtils.isEmpty(stylesheetNameFromRequest)) {
+            return DEFAULT_STYLESHEET_NAME;
+        } else {
+            return stylesheetNameFromRequest;
+        }
     }
 
     @Override
     public PreferencesScope getStylesheetPreferencesScope(HttpServletRequest request) {
         return PreferencesScope.STRUCTURE;
     }
+
 }

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonStructureTransformerSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonStructureTransformerSource.java
@@ -18,16 +18,64 @@
  */
 package org.jasig.portal.json.rendering;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portal.IUserPreferencesManager;
 import org.jasig.portal.layout.om.IStylesheetDescriptor;
 import org.jasig.portal.rendering.xslt.BaseTransformerSource;
+import org.jasig.portal.rendering.xslt.TransformerSource;
 
+/**
+ * {@link TransformerSource} specific to stylesheets used to produce layout data in JSON format.  
+ * This class originally hardcoded the stylesheet name as "DLMMobileColumns" and was used to 
+ * support the "/uPortal/layout.json" call (used for mobile layout rendering).  This class has 
+ * been updated to support new layout JSON endpoints that will be  versioned.  For the newer 
+ * endpoints, this class is now able to use any stylesheet specified.  This class now looks for a 
+ * request attribute that specifies the stylesheet.  The  stylesheet will typically be specified 
+ * in the controller class for the endpoint.  For backwards compatibility, if no stylesheet 
+ * request attribute is found, the default stylesheet used will be the original "DLMMobileColumns".
+ * 
+ * Note that the only difference in the rendering pipeline between the original endpoint and the 
+ * new versioned endpoints are the stylesheets used.  Because of the number of beans required to 
+ * set up the pipeline (due to the deep chaining of {@link PipelineComponents}), it is desireable 
+ * to reuse the Spring Framework configuration that sets this up rather than duplicating it for 
+ * each endpoint.  Using a request attribute to specify the stylesheet (instead of using a 
+ * configured value) allows us to do this as each endpoint class or method can specify a different 
+ * stylesheet.
+ * 
+ * @see {@link LayoutJsonV1RenderingController}
+ * @see {@link LayoutJsonV2RenderingController}
+ * @see {@link JsonStructureAttributeSourceSource}
+ */
 public class JsonStructureTransformerSource extends BaseTransformerSource {
+
+    public static final String DEFAULT_STYLESHEET_NAME = "DLMMobileColumns";
+    public static final String STYLESHEET_NAME_REQUEST_ATTRIBUTE =
+            JsonStructureTransformerSource.class.getCanonicalName() + ".STYLESHEET_NAME";
 
     @Override
     protected long getStylesheetDescriptorId(IUserPreferencesManager preferencesManager) {
-        IStylesheetDescriptor descriptor = this.stylesheetDescriptorDao.getStylesheetDescriptorByName("DLMMobileColumns");
+        IStylesheetDescriptor descriptor =
+                this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                        DEFAULT_STYLESHEET_NAME);
         return descriptor.getId();
+    }
+
+    @Override
+    protected IStylesheetDescriptor getStylesheetDescriptor(HttpServletRequest request) {
+        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                this.getStyleSheetName(request));
+    }
+
+    protected String getStyleSheetName(final HttpServletRequest request) {
+        final String stylesheetNameFromRequest =
+                (String)request.getAttribute(STYLESHEET_NAME_REQUEST_ATTRIBUTE);
+        if (StringUtils.isEmpty(stylesheetNameFromRequest)) {
+            return DEFAULT_STYLESHEET_NAME;
+        } else {
+            return stylesheetNameFromRequest;
+        }
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonThemeAttributeSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonThemeAttributeSource.java
@@ -20,20 +20,60 @@ package org.jasig.portal.json.rendering;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portal.layout.IStylesheetUserPreferencesService.PreferencesScope;
 import org.jasig.portal.layout.om.IStylesheetDescriptor;
 import org.jasig.portal.rendering.StylesheetAttributeSource;
 
+/**
+ * {@link StylesheetAttributeSource} specific to stylesheets used to produce layout data in JSON 
+ * format.  This class originally hardcoded the stylesheet name as "JsonLayout" and was used to 
+ * support the "/uPortal/layout.json" call (used for mobile layout rendering).  This class has 
+ * been updated to support new layout JSON endpoints that will be versioned.  For the newer 
+ * endpoints, this class is now able to use stylesheets with the name "JsonLayout<version>", 
+ * where "<version>" specifies the version (e.g. "JsonLayoutV2").  This class now looks for a 
+ * request attribute that specifies the version.  The version will typically be specified in the 
+ * controller class for the endpoint.  For backwards compatibility, if no version request 
+ * attribute is found, the default stylesheet used will be the original "JsonLayout".
+ * 
+ * Note that the only difference in the rendering pipeline between the original endpoint and the 
+ * new versioned endpoints are the stylesheets used.  Because of the number of beans required to 
+ * set up the pipeline (due to the deep chaining of {@link PipelineComponents}), it is desireable 
+ * to reuse the Spring Framework configuration that sets this up rather than duplicating it for 
+ * each endpoint.  Using a request attribute to specify the stylesheet version (instead of using a 
+ * configured value) allows us to do this as each endpoint class or method can specify a different 
+ * version.
+ * 
+ * @see {@link LayoutJsonV1RenderingController}
+ * @see {@link LayoutJsonV2RenderingController}
+ * @see {@link JsonThemeTransformerSource}
+ */
 public class JsonThemeAttributeSource extends StylesheetAttributeSource {
+
+	public static final String STYLESHEET_ROOT_NAME = "JsonLayout";
+	public static final String DEFAULT_STYLESHEET_NAME = STYLESHEET_ROOT_NAME;
+    public static final String STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME = 
+            JsonThemeAttributeSource.class.getCanonicalName() + ".STYLESHEET_VERSION";
 
     @Override
     public IStylesheetDescriptor getStylesheetDescriptor(HttpServletRequest request) {
-        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName("JsonLayout");
+        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                this.getStyleSheetName(request));
+    }
+
+    protected String getStyleSheetName(final HttpServletRequest request) {
+        final String stylesheetVersionFromRequest =
+                (String)request.getAttribute(STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME);
+        if (StringUtils.isEmpty(stylesheetVersionFromRequest)) {
+            return DEFAULT_STYLESHEET_NAME;
+        } else {
+            return STYLESHEET_ROOT_NAME + stylesheetVersionFromRequest;
+        }
     }
 
     @Override
     public PreferencesScope getStylesheetPreferencesScope(HttpServletRequest request) {
         return PreferencesScope.THEME;
     }
-}
 
+}

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonThemeTransformerSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/JsonThemeTransformerSource.java
@@ -18,16 +18,64 @@
  */
 package org.jasig.portal.json.rendering;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portal.IUserPreferencesManager;
 import org.jasig.portal.layout.om.IStylesheetDescriptor;
 import org.jasig.portal.rendering.xslt.BaseTransformerSource;
+import org.jasig.portal.rendering.xslt.TransformerSource;
 
+/**
+ * {@link TransformerSource} specific to stylesheets used to produce layout data in JSON format.  
+ * This class originally hardcoded the stylesheet name as "JsonLayout" and was used to support the 
+ * "/uPortal/layout.json" call (used for mobile layout rendering).  This class has been updated to 
+ * support new layout JSON endpoints that will be versioned.  For the newer endpoints, this class 
+ * is now able to use stylesheets with the name "JsonLayout<version>", where "<version>" specifies 
+ * the version (e.g. "JsonLayoutV2").  This class now looks for a request attribute that specifies 
+ * the version.  The version will typically be specified in the controller class for the 
+ * endpoint.  For backwards compatibility, if no version request attribute is found, the default 
+ * stylesheet used will be the original "JsonLayout".  Note that the only difference in the 
+ * rendering pipeline between the original endpoint and the new versioned endpoints are the 
+ * stylesheets used.  Because of the number of beans required to set up the pipeline (due to the 
+ * deep chaining of {@link PipelineComponents}), it is desireable to reuse the Spring Framework 
+ * configuration that sets this up rather than duplicating it for each endpoint.  Using a request 
+ * attribute to specify the stylesheet version (instead of using a configured value) allows us to 
+ * do this as each endpoint class or method can specify a different version.
+ * 
+ * @see {@link LayoutJsonV1RenderingController}
+ * @see {@link LayoutJsonV2RenderingController}
+ * @see {@link JsonThemeAttributeSource}
+ */
 public class JsonThemeTransformerSource extends BaseTransformerSource {
-    
+
+    public static final String STYLESHEET_ROOT_NAME = "JsonLayout";
+    public static final String DEFAULT_STYLESHEET_NAME = STYLESHEET_ROOT_NAME;
+    public static final String STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME = 
+            JsonThemeTransformerSource.class.getCanonicalName() + ".STYLESHEET_VERSION";
+
     @Override
     protected long getStylesheetDescriptorId(IUserPreferencesManager preferencesManager) {
-        IStylesheetDescriptor descriptor = this.stylesheetDescriptorDao.getStylesheetDescriptorByName("JsonLayout");
+        IStylesheetDescriptor descriptor = 
+                this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                        DEFAULT_STYLESHEET_NAME);
         return descriptor.getId();
+    }
+
+    @Override
+    protected IStylesheetDescriptor getStylesheetDescriptor(HttpServletRequest request) {
+        return this.stylesheetDescriptorDao.getStylesheetDescriptorByName(
+                this.getStyleSheetName(request));
+    }
+
+    protected String getStyleSheetName(final HttpServletRequest request) {
+        final String stylesheetVersionFromRequest = 
+                (String)request.getAttribute(STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME);
+        if (StringUtils.isEmpty(stylesheetVersionFromRequest)) {
+            return DEFAULT_STYLESHEET_NAME;
+        } else {
+            return STYLESHEET_ROOT_NAME + stylesheetVersionFromRequest;
+        }
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/LayoutJsonV1RenderingController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/LayoutJsonV1RenderingController.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jasig.portal.portlet.registry.IPortletWindowRegistry;
+import org.jasig.portal.rendering.IPortalRenderingPipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * @author Eric Dalquist
+ * @version $Revision$
+ */
+@Controller
+public class LayoutJsonV1RenderingController {
+
+    public static final String STYLESHEET_NAME = "DLMMobileColumns";
+
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private IPortalRenderingPipeline portalRenderingPipeline;
+    private IPortletWindowRegistry portletWindowRegistry;
+
+    @Autowired
+    @Qualifier("json")
+    public void setPortalRenderingPipeline(IPortalRenderingPipeline portalRenderingPipeline) {
+        this.portalRenderingPipeline = portalRenderingPipeline;
+    }
+
+    @Autowired
+    public void setPortletWindowRegistry(IPortletWindowRegistry portletWindowRegistry) {
+        this.portletWindowRegistry = portletWindowRegistry;
+    }
+
+    @RequestMapping(value={"/layout.json","/layout/v1/layout.json"}, method = RequestMethod.GET)
+    public void v1RenderRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        this.internalRenderRequest(request, response);
+    }
+
+    private void internalRenderRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        this.setStylesheetName(request);
+        this.portletWindowRegistry.disablePersistentWindowStates(request);
+        this.portalRenderingPipeline.renderState(request, response);
+    }
+
+    private void setStylesheetName(final HttpServletRequest request) {
+        request.setAttribute(
+                JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, STYLESHEET_NAME);
+        request.setAttribute(
+                JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, STYLESHEET_NAME);
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/json/rendering/LayoutJsonV2RenderingController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/json/rendering/LayoutJsonV2RenderingController.java
@@ -32,18 +32,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
- * @author Eric Dalquist
+ * Provides endpoint that returns a JSON representation of the user's layout.  The purpose of this 
+ * data is to support the Javascript-driven rendering of the uPortal UI.
+ * 
+ * @author Gary Roybal
  * @version $Revision$
+ * @since uPortal 4.2
  */
 @Controller
-public class JsonRenderingController {
+@RequestMapping("/layout/v2")
+public class LayoutJsonV2RenderingController {
+
+    private static final String STRUCTURE_STYLESHEET_NAME = "DLMTabsColumnsJS";
+
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
-    
+
     private IPortalRenderingPipeline portalRenderingPipeline;
     private IPortletWindowRegistry portletWindowRegistry;
-    
+
     @Autowired
     @Qualifier("json")
     public void setPortalRenderingPipeline(IPortalRenderingPipeline portalRenderingPipeline) {
@@ -55,10 +64,33 @@ public class JsonRenderingController {
         this.portletWindowRegistry = portletWindowRegistry;
     }
 
-    @RequestMapping("/layout.json")
-    public void renderRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    @RequestMapping(value="/layout.json", method = RequestMethod.GET)
+    public void renderRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        this.setStructureStylesheetNameForJavascriptDrivenContentRendering(request);
+        this.setThemeStylesheetVersionForJavascriptDrivenContentRendering(request);
         this.portletWindowRegistry.disablePersistentWindowStates(request);
         this.portalRenderingPipeline.renderState(request, response);
+    }
+
+    private void setStructureStylesheetNameForJavascriptDrivenContentRendering(
+            final HttpServletRequest request) {
+        request.setAttribute(
+                JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE,
+                STRUCTURE_STYLESHEET_NAME);
+        request.setAttribute(
+                JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE,
+                STRUCTURE_STYLESHEET_NAME);
+    }
+
+    private void setThemeStylesheetVersionForJavascriptDrivenContentRendering(
+            final HttpServletRequest request) {
+        request.setAttribute(
+                JsonThemeAttributeSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME,
+                "V2");
+        request.setAttribute(
+                JsonThemeTransformerSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME,
+                "V2");
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/xslt/BaseTransformerSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/xslt/BaseTransformerSource.java
@@ -115,11 +115,15 @@ public abstract class BaseTransformerSource implements TransformerSource, Resour
      */
     protected abstract long getStylesheetDescriptorId(IUserPreferencesManager preferencesManager);
 
-    private Resource getStylesheetResource(HttpServletRequest request) {
+    protected IStylesheetDescriptor getStylesheetDescriptor(HttpServletRequest request) {
         final IUserInstance userInstance = this.userInstanceManager.getUserInstance(request);
         final IUserPreferencesManager preferencesManager = userInstance.getPreferencesManager();
-        final long stylesheetDescriptorId = this.getStylesheetDescriptorId(preferencesManager);
-        final IStylesheetDescriptor stylesheetDescriptor = this.stylesheetDescriptorDao.getStylesheetDescriptor(stylesheetDescriptorId);
+        final long id = this.getStylesheetDescriptorId(preferencesManager);
+        return this.stylesheetDescriptorDao.getStylesheetDescriptor(id);
+    };
+
+    private Resource getStylesheetResource(HttpServletRequest request) {
+        final IStylesheetDescriptor stylesheetDescriptor = this.getStylesheetDescriptor(request);
         final String stylesheetResource = stylesheetDescriptor.getStylesheetResource();
         return this.resourceLoader.getResource(stylesheetResource);
     }

--- a/uportal-war/src/main/resources/layout/structure/columns/columns-imports.xsl
+++ b/uportal-war/src/main/resources/layout/structure/columns/columns-imports.xsl
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:dlm="http://www.uportal.org/layout/dlm" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<!--=====START: DOCUMENT DESCRIPTION=====-->
+<!--
+    Version: $Revision$
+    @since uPortal 4.2
+
+    General Description:  This file was created in order to help minize duplication of code 
+    between columns.xsl and columns-js.xsl (which was derived from columns.xsl).  It contains 
+    items that are common between the two.
+-->
+<!--=====END: DOCUMENT DESCRIPTION=====-->
+
+    <xsl:param name="userLayoutRoot">root</xsl:param>
+    <xsl:param name="userImpersonating">false</xsl:param>
+
+    <!-- Check if we have favorites or not -->
+    <xsl:variable name="hasFavorites">
+        <xsl:choose>
+            <xsl:when test="layout/folder/folder[@type='favorites']">true</xsl:when>
+            <xsl:otherwise>false</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+    <!-- Used to build the tabGroupsList:  discover tab groups, add each to the list ONLY ONCE -->
+    <xsl:key name="tabGroupKey" match="layout/folder/folder[@hidden='false' and @type='regular']" use="@tabGroup"/>
+
+    <xsl:variable name="activeTabGroup">DEFAULT_TABGROUP</xsl:variable>
+
+    <!-- 
+     | Regions and Roles
+     | =================
+     | The <regions> section allows non-regular, non-sidebar portlets to appear in the
+     | output page, even in focused mode.  In Universality this is done with a 'role' 
+     | attribute on the portlet publication record.
+     |
+     | In Respondr, this is done through regions: folders with a type attribute _other than_
+     | 'root', 'regular', or 'sidebar' (for legacy support).  Any folder type beyond these
+     | three automatically becomes a region.  Respondr is responsible for recognizing
+     | region-based portlets and placing them appropriately on the page.  Note that a region
+     | name can appear multiple times in the output;  this approach allows multiple
+     | fragments to place portlets in the same region.
+     |
+     | Regions behave normally in dashboard (normal) and focused (maximized) mode;  in
+     | DETACHED window state, only a few regions are processed, and then ONLY IF THE STICKY
+     | HEADER option is in effect.  The list of regions included with a sticky-header is:
+     | hidden-top, page-top, page-bottom, hidden-bottom.  The remaining regions are not
+     | present in the DOM and therefore their portlets MUST NOT be added to the rendering
+     | queue. 
+     +-->
+    <xsl:template name="region">
+        <region name="{@type}">
+            <xsl:copy-of select="channel"/>
+        </region>
+    </xsl:template>
+
+    <xsl:template name="tabList">
+        <navigation>
+            <!-- Signals that add-tab prompt is appropriate in the context of this navigation
+                 user might or might not actually have permission to add a tab, which is evaluated later (in the theme) -->
+            <xsl:attribute name="allowAddTab">true</xsl:attribute>
+            <!-- The tabGroups (optional feature) -->
+            <tabGroupsList>
+                <xsl:attribute name="activeTabGroup">
+                    <xsl:value-of select="$activeTabGroup"/>
+                </xsl:attribute>
+                <xsl:for-each select="/layout/folder/folder[@type='regular' and @hidden='false']"><!-- These are standard tabs -->
+                    <!-- Process only the first tab in each Tab Group (avoid duplicates) -->
+                    <xsl:if test="self::node()[generate-id() = generate-id(key('tabGroupKey',@tabGroup)[1])]">
+                        <tabGroup name="{@tabGroup}" firstTabId="{@ID}">
+                            <xsl:value-of select="@tabGroup"/>
+                        </tabGroup>
+                    </xsl:if>
+                </xsl:for-each>
+            </tabGroupsList>
+            <!-- The tabs -->
+            <xsl:for-each select="/layout/folder/folder[@type='regular' and @hidden='false']">
+                <xsl:call-template name="tab" />
+            </xsl:for-each>
+        </navigation>
+    </xsl:template>
+
+    <!-- List of Favorites
+     |   =================
+     |   A list of favorited channels. 
+     |   To be utilized to establish if "add to favorites" 
+     |   or "remove from favorites" shows in the options menu -->
+    <xsl:template name="favorites">
+        <favorites>
+            <xsl:for-each select="/layout/folder/folder[@type='favorites']/folder/channel">
+                <favorite fname='{@fname}'/>
+            </xsl:for-each>
+            <xsl:for-each select="/layout/folder/folder[@type='favorite_collection']/folder/channel">
+                <favorite fname='{@fname}'/>
+            </xsl:for-each>
+        </favorites>
+    </xsl:template>
+
+    <xsl:template match="channel">
+        <xsl:choose>
+            <xsl:when test="$userImpersonating = 'true' and parameter[@name='blockImpersonation']/@value = 'true'">
+                <blocked-channel>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:copy-of select="child::*"/>
+                </blocked-channel>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="parameter">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/uportal-war/src/main/resources/layout/structure/columns/columns-js.xsl
+++ b/uportal-war/src/main/resources/layout/structure/columns/columns-js.xsl
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:dlm="http://www.uportal.org/layout/dlm" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<!--=====START: DOCUMENT DESCRIPTION=====-->
+<!--
+    Version: $Revision$
+    @since uPortal 4.2
+
+    General Description:  This file was developed to support Javascript-driven rendering of the 
+    uPortal UI.  This file collects the necessary user layout data and exports xml that is then 
+    organized and transformed into JSON using the json-v2.xsl file and a JSON-specific rendering
+    pipeline.  This file is based on the columns.xsl file, but has been updated to include 
+    additional data.
+-->
+<!--=====END: DOCUMENT DESCRIPTION=====-->
+
+    <!-- Import standard templates for column output -->
+    <xsl:import href="columns-imports.xsl" />
+
+    <!-- ROOT template.  Default to NORMAL window state (since DETACHED window state does not apply). -->
+    <xsl:template match="layout">
+        <xsl:apply-templates select="folder[@type='root']" mode="NORMAL" />
+    </xsl:template>
+
+    <!-- NORMAL page template.  Governs the overall structure when the page is non-detached. -->
+    <xsl:template match="folder[@type='root']" mode="NORMAL">
+        <layout>
+            <xsl:call-template name="debug-info"/>
+
+            <xsl:if test="/layout/@dlm:fragmentName">
+                <xsl:attribute name="dlm:fragmentName"><xsl:value-of select="/layout/@dlm:fragmentName"/></xsl:attribute>
+            </xsl:if>
+
+            <xsl:call-template name="regions" />
+
+            <xsl:call-template name="tabList"/>
+
+            <xsl:call-template name="favorites" />
+
+            <xsl:call-template name="favorite-groups" />
+        </layout>
+    </xsl:template>
+
+    <xsl:template name="regions">
+            <regions>
+                <xsl:choose>
+                    <xsl:when test="$userLayoutRoot = 'root'">
+                        <!-- Include all regions when in DASHBOARD mode -->
+                        <xsl:for-each select="child::folder[@type!='regular' and @type!='sidebar' and @type!='customize' and channel]"><!-- Ignores empty folders -->
+                            <xsl:call-template name="region"/>
+                        </xsl:for-each>
+                        <!--  Combine 'customize' regions -->
+                        <xsl:if test="child::folder[@type='customize' and channel]">
+                            <region name="customize">
+                                <xsl:for-each select="child::folder[@type='customize' and channel]">
+                                    <xsl:copy-of select="channel"/>
+                                </xsl:for-each>
+                            </region>
+                        </xsl:if>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <!-- Include all regions EXCEPT 'region-customize' when in FOCUSED mode -->
+                        <xsl:for-each select="child::folder[@type!='customize' and @type!='regular' and @type!='sidebar' and channel]"><!-- Ignores empty folders -->
+                            <xsl:call-template name="region"/>
+                        </xsl:for-each>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </regions>
+    </xsl:template>
+
+    <xsl:template name="debug-info">
+        <!-- This element is not (presently) consumed by the theme transform, but it can be written to the logs easy debugging -->
+        <debug>
+            <userLayoutRoot><xsl:value-of select="$userLayoutRoot"></xsl:value-of></userLayoutRoot>
+            <hasFavorites><xsl:value-of select="$hasFavorites"/></hasFavorites>
+            <activeTabGroup><xsl:value-of select="$activeTabGroup"></xsl:value-of></activeTabGroup>
+            <tabsInTabGroup><xsl:value-of select="count(/layout/folder/folder[@tabGroup=$activeTabGroup and @type='regular' and @hidden='false'])"/></tabsInTabGroup>
+            <userImpersonation><xsl:value-of select="$userImpersonating"/></userImpersonation>
+        </debug>
+    </xsl:template>
+
+    <xsl:template match="folder[@type!='root' and @hidden='false']">
+        <xsl:attribute name="type">regular</xsl:attribute>
+        <xsl:if test="child::folder">
+            <xsl:for-each select="folder">
+                <xsl:call-template name="column" />
+            </xsl:for-each>
+        </xsl:if>
+        <xsl:if test="child::channel">
+            <xsl:call-template name="column" />
+        </xsl:if>
+        <!-- handle columns with no portlets -->
+        <xsl:if test="not(node()) and parent::folder[@type!='root']">
+            <xsl:call-template name="column" />
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="@*">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template name="column">
+                <column>
+                    <xsl:copy-of select="@*" />
+                    <xsl:apply-templates/>
+                </column>
+    </xsl:template>
+
+    <xsl:template name="tab">
+        <tab>
+            <!-- Copy folder attributes verbatim -->
+            <xsl:for-each select="attribute::*">
+                <xsl:attribute name="{name()}"><xsl:value-of select="."/></xsl:attribute>
+            </xsl:for-each>
+            <xsl:if test="count(./folder[not(@dlm:addChildAllowed='false')]) >0">
+                <xsl:attribute name="dlm:addChildAllowed">true</xsl:attribute>
+            </xsl:if>
+
+            <content>
+                <xsl:choose>
+                    <xsl:when test="$userLayoutRoot = 'root'">
+                        <xsl:apply-templates select="folder[@type='regular']"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <focused>
+                            <!-- Detect whether a focused channel is present in the user's layout -->
+                            <xsl:attribute name="in-user-layout">
+                                <xsl:choose>
+                                    <xsl:when test="//folder[@type='regular' and @hidden='false']/channel[@ID = $userLayoutRoot]">yes</xsl:when>
+                                    <xsl:otherwise>no</xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:attribute>
+                            <xsl:apply-templates select="//*[@ID = $userLayoutRoot]"/>
+                        </focused>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </content>
+        </tab>
+    </xsl:template>
+
+    <xsl:template name="favorites">
+        <favorites>
+            <xsl:for-each select="/layout/folder/folder[@type='favorites']/folder/channel">
+                <favorite>
+                    <xsl:apply-templates select="." />
+                </favorite>
+            </xsl:for-each>
+        </favorites>
+    </xsl:template>
+
+    <xsl:template name="favorite-groups">
+        <favoriteGroups>
+            <xsl:for-each select="/layout/folder/folder[@type='favorite_collection']">
+                <favoriteGroup>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:apply-templates select="folder" />
+                </favoriteGroup>
+            </xsl:for-each>
+        </favoriteGroups>
+    </xsl:template>
+
+    <xsl:template match="/layout/folder/folder[@type='favorite_collections']/folder">
+        <xsl:call-template name="column" />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/uportal-war/src/main/resources/layout/theme/json/json-v2.xsl
+++ b/uportal-war/src/main/resources/layout/theme/json/json-v2.xsl
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- ========================================================================= -->
+<!-- ========== README ======================================================= -->
+<!-- ========================================================================= -->
+<!-- 
+ | The theme is written in XSL. For more information on XSL, refer to 
+ | [http://www.w3.org/Style/XSL/].  Baseline XSL skill is strongly recommended before modifying 
+ | this file.
+ |
+ | This purpose of this file is to provide structure and theme data for use in 
+ | javascript-driven rendering of the uPortal UI
+ |
+ | As such, this file has a mixture of code that should not be modified, and code that exists 
+ | explicitly to be modified.  To help make clear what is what, a RED-YELLOW-GREEN legend has 
+ | been added to all of the sections of the file.
+ |
+ | RED: Stop! Do not modify.
+ | YELLOW: Warning, proceed with caution.  Modifications can be made, but should not generally be 
+ |         necessary and may require more advanced skill.
+ | GREEN: Go! Modify as desired.
+-->
+
+<!-- ========================================================================= -->
+<!-- ========== DOCUMENT DESCRIPTION ========================================= -->
+<!-- ========================================================================= -->
+<!-- 
+ | Date: 04/01/2015
+ | Company: Unicon, Inc.
+ | uPortal Version: 4.2.0
+ |
+ | General Description: This file, json-v2.xsl, was developed for sending layout data to the UI 
+ | for use in rendering the uPortal UI using Javascript.  The original json.xsl file is now 
+ | considered 'version 1' and this new file is 'version 2'.  The original endpoint, 
+ | "/uPortal/layout.json", has been preserved for backwards compatibility.  However, the same 
+ | content is now also available at: "/uPortal/layout/v1/layout.json".  A new endpoint, 
+ | "/uPortal/layout/v2/layout.json", which utilizes this file, has been added.
+-->
+
+
+<!-- ========================================================================= -->
+<!-- ========== STYLESHEET DECLARATION ======================================= -->
+<!-- ========================================================================= -->
+<!-- 
+ | RED
+ | This statement defines this document as XSL.
+-->
+<xsl:stylesheet 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+    xmlns:dlm="http://www.uportal.org/layout/dlm"
+    xmlns:upAuth="http://xml.apache.org/xalan/java/org.jasig.portal.security.xslt.XalanAuthorizationHelper"
+    xmlns:upGroup="http://xml.apache.org/xalan/java/org.jasig.portal.security.xslt.XalanGroupMembershipHelper"
+    xmlns:upMsg="http://xml.apache.org/xalan/java/org.jasig.portal.security.xslt.XalanMessageHelper"
+    xmlns:url="https://source.jasig.org/schemas/uportal/layout/portal-url"
+    xmlns:upElemTitle="http://xml.apache.org/xalan/java/org.jasig.portal.security.xslt.XalanLayoutElementTitleHelper"
+    xsi:schemaLocation="
+            https://source.jasig.org/schemas/uportal/layout/portal-url https://source.jasig.org/schemas/uportal/layout/portal-url-4.0.xsd"
+    exclude-result-prefixes="url upAuth upGroup upMsg upElemTitle" 
+    version="1.0">
+
+<!-- ========================================================================= -->
+
+
+<!-- ========================================================================= -->
+<!-- ========== IMPORTS ====================================================== -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+| Imports are the XSL files that build the theme.
+| Import statments and the XSL files they refer to should not be modified.
+-->
+<xsl:import href="../resourcesTemplates.xsl" />  <!-- Templates for Skin Resource generation -->
+<xsl:import href="../urlTemplates.xsl" />        <!-- Templates for URL generation -->
+<!-- ========================================================================= -->
+
+
+<!-- ========================================= -->
+<!-- ========== OUTPUT DELCARATION =========== -->
+<!-- ========================================= -->
+<!-- 
+    | RED
+    | This statement instructs the XSL how to output.
+-->
+<xsl:output method="xml" indent="yes" media-type="text/html"/>
+<!-- ========================================= -->
+
+<!-- ============================================== -->
+<!-- ========== VARIABLES and PARAMETERS ========== -->
+<!-- ============================================== -->
+<!-- 
+| YELLOW - GREEN
+| These variables and parameters provide flexibility and customization of the user interface.
+| Changing the values of the variables and parameters signals the theme to reconfigure use 
+| and location of user interface components. Most text used within the theme is localized.  
+-->
+  
+  
+<!-- ****** XSL UTILITY PARAMETERS ****** -->
+<!-- 
+| RED
+| Parameters used by XSL->Java Callbacks
+-->
+<xsl:param name="CURRENT_REQUEST" />
+<xsl:param name="RESOURCES_ELEMENTS_HELPER" />
+<xsl:param name="XSLT_PORTAL_URL_PROVIDER" />
+
+
+<!-- ****** SKIN SETTINGS ****** -->
+<!-- 
+| YELLOW
+| Skin Settings can be used to change the location of skin files.
+--> 
+<xsl:param name="CONTEXT_PATH">/NOT_SET</xsl:param>
+<xsl:variable name="MEDIA_PATH">media/skins/muniversality</xsl:variable>
+<xsl:variable name="ABSOLUTE_MEDIA_PATH" select="concat($CONTEXT_PATH,'/',$MEDIA_PATH)"/>
+<xsl:variable name="PORTAL_SHORTCUT_ICON" select="concat($CONTEXT_PATH,'/favicon.ico')" />
+<!-- ======================================== -->
+
+
+<!-- ****** LOCALIZATION SETTINGS ****** -->
+<!-- 
+| GREEN
+| Locatlization Settings can be used to change the localization of the theme.
+-->
+<xsl:param name="MESSAGE_DOC_URL">messages.xml</xsl:param>
+<xsl:param name="USER_LANG">en</xsl:param>
+<!-- ======================================== -->
+
+
+<!-- ****** PORTAL SETTINGS ****** -->
+<!-- 
+| YELLOW
+| Portal Settings should generally not be (and not need to be) modified.
+-->
+<xsl:param name="AUTHENTICATED" select="'false'"/>
+<xsl:param name="USER_ID">guest</xsl:param>
+<xsl:param name="userName">Guest User</xsl:param>
+<xsl:param name="USER_NAME"><xsl:value-of select="$userName"/></xsl:param>
+<xsl:param name="USE_SELECT_DROP_DOWN">true</xsl:param>
+<xsl:param name="uP_productAndVersion">uPortal</xsl:param>
+<xsl:param name="UP_VERSION"><xsl:value-of select="$uP_productAndVersion"/></xsl:param>
+<xsl:param name="WINDOW_STATE_FOR_PORTLET_URLS">EXCLUSIVE</xsl:param>
+<xsl:param name="baseActionURL">render.uP</xsl:param>
+<xsl:variable name="BASE_ACTION_URL"><xsl:value-of select="$baseActionURL"/></xsl:variable>
+<!--  
+<xsl:param name="HOME_ACTION_URL"><xsl:value-of select="$BASE_ACTION_URL"/>?uP_root=root&amp;uP_reload_layout=true&amp;uP_sparam=targetRestriction&amp;targetRestriction=no targetRestriction parameter&amp;uP_sparam=targetAction&amp;targetAction=no targetAction parameter&amp;uP_sparam=selectedID&amp;selectedID=&amp;uP_cancel_targets=true&amp;uP_sparam=mode&amp;mode=view</xsl:param> 
+-->
+
+<xsl:param name="EXTERNAL_LOGIN_URL"></xsl:param>
+    
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: ROOT =============================================== -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+| This is the root xsl template and it defines the overall structure of the html markup. 
+| Focused and Non-focused content is controlled through an xsl:choose statement.
+| Template contents can be any valid XSL or XHTML.
+-->
+<xsl:template match="/">
+    <layout><json/>{
+    "user": "<xsl:value-of select="$USER_ID"/>",
+    "locale": "<xsl:value-of select="$USER_LANG"/>", 
+    "layout": {
+        "globals": {
+            <xsl:apply-templates select="layout/debug" />
+        },
+        "regions": [
+            <xsl:apply-templates select="layout/regions" />
+        ],
+        "navigation": {
+            <xsl:apply-templates select="layout/navigation" />
+        },
+        "favorites": [
+            <xsl:apply-templates select="layout/favorites" />
+        ],
+        "favoriteGroups": [
+            <xsl:apply-templates select="layout/favoriteGroups" />
+        ]
+    }
+}<json/></layout>
+</xsl:template>
+<!-- ========================================================================= -->
+
+
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: PORTLET =============================================== -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+| This template defines the method for expressing the presence of a portlet within a layout.
+-->
+<xsl:template match="channel">
+    <xsl:variable name="defaultPortletUrl">
+        <xsl:call-template name="portalUrl">
+            <xsl:with-param name="url">
+                <url:portal-url>
+                    <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
+                    <url:portlet-url state="{$WINDOW_STATE_FOR_PORTLET_URLS}" />
+                </url:portal-url>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="portletUrl">{up-portlet-link(<xsl:value-of select="@ID" />,<xsl:value-of select="$defaultPortletUrl" />)}</xsl:variable>
+    <xsl:variable name="iconUrl">
+        <xsl:choose>
+            <xsl:when test="parameter[@name='mobileIconUrl'] and parameter[@name='mobileIconUrl']/@value != ''">
+                <xsl:value-of select="parameter[@name='mobileIconUrl']/@value"/>
+            </xsl:when>
+            <xsl:otherwise><xsl:value-of select="$CONTEXT_PATH"/>/media/skins/icons/mobile/default.png</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+                                        {
+                                            "url": "<xsl:value-of select="$portletUrl"/>",
+                                            "newItemCount": "{up-portlet-new-item-count(<xsl:value-of select="@ID" />)}",
+                                            "iconUrl": "<xsl:value-of select="$iconUrl"/>",
+                                            <xsl:for-each select="@*[local-name() != 'hidden' and local-name() != 'immutable' and local-name() != 'unremovable']">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                                            </xsl:for-each>
+                                            "parameters": [
+                                                <xsl:for-each select="parameter">
+                                                {
+                                                    "name": "<xsl:value-of select ="@name" />",
+                                                    "value": "<xsl:value-of select="@value" />"
+                                                }<xsl:if test="position() != last()">,</xsl:if>
+                                                </xsl:for-each>
+                                            ]
+                                        }<xsl:if test="position() != last()">,</xsl:if>
+</xsl:template>
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: DEBUG ============================================== -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+-->
+<xsl:template match="debug">
+        <xsl:for-each select="*">
+             "<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>"<xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>
+</xsl:template>
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: REGIONS ============================================ -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+-->
+<xsl:template match="regions">
+            <xsl:for-each select="region">
+            {
+                <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                </xsl:for-each>
+                "portlets": [
+                        <xsl:apply-templates select="channel" />
+                ]
+            }<xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+</xsl:template>
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: NAVIGATION ========================================= -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+-->
+<xsl:template match="navigation">
+            <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+            </xsl:for-each>
+            "tabGroupsList": {
+                <xsl:for-each select="tabGroupsList/@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                </xsl:for-each>
+                "tabGroups": [
+                    <xsl:for-each select="tabGroupsList/tabGroup">
+                    {
+                        <xsl:for-each select="@*">
+                            "<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>"<xsl:if test="position() != last()">,</xsl:if>
+                        </xsl:for-each>
+                    }<xsl:if test="position() != last()">,</xsl:if>
+                    </xsl:for-each>
+                ]
+            },
+            "tabs": [
+                <xsl:for-each select="tab">
+                {
+                    <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                    </xsl:for-each>
+<!--                     "tabChannels": [
+                        <xsl:for-each select="tabChannel">
+                        {
+                            <xsl:for-each select="@*">
+                                "<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                            </xsl:for-each>
+                        }<xsl:if test="position() != last()">,</xsl:if>
+                        </xsl:for-each>
+                    ],
+-->
+                    "content": {
+                        <xsl:apply-templates select="content" />
+                    }
+                }<xsl:if test="position() != last()">,</xsl:if>
+                </xsl:for-each>
+            ]
+</xsl:template>
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: CONTENT ============================================ -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+-->
+<xsl:template match="content">
+                        <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
+                        </xsl:for-each>
+                        "columns": [
+                            <xsl:apply-templates select="column" />
+                        ]
+</xsl:template>
+
+<xsl:template match="column">
+                            {
+                                <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="normalize-space(.)"/>",
+                                </xsl:for-each>
+                                "portlets": [
+                                <xsl:apply-templates select="channel" />
+                                ]
+                            }<xsl:if test="position() != last()">,</xsl:if>
+</xsl:template>
+
+<!-- ========================================================================= -->
+<!-- ========== TEMPLATE: FAVORITES ========================================== -->
+<!-- ========================================================================= -->
+<!-- 
+| RED
+-->
+<xsl:template match="favorites">
+            <xsl:apply-templates select="favorite" />
+</xsl:template>
+
+<xsl:template match="favorite">
+            {
+                "portlet":
+                    <xsl:apply-templates select="channel" />
+            }<xsl:if test="position() != last()">,</xsl:if>
+</xsl:template>
+
+<xsl:template match="favoriteGroups">
+            <xsl:apply-templates select="favoriteGroup" />
+</xsl:template>
+
+<xsl:template match="favoriteGroup">
+            {
+                <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="normalize-space(.)"/>",
+                </xsl:for-each>
+                "columns:" : [
+                <xsl:apply-templates select="column" />
+                ]
+            }<xsl:if test="position() != last()">,</xsl:if>
+</xsl:template>
+
+<!-- ========================================================================= -->
+
+</xsl:stylesheet>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -414,6 +414,8 @@
 
     <servlet-mapping>
         <servlet-name>JsonRenderingDispatcherServlet</servlet-name>
+        <url-pattern>/layout/v2/layout.json</url-pattern>
+        <url-pattern>/layout/v1/layout.json</url-pattern>
         <url-pattern>/layout.json</url-pattern>
     </servlet-mapping>
 

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonStructureAttributeSourceTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonStructureAttributeSourceTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.layout.IStylesheetUserPreferencesService;
+import org.jasig.portal.layout.dao.IStylesheetDescriptorDao;
+import org.jasig.portal.user.IUserInstanceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * JUnit test class for {@link JsonStructureAttributeSource}.
+ */
+public class JsonStructureAttributeSourceTest {
+
+    @Mock HttpServletRequest request;
+    @Mock IStylesheetDescriptorDao stylesheetDescriptorDao;
+    @Mock IStylesheetUserPreferencesService stylesheetUserPreferencesService;
+    @Mock IUserInstanceManager userInstanceManager;
+
+    private JsonStructureAttributeSource source;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        this.source = new JsonStructureAttributeSource();
+        this.source.setStylesheetDescriptorDao(this.stylesheetDescriptorDao);
+        this.source.setStylesheetUserPreferencesService(this.stylesheetUserPreferencesService);
+        this.source.setUserInstanceManager(this.userInstanceManager);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void getStylesheetDescriptorMethodShouldUseMobileStylesheetByDefault() {
+        // given
+        given(this.request.getAttribute(JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE)).willReturn(null);
+        // when
+        this.source.getStylesheetDescriptor(this.request);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName("DLMMobileColumns");
+    }
+
+    @Test
+    public void getStylesheetDescriptorMethodShouldUseRequestAttributeValue() {
+        // given
+        final String stylesheetName = "mystylesheet.xsl";
+        given(this.request.getAttribute(JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE)).willReturn(stylesheetName);
+        // when
+        this.source.getStylesheetDescriptor(this.request);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName(stylesheetName);
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonStructureTransformerSourceTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonStructureTransformerSourceTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jasig.portal.IUserPreferencesManager;
+import org.jasig.portal.layout.IStylesheetUserPreferencesService;
+import org.jasig.portal.layout.dao.IStylesheetDescriptorDao;
+import org.jasig.portal.layout.om.IStylesheetDescriptor;
+import org.jasig.portal.user.IUserInstance;
+import org.jasig.portal.user.IUserInstanceManager;
+import org.jasig.portal.xml.XmlUtilities;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ * JUnit test class for {@link JsonStructureTransformerSource}.
+ */
+public class JsonStructureTransformerSourceTest {
+
+    final private long id = 1L;
+    final private String stylesheetName = "mystylesheet.xsl";
+    final private String stylesheetResourceLocation = "/path/to/" + this.stylesheetName;
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private IUserInstance userInstance;
+    @Mock private IUserPreferencesManager userPreferencesManager;
+    @Mock private IStylesheetDescriptor stylesheetDescriptor;
+    @Mock private IStylesheetDescriptorDao stylesheetDescriptorDao;
+    @Mock private IStylesheetUserPreferencesService stylesheetUserPreferencesService;
+    @Mock private IUserInstanceManager userInstanceManager;
+    @Mock private Resource stylesheetResource;
+    @Mock private ResourceLoader resourseLoader;
+    @Mock private XmlUtilities xmlUtilities;
+
+    private JsonStructureTransformerSource source;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        given(this.userInstanceManager.getUserInstance(this.request)).willReturn(this.userInstance);
+        given(this.userInstance.getPreferencesManager()).willReturn(this.userPreferencesManager);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptor(this.id)).willReturn(this.stylesheetDescriptor);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(this.stylesheetName)).willReturn(this.stylesheetDescriptor);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(JsonStructureTransformerSource.DEFAULT_STYLESHEET_NAME)).willReturn(this.stylesheetDescriptor);
+        given(this.stylesheetDescriptor.getId()).willReturn(this.id);
+        given(this.resourseLoader.getResource(this.stylesheetResourceLocation)).willReturn(this.stylesheetResource);
+        this.source = new JsonStructureTransformerSource();
+        this.source.setStylesheetDescriptorDao(this.stylesheetDescriptorDao);
+        this.source.setResourceLoader(this.resourseLoader);
+        this.source.setUserInstanceManager(this.userInstanceManager);
+        this.source.setXmlUtilities(this.xmlUtilities);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void getTransformerMethodShouldUseMobileStylesheetByDefault() {
+        // given
+        given(this.request.getAttribute(JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE)).willReturn(null);
+        // when
+        this.source.getTransformer(this.request, this.response);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName("DLMMobileColumns");
+    }
+
+    @Test
+    public void getTransformerMethodShouldUseRequestAttributeValue() {
+        // given
+        given(this.request.getAttribute(JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE)).willReturn(this.stylesheetName);
+        // when
+        this.source.getTransformer(this.request, this.response);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName(this.stylesheetName);
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonThemeAttributeSourceTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonThemeAttributeSourceTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.layout.dao.IStylesheetDescriptorDao;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * JUnit test class for {@link JsonThemeAttributeSource}.
+ */
+public class JsonThemeAttributeSourceTest {
+
+	@Mock HttpServletRequest request;
+	@Mock IStylesheetDescriptorDao styleSheetDescriptorDao;
+	private JsonThemeAttributeSource source;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		this.source = new JsonThemeAttributeSource();
+		this.source.setStylesheetDescriptorDao(this.styleSheetDescriptorDao);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void getStylesheetDescriptorMethodShouldReturnDefaultWhenNoOverrideIsSpecified() {
+		// when
+		this.source.getStylesheetDescriptor(this.request);
+		// then
+		verify(this.styleSheetDescriptorDao).getStylesheetDescriptorByName("JsonLayout");
+	}
+
+	@Test
+	public void getStylesheetDescriptorMethodShouldReturnSpecifiedStylesheetWhenOverrideIsSpecified() {
+		// given
+		final String versionOverride = "V2";
+		given(this.request.getAttribute(JsonThemeAttributeSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME)).willReturn(versionOverride);
+		// when
+		this.source.getStylesheetDescriptor(this.request);
+		// then
+		verify(this.styleSheetDescriptorDao).getStylesheetDescriptorByName("JsonLayout"+versionOverride);
+	}
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonThemeTransformerSourceTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/JsonThemeTransformerSourceTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jasig.portal.IUserPreferencesManager;
+import org.jasig.portal.layout.IStylesheetUserPreferencesService;
+import org.jasig.portal.layout.dao.IStylesheetDescriptorDao;
+import org.jasig.portal.layout.om.IStylesheetDescriptor;
+import org.jasig.portal.user.IUserInstance;
+import org.jasig.portal.user.IUserInstanceManager;
+import org.jasig.portal.xml.XmlUtilities;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ * JUnit test class for {@link JsonThemeTransformerSource}.
+ */
+public class JsonThemeTransformerSourceTest {
+
+    final private long id = 1L;
+    final private String stylesheetName1 = "JsonLayout";
+    final private String stylesheetName2 = "JsonLayoutV2";
+    final private String stylesheetResourceLocation1 = "/path/to/json.xsl";
+    final private String stylesheetResourceLocation2 = "/path/to/json-v2.xsl";
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private IUserInstance userInstance;
+    @Mock private IUserPreferencesManager userPreferencesManager;
+    @Mock private IStylesheetDescriptor stylesheetDescriptor1;
+    @Mock private IStylesheetDescriptor stylesheetDescriptor2;
+    @Mock private IStylesheetDescriptorDao stylesheetDescriptorDao;
+    @Mock private IStylesheetUserPreferencesService stylesheetUserPreferencesService;
+    @Mock private IUserInstanceManager userInstanceManager;
+    @Mock private Resource stylesheetResource1;
+    @Mock private Resource stylesheetResource2;
+    @Mock private ResourceLoader resourseLoader;
+    @Mock private XmlUtilities xmlUtilities;
+
+    private JsonThemeTransformerSource source;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        given(this.userInstanceManager.getUserInstance(this.request)).willReturn(this.userInstance);
+        given(this.userInstance.getPreferencesManager()).willReturn(this.userPreferencesManager);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptor(this.id)).willReturn(this.stylesheetDescriptor1);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(this.stylesheetName1)).willReturn(this.stylesheetDescriptor1);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(this.stylesheetName2)).willReturn(this.stylesheetDescriptor2);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(JsonThemeTransformerSource.DEFAULT_STYLESHEET_NAME)).willReturn(this.stylesheetDescriptor1);
+        given(this.stylesheetDescriptorDao.getStylesheetDescriptorByName(JsonThemeTransformerSource.DEFAULT_STYLESHEET_NAME)).willReturn(this.stylesheetDescriptor1);
+        given(this.stylesheetDescriptor1.getId()).willReturn(this.id);
+        given(this.resourseLoader.getResource(this.stylesheetResourceLocation1)).willReturn(this.stylesheetResource1);
+        given(this.resourseLoader.getResource(this.stylesheetResourceLocation2)).willReturn(this.stylesheetResource2);
+        this.source = new JsonThemeTransformerSource();
+        this.source.setStylesheetDescriptorDao(this.stylesheetDescriptorDao);
+        this.source.setResourceLoader(this.resourseLoader);
+        this.source.setUserInstanceManager(this.userInstanceManager);
+        this.source.setXmlUtilities(this.xmlUtilities);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void getTransformerMethodShouldUseDefaultStylesheetWhenNoVersionOverrideSpecified() {
+        // given
+        given(this.request.getAttribute(JsonThemeTransformerSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME)).willReturn(null);
+        // when
+        this.source.getTransformer(this.request, this.response);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName(JsonThemeTransformerSource.DEFAULT_STYLESHEET_NAME);
+    }
+
+    @Test
+    public void getTransformerMethodShouldUseStylesheetVersionSpecifiecInRequestAttributeValue() {
+        // given
+        final String versionOverride = "V2";
+        given(this.request.getAttribute(JsonThemeTransformerSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME)).willReturn(versionOverride);
+        // when
+        this.source.getTransformer(this.request, this.response);
+        // then
+        verify(this.stylesheetDescriptorDao).getStylesheetDescriptorByName(JsonThemeTransformerSource.STYLESHEET_ROOT_NAME + versionOverride);
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/LayoutJsonV1RenderingControllerTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/LayoutJsonV1RenderingControllerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jasig.portal.portlet.registry.IPortletWindowRegistry;
+import org.jasig.portal.rendering.IPortalRenderingPipeline;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * JUnit test class for {@link LayoutJsonV1RenderingController}.
+ */
+public class LayoutJsonV1RenderingControllerTest {
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private IPortalRenderingPipeline portalRenderingPipeline;
+    @Mock private IPortletWindowRegistry portletWindowRegistry;
+
+    private LayoutJsonV1RenderingController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        this.controller = new LayoutJsonV1RenderingController();
+        this.controller.setPortalRenderingPipeline(this.portalRenderingPipeline);
+        this.controller.setPortletWindowRegistry(this.portletWindowRegistry);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetStructureAttributeStylesheetName() throws Exception {
+        // when
+        this.controller.v1RenderRequest(this.request, this.response);
+        // then
+        this.verifyStructureAttributeStylesheetNameWasSet(this.request);
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetStructureTransformerStylesheetName() throws Exception {
+        // when
+        this.controller.v1RenderRequest(this.request, this.response);
+        // then
+        this.verifyStructureTransformerStylesheetNameWasSet(this.request);
+    }
+
+    private void verifyStructureAttributeStylesheetNameWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, "DLMMobileColumns");
+    }
+
+    private void verifyStructureTransformerStylesheetNameWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, "DLMMobileColumns");
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/json/rendering/LayoutJsonV2RenderingControllerTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/json/rendering/LayoutJsonV2RenderingControllerTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.json.rendering;
+
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jasig.portal.portlet.registry.IPortletWindowRegistry;
+import org.jasig.portal.rendering.IPortalRenderingPipeline;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * JUnit test class for {@link LayoutJsonV2RenderingController}.
+ */
+public class LayoutJsonV2RenderingControllerTest {
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private IPortalRenderingPipeline portalRenderingPipeline;
+    @Mock private IPortletWindowRegistry portletWindowRegistry;
+
+    private LayoutJsonV2RenderingController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        this.controller = new LayoutJsonV2RenderingController();
+        this.controller.setPortalRenderingPipeline(this.portalRenderingPipeline);
+        this.controller.setPortletWindowRegistry(this.portletWindowRegistry);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetStructureAttributeStylesheetName() throws Exception {
+        // when
+        this.controller.renderRequest(this.request, this.response);
+        // then
+        this.verifyStructureAttributeStylesheetNameWasSet(this.request);
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetStructureTransformerStylesheet() throws Exception {
+        // when
+        this.controller.renderRequest(this.request, this.response);
+        // then
+        this.verifyStructureTransformerStylesheetNameWasSet(this.request);
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetThemeAttributeStylesheetVersion() throws Exception {
+        // when
+        this.controller.renderRequest(this.request, this.response);
+        // then
+        this.verifyThemeAttributeStylesheetVersionWasSet(this.request);
+    }
+
+    @Test
+    public void renderRequestMethodShouldSetThemeTransformerStylesheetVersion() throws Exception {
+        // when
+        this.controller.renderRequest(this.request, this.response);
+        // then
+        this.verifyThemeTransformerStylesheetVersionWasSet(this.request);
+    }
+
+    private void verifyStructureAttributeStylesheetNameWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonStructureAttributeSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, "DLMTabsColumnsJS");
+    }
+
+    private void verifyStructureTransformerStylesheetNameWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonStructureTransformerSource.STYLESHEET_NAME_REQUEST_ATTRIBUTE, "DLMTabsColumnsJS");
+    }
+
+    private void verifyThemeAttributeStylesheetVersionWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonThemeAttributeSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME, "V2");
+    }
+
+    private void verifyThemeTransformerStylesheetVersionWasSet(final HttpServletRequest request) {
+        verify(this.request).setAttribute(JsonThemeTransformerSource.STYLESHEET_VERSION_OVERRIDE_REQUEST_ATTRIBUTE_NAME, "V2");
+    }
+
+}


### PR DESCRIPTION
...ut data needed for rendering the uPortal UI using Javascript.  Also, added '/layout/v1/layout.json' endpoint, which returns the same JSON as the existing '/layout.json' endpoint'.

See:  https://issues.jasig.org/browse/UP-4438
Sample JSON output:  
https://issues.jasig.org/secure/attachment/14744/layout-json-v2-admin-sample.txt
https://issues.jasig.org/secure/attachment/14744/layout-json-v2-student-sample.txt