### PR TITLE
Clarify : ant.sh / ant.bat rather than bare ant.

### DIFF
--- a/assembly/quickstart/README.txt
+++ b/assembly/quickstart/README.txt
@@ -54,8 +54,12 @@ Windows: ant.bat
 UNIX:    ant.sh
 
 'ant start' - Starts HSQL and then Tomcat, both are started in the background.
+  (That is, under a UNIX-style operating system this is `ant.sh start` ,
+   and under a Windows operating system this is `ant.bat` ).
 
 'ant stop' - Stops Tomcat then stops HSQL. 
+  (That is, under a UNIX-style operating system this is `ant.sh stop` ,
+   and under a Windows operating system this is `ant.bat stop` ).
 
 
 Using uPortal


### PR DESCRIPTION
In response to today's `uportal-user@` email thread, make the included-in-quickstart README clearer about using the operating-system-specific `ant.sh` or `ant.bat`, as appropriate.