### PR TITLE
UP-4456:  PAGS (JPA) -- Add constructors to IPersonTester implementation...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/IPersonTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/IPersonTester.java
@@ -16,17 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.groups.pags;
 
 import org.jasig.portal.security.IPerson;
 
  /**
- * A very basic interface for examining <code>IPersons</code>.  
- * <p>
+ * A very basic interface for examining <code>IPersons</code>.
+ * <p/>
+ * Concrete implementations should provide a constructor that takes a single
+ * {@link PersonAttributesGroupTestDefinitionImpl} so that they can be properly
+ * instantiated and configured by the group store..
+ *
  * @author Dan Ellentuck
- * @version $Revision$
  */
-
 public interface IPersonTester {
-    public boolean test(IPerson person);
+    boolean test(IPerson person);
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
@@ -317,7 +317,7 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
             TestGroup tg = new TestGroup();
             Set<IPersonAttributesGroupTestDefinition> tests = testGroup.getTests();
             for(IPersonAttributesGroupTestDefinition test : tests) {
-                IPersonTester testerInst = initializeTester(test.getTesterClassName(), test.getAttributeName(), test.getTestValue());
+                IPersonTester testerInst = initializeTester(test);
                 tg.addTest(testerInst);
             }
             groupDef.addTestGroup(tg);
@@ -330,17 +330,19 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
             groupDef.addMember(member.getName());
         }
     }
-    private IPersonTester initializeTester(String tester, String attribute, String value) {
-          try {
-             Class<?> testerClass = Class.forName(tester);
-             Constructor<?> c = testerClass.getConstructor(new Class[]{String.class, String.class});
-             Object o = c.newInstance(new Object[]{attribute, value});
-             return (IPersonTester)o;
-          } catch (Exception e) {
-             logger.error("Error in initializing tester class: {}", tester, e);
-             return null;
-          }
-       }
+
+    private IPersonTester initializeTester(IPersonAttributesGroupTestDefinition test) {
+        try {
+            Class<?> testerClass = Class.forName(test.getTesterClassName());
+            Constructor<?> c = testerClass.getConstructor(new Class[]{IPersonAttributesGroupTestDefinition.class});
+            Object o = c.newInstance(new Object[]{test});
+            return (IPersonTester) o;
+        } catch (Exception e) {
+            logger.error("Error in initializing tester class: {}", test.getTesterClassName(), e);
+            return null;
+        }
+   }
+
     private Set<IEntityGroup> getContainingGroups(String name, Set<IEntityGroup> groups) throws GroupsException
     {
         logger.debug("Looking up containing groups for {}", name);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
@@ -318,6 +318,17 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
             Set<IPersonAttributesGroupTestDefinition> tests = testGroup.getTests();
             for(IPersonAttributesGroupTestDefinition test : tests) {
                 IPersonTester testerInst = initializeTester(test);
+                if (testerInst == null) {
+                    /*
+                     * A tester was intended that we cannot now recreate.  This
+                     * is a potentially dangerous situation, since tests in PAGS
+                     * are "or-ed" together;  a functioning group with a missing
+                     * test would have a wider membership, not narrower.  (And
+                     * remember -- permissions are tied to groups.)  We need to
+                     * play it safe and keep this group out of the mix.
+                     */
+                    return null;
+                }
                 tg.addTest(testerInst);
             }
             groupDef.addTestGroup(tg);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/AlwaysTrueTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/AlwaysTrueTester.java
@@ -28,12 +28,16 @@ import org.jasig.portal.security.IPerson;
  */
 public class AlwaysTrueTester implements IPersonTester {
 
+    /**
+     * @since 4.3
+     */
     public AlwaysTrueTester(IPersonAttributesGroupTestDefinition definition) {}
 
     /**
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public AlwaysTrueTester(String attribute, String test) {}
 
     /* (non-Javadoc)

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/AlwaysTrueTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/AlwaysTrueTester.java
@@ -16,19 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.groups.pags.testers;
 
 import org.jasig.portal.groups.pags.IPersonTester;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.security.IPerson;
 
 /**
  * @author Eric Dalquist
- * @version $Revision$
  */
 public class AlwaysTrueTester implements IPersonTester {
-    
-    public AlwaysTrueTester(String attribute, String test) {
-    }
+
+    public AlwaysTrueTester(IPersonAttributesGroupTestDefinition definition) {}
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public AlwaysTrueTester(String attribute, String test) {}
 
     /* (non-Javadoc)
      * @see org.jasig.portal.groups.pags.IPersonTester#test(org.jasig.portal.security.IPerson)

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/BaseAttributeTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/BaseAttributeTester.java
@@ -32,6 +32,9 @@ public abstract class BaseAttributeTester implements IPersonTester {
     protected final String attributeName;
     protected final String testValue;
 
+    /**
+     * @since 4.3
+     */
     public BaseAttributeTester(IPersonAttributesGroupTestDefinition definition) {
         super();
         attributeName = definition.getAttributeName();
@@ -42,6 +45,7 @@ public abstract class BaseAttributeTester implements IPersonTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public BaseAttributeTester(String attribute, String test) {
         super();
         attributeName = attribute;

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/BaseAttributeTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/BaseAttributeTester.java
@@ -16,9 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.groups.pags.testers;
 
 import org.jasig.portal.groups.pags.IPersonTester;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 /**
  * A tester for examining <code>IPerson</code> attributes.  
@@ -26,48 +28,60 @@ import org.jasig.portal.groups.pags.IPersonTester;
  * @author Dan Ellentuck
  * @version $Revision$
  */
-
 public abstract class BaseAttributeTester implements IPersonTester {
-    protected String attributeName;
-    protected String testValue;
+    protected final String attributeName;
+    protected final String testValue;
 
-public BaseAttributeTester(String attribute, String test) {
-    super();
-    attributeName = attribute;
-    testValue = test;
-}
-/**
- * @return String
- */
-public String getAttributeName() {
-    return attributeName;
-}
-/**
- * @return String
- */
-public String getTestValue() {
-    return testValue;
-}
-/**
- * return String
- */
-public String asString(Object o) {
-    String result = null;
-    if ( o instanceof String )
-        { result = (String)o; } 
-    else
-    {
-        if ( o instanceof String[] ) 
-        {
-            String[] sa = (String[])o;
-            if ( sa.length > 0 )
-                { result = sa[0]; } 
+    public BaseAttributeTester(IPersonAttributesGroupTestDefinition definition) {
+        super();
+        attributeName = definition.getAttributeName();
+        testValue = definition.getTestValue();
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public BaseAttributeTester(String attribute, String test) {
+        super();
+        attributeName = attribute;
+        testValue = test;
+    }
+
+    /**
+     * @return String
+     */
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    /**
+     * @return String
+     */
+    public String getTestValue() {
+        return testValue;
+    }
+
+    /**
+     * return String
+     */
+    public String asString(Object o) {
+        String result = null;
+        if (o instanceof String) {
+            result = (String) o;
+        } else {
+            if (o instanceof String[]) {
+                String[] sa = (String[]) o;
+                if (sa.length > 0) {
+                    result = sa[0];
+                }
+            }
         }
-    }      
-    return result;
-}
-public String toString() {
-    return "Tester for " + getAttributeName() + " : " + getTestValue();
-}
+        return result;
+    }
+
+    public String toString() {
+        return "Tester for " + getAttributeName() + " : " + getTestValue();
+    }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/EagerRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/EagerRegexTester.java
@@ -58,6 +58,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
  */
 public class EagerRegexTester extends RegexTester {
 
+    /**
+     * @since 4.3
+     */
     public EagerRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -66,6 +69,7 @@ public class EagerRegexTester extends RegexTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public EagerRegexTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/EagerRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/EagerRegexTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * A tester for matching multiple values of an attribute 
  * against a regular expression.  The match function attempts to find the 
@@ -55,7 +57,15 @@ package org.jasig.portal.groups.pags.testers;
  * @see RegexTester
  */
 public class EagerRegexTester extends RegexTester {
-    
+
+    public EagerRegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public EagerRegexTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/GuestUserTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/GuestUserTester.java
@@ -16,19 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.groups.pags.testers;
 
 import org.jasig.portal.groups.pags.IPersonTester;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.security.IPerson;
 
+/**
+ * {@link IPersonTester} implementation that evaluates whether the user is a
+ * guest (unauthenticated).
+ */
 public class GuestUserTester implements IPersonTester {
 
     public boolean guestValue;
 
+    public GuestUserTester(IPersonAttributesGroupTestDefinition definition) {
+        this.guestValue = Boolean.getBoolean(definition.getTestValue());
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public GuestUserTester(String attribute, String guestValue) {
         this.guestValue = Boolean.getBoolean(guestValue);
     }
-    
+
     public boolean test(IPerson person) {
         if (guestValue) {
             return person.isGuest();

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/GuestUserTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/GuestUserTester.java
@@ -31,6 +31,9 @@ public class GuestUserTester implements IPersonTester {
 
     public boolean guestValue;
 
+    /**
+     * @since 4.3
+     */
     public GuestUserTester(IPersonAttributesGroupTestDefinition definition) {
         this.guestValue = Boolean.getBoolean(definition.getTestValue());
     }
@@ -39,6 +42,7 @@ public class GuestUserTester implements IPersonTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public GuestUserTester(String attribute, String guestValue) {
         this.guestValue = Boolean.getBoolean(guestValue);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerEQTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerEQTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 
 /**
  * Tests if any of the possibly multiple values of the attribute are EQ
@@ -29,10 +31,18 @@ package org.jasig.portal.groups.pags.testers;
 
 public class IntegerEQTester extends IntegerTester {
 
-public IntegerEQTester(String attribute, String test) {
-    super(attribute, test); 
-}
-public boolean test(int attributeValue) {
-    return attributeValue == testInteger;
-}
+    public IntegerEQTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerEQTester(String attribute, String test) {
+        super(attribute, test); 
+    }
+    public boolean test(int attributeValue) {
+        return attributeValue == testInteger;
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerEQTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerEQTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class IntegerEQTester extends IntegerTester {
 
+    /**
+     * @since 4.3
+     */
     public IntegerEQTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class IntegerEQTester extends IntegerTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerEQTester(String attribute, String test) {
         super(attribute, test); 
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGETester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGETester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class IntegerGETester extends IntegerTester {
 
+    /**
+     * @since 4.3
+     */
     public IntegerGETester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class IntegerGETester extends IntegerTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerGETester(String attribute, String test) {
         super(attribute, test); 
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGETester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGETester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 
 /**
  * Tests if any of the possibly multiple values of the attribute are GE
@@ -29,10 +31,18 @@ package org.jasig.portal.groups.pags.testers;
 
 public class IntegerGETester extends IntegerTester {
 
-public IntegerGETester(String attribute, String test) {
-    super(attribute, test); 
-}
-public boolean test(int attributeValue) {
-    return ! (attributeValue < testInteger);
-}
+    public IntegerGETester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerGETester(String attribute, String test) {
+        super(attribute, test); 
+    }
+    public boolean test(int attributeValue) {
+        return ! (attributeValue < testInteger);
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGTTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGTTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class IntegerGTTester extends IntegerTester {
 
+    /**
+     * @since 4.3
+     */
     public IntegerGTTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class IntegerGTTester extends IntegerTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerGTTester(String attribute, String test) {
         super(attribute, test); 
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGTTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerGTTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 
 /**
  * Tests if any of the possibly multiple values of the attribute are GT
@@ -29,10 +31,18 @@ package org.jasig.portal.groups.pags.testers;
 
 public class IntegerGTTester extends IntegerTester {
 
-public IntegerGTTester(String attribute, String test) {
-    super(attribute, test); 
-}
-public boolean test(int attributeValue) {
-    return attributeValue > testInteger;
-}
+    public IntegerGTTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerGTTester(String attribute, String test) {
+        super(attribute, test); 
+    }
+    public boolean test(int attributeValue) {
+        return attributeValue > testInteger;
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLETester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLETester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 
 /**
  * Tests if any of the possibly multiple values of the attribute are GE
@@ -29,10 +31,18 @@ package org.jasig.portal.groups.pags.testers;
 
 public class IntegerLETester extends IntegerTester {
 
-public IntegerLETester(String attribute, String test) {
-    super(attribute, test); 
-}
-public boolean test(int attributeValue) {
-    return ! (attributeValue > testInteger);
-}
+    public IntegerLETester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerLETester(String attribute, String test) {
+        super(attribute, test); 
+    }
+    public boolean test(int attributeValue) {
+        return ! (attributeValue > testInteger);
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLETester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLETester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class IntegerLETester extends IntegerTester {
 
+    /**
+     * @since 4.3
+     */
     public IntegerLETester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class IntegerLETester extends IntegerTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerLETester(String attribute, String test) {
         super(attribute, test); 
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLTTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLTTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 
 /**
  * Tests if any of the possibly multiple values of the attribute are LT
@@ -29,10 +31,18 @@ package org.jasig.portal.groups.pags.testers;
 
 public class IntegerLTTester extends IntegerTester {
 
-public IntegerLTTester(String attribute, String test) {
-    super(attribute, test); 
-}
-public boolean test(int attributeValue) {
-    return attributeValue < testInteger;
-}
+    public IntegerLTTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerLTTester(String attribute, String test) {
+        super(attribute, test); 
+    }
+    public boolean test(int attributeValue) {
+        return attributeValue < testInteger;
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLTTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerLTTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class IntegerLTTester extends IntegerTester {
 
+    /**
+     * @since 4.3
+     */
     public IntegerLTTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class IntegerLTTester extends IntegerTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerLTTester(String attribute, String test) {
         super(attribute, test); 
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerTester.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.security.IPerson;
 
 /**
@@ -31,38 +32,47 @@ import org.jasig.portal.security.IPerson;
 public abstract class IntegerTester extends BaseAttributeTester {
     protected int testInteger = Integer.MIN_VALUE;
 
-public IntegerTester(String attribute, String test) {
-    super(attribute, test); 
-    testInteger = Integer.parseInt(test);
-}
-public int getTestInteger() {
-    return testInteger;
-}
-public boolean test(IPerson person) {
-    boolean result = false;
-    Object[] atts = person.getAttributeValues(getAttributeName());
-    if ( atts != null )
-    {
-        for (int i=0; i<atts.length && result == false; i++)
-        {
-            try 
-            {
-                int integerAtt = Integer.parseInt((String)atts[i]);
-                result = test( integerAtt );
-                
-                // Assume that we should perform OR matching on multi-valued 
-                // attributes.  If the current attribute matches, return true
-                // for the person.
-                if (result) {
-                    return true;
-                }
-                
-            }
-            catch (NumberFormatException nfe) {  } // result stays false
-        }
+    public IntegerTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        this.testInteger = Integer.parseInt(definition.getTestValue());
     }
-    return result;
-}
-public boolean test(int attributeValue) {return false;}
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public IntegerTester(String attribute, String test) {
+        super(attribute, test); 
+        testInteger = Integer.parseInt(test);
+    }
+    public int getTestInteger() {
+        return testInteger;
+    }
+    public boolean test(IPerson person) {
+        boolean result = false;
+        Object[] atts = person.getAttributeValues(getAttributeName());
+        if ( atts != null )
+        {
+            for (int i=0; i<atts.length && result == false; i++)
+            {
+                try 
+                {
+                    int integerAtt = Integer.parseInt((String)atts[i]);
+                    result = test( integerAtt );
+                    
+                    // Assume that we should perform OR matching on multi-valued 
+                    // attributes.  If the current attribute matches, return true
+                    // for the person.
+                    if (result) {
+                        return true;
+                    }
+                    
+                }
+                catch (NumberFormatException nfe) {  } // result stays false
+            }
+        }
+        return result;
+    }
+    public boolean test(int attributeValue) {return false;}
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/IntegerTester.java
@@ -32,6 +32,9 @@ import org.jasig.portal.security.IPerson;
 public abstract class IntegerTester extends BaseAttributeTester {
     protected int testInteger = Integer.MIN_VALUE;
 
+    /**
+     * @since 4.3
+     */
     public IntegerTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
         this.testInteger = Integer.parseInt(definition.getTestValue());
@@ -41,6 +44,7 @@ public abstract class IntegerTester extends BaseAttributeTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public IntegerTester(String attribute, String test) {
         super(attribute, test); 
         testInteger = Integer.parseInt(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/InvertedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/InvertedRegexTester.java
@@ -20,6 +20,8 @@ package org.jasig.portal.groups.pags.testers;
 
 import java.util.regex.Pattern;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * A tester for matching the possibly multiple values of an attribute 
  * against a regular expression and returning true for a FAILURE to match.
@@ -57,6 +59,15 @@ import java.util.regex.Pattern;
 public class InvertedRegexTester extends StringTester {
     protected Pattern pattern;
 
+    public InvertedRegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        this.pattern = Pattern.compile(definition.getTestValue());
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public InvertedRegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/InvertedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/InvertedRegexTester.java
@@ -59,6 +59,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 public class InvertedRegexTester extends StringTester {
     protected Pattern pattern;
 
+    /**
+     * @since 4.3
+     */
     public InvertedRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
         this.pattern = Pattern.compile(definition.getTestValue());
@@ -68,6 +71,7 @@ public class InvertedRegexTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public InvertedRegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/LowercasedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/LowercasedRegexTester.java
@@ -20,6 +20,8 @@ package org.jasig.portal.groups.pags.testers;
 
 import java.util.regex.Pattern;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * A tester for matching the possibly multiple values of an attribute (made lower case) against a regular expression.
  * The match function attempts to match the entire region against the pattern specified.
@@ -59,6 +61,15 @@ import java.util.regex.Pattern;
 public class LowercasedRegexTester extends StringTester {
     protected Pattern pattern;
 
+    public LowercasedRegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        this.pattern = Pattern.compile(definition.getTestValue());
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public LowercasedRegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/LowercasedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/LowercasedRegexTester.java
@@ -61,6 +61,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 public class LowercasedRegexTester extends StringTester {
     protected Pattern pattern;
 
+    /**
+     * @since 4.3
+     */
     public LowercasedRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
         this.pattern = Pattern.compile(definition.getTestValue());
@@ -70,6 +73,7 @@ public class LowercasedRegexTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public LowercasedRegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyInvertedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyInvertedRegexTester.java
@@ -19,6 +19,7 @@
 package org.jasig.portal.groups.pags.testers;
 
 import org.apache.commons.lang.StringUtils;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.properties.PropertiesManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +38,25 @@ public class PropertyInvertedRegexTester extends InvertedRegexTester {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    public PropertyInvertedRegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        final String propertyName = definition.getTestValue();
+        String regexExpression = PropertiesManager.getProperty
+                (propertyName, "");
+        if (StringUtils.isBlank(regexExpression)) {
+            logger.error("Unable to find property name {} in portal.properties or has empty value."
+                    + " PAGS PropertyInvertedRegexTester will always return true for attribute {}",
+                    propertyName, definition.getAttributeName());
+        }
+        setPattern(regexExpression);
+    }
+
     /**
      *
      * @param attribute Person attribute to test against
      * @param propertyName name of a property defined in portal.properties
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
      */
     public PropertyInvertedRegexTester(String attribute, String propertyName) {
         super(attribute, propertyName);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyInvertedRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyInvertedRegexTester.java
@@ -38,17 +38,12 @@ public class PropertyInvertedRegexTester extends InvertedRegexTester {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    /**
+     * @since 4.3
+     */
     public PropertyInvertedRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
-        final String propertyName = definition.getTestValue();
-        String regexExpression = PropertiesManager.getProperty
-                (propertyName, "");
-        if (StringUtils.isBlank(regexExpression)) {
-            logger.error("Unable to find property name {} in portal.properties or has empty value."
-                    + " PAGS PropertyInvertedRegexTester will always return true for attribute {}",
-                    propertyName, definition.getAttributeName());
-        }
-        setPattern(regexExpression);
+        setPattern(definition.getAttributeName(), definition.getTestValue());
     }
 
     /**
@@ -58,8 +53,18 @@ public class PropertyInvertedRegexTester extends InvertedRegexTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public PropertyInvertedRegexTester(String attribute, String propertyName) {
         super(attribute, propertyName);
+        setPattern(attribute, propertyName);
+    }
+
+    @Override
+    public boolean test(String att) {
+        return !pattern.matcher(att).matches();
+    }
+
+    private void setPattern(String attribute, String propertyName) {
         String regexExpression = PropertiesManager.getProperty
                 (propertyName, "");
         if (StringUtils.isBlank(regexExpression)) {
@@ -70,8 +75,4 @@ public class PropertyInvertedRegexTester extends InvertedRegexTester {
         setPattern(regexExpression);
     }
 
-    @Override
-    public boolean test(String att) {
-        return !pattern.matcher(att).matches();
-    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyRegexTester.java
@@ -37,17 +37,12 @@ import org.slf4j.LoggerFactory;
 public class PropertyRegexTester extends RegexTester {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    /**
+     * @since 4.3
+     */
     public PropertyRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
-        final String propertyName = definition.getTestValue();
-        String regexExpression = PropertiesManager.getProperty
-                (propertyName, "");
-        if (StringUtils.isBlank(regexExpression)) {
-            logger.error("Unable to find property name {} in portal.properties or has empty value."
-                + " PAGS PropertyRegexTester will always return false for attribute {}", propertyName,
-                definition.getAttributeName());
-        }
-        setPattern(regexExpression);
+        setPattern(definition.getAttributeName(), definition.getTestValue());
     }
 
     /**
@@ -57,19 +52,26 @@ public class PropertyRegexTester extends RegexTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public PropertyRegexTester(String attribute, String propertyName) {
         super(attribute, propertyName);
-        String regexExpression = PropertiesManager.getProperty
-                (propertyName, "");
-        if (StringUtils.isBlank(regexExpression)) {
-            logger.error("Unable to find property name {} in portal.properties or has empty value."
-                + " PAGS PropertyRegexTester will always return false for attribute {}", propertyName, attribute);
-        }
-        setPattern(regexExpression);
+        setPattern(attribute, propertyName);
     }
 
     @Override
     public boolean test(String att) {
         return pattern.matcher(att).matches();
     }
+
+    private void setPattern(String attribute, String propertyName) {
+        String regexExpression = PropertiesManager.getProperty
+                (propertyName, "");
+        if (StringUtils.isBlank(regexExpression)) {
+            logger.error("Unable to find property name {} in portal.properties or has empty value."
+                + " PAGS PropertyRegexTester will always return false for attribute {}",
+                propertyName, attribute);
+        }
+        setPattern(regexExpression);
+    }
+
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyRegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/PropertyRegexTester.java
@@ -19,6 +19,7 @@
 package org.jasig.portal.groups.pags.testers;
 
 import org.apache.commons.lang.StringUtils;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.properties.PropertiesManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,10 +37,25 @@ import org.slf4j.LoggerFactory;
 public class PropertyRegexTester extends RegexTester {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    public PropertyRegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        final String propertyName = definition.getTestValue();
+        String regexExpression = PropertiesManager.getProperty
+                (propertyName, "");
+        if (StringUtils.isBlank(regexExpression)) {
+            logger.error("Unable to find property name {} in portal.properties or has empty value."
+                + " PAGS PropertyRegexTester will always return false for attribute {}", propertyName,
+                definition.getAttributeName());
+        }
+        setPattern(regexExpression);
+    }
+
     /**
      *
      * @param attribute Person attribute to propertyName against
      * @param propertyName name of a property defined in portal.properties
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
      */
     public PropertyRegexTester(String attribute, String propertyName) {
         super(attribute, propertyName);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/RegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/RegexTester.java
@@ -20,6 +20,8 @@ package org.jasig.portal.groups.pags.testers;
 
 import java.util.regex.Pattern;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * A tester for matching the possibly multiple values of an attribute 
  * against a regular expression.  The match function attempts to match the 
@@ -59,6 +61,15 @@ import java.util.regex.Pattern;
 public class RegexTester extends StringTester {
     protected Pattern pattern;
 
+    public RegexTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+        this.pattern = Pattern.compile(definition.getTestValue());
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public RegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/RegexTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/RegexTester.java
@@ -61,6 +61,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 public class RegexTester extends StringTester {
     protected Pattern pattern;
 
+    /**
+     * @since 4.3
+     */
     public RegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
         this.pattern = Pattern.compile(definition.getTestValue());
@@ -70,6 +73,7 @@ public class RegexTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public RegexTester(String attribute, String test) {
         super(attribute, test);
         this.pattern = Pattern.compile(test);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsIgnoreCaseTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsIgnoreCaseTester.java
@@ -32,6 +32,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class StringEqualsIgnoreCaseTester extends StringTester {
 
+    /**
+     * @since 4.3
+     */
     public StringEqualsIgnoreCaseTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -40,6 +43,7 @@ public class StringEqualsIgnoreCaseTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public StringEqualsIgnoreCaseTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsIgnoreCaseTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsIgnoreCaseTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * Tests an <code>IPerson</code> attribute for String equality 
  * regardless of case and answers true if any of the possibly 
@@ -30,11 +32,19 @@ package org.jasig.portal.groups.pags.testers;
 
 public class StringEqualsIgnoreCaseTester extends StringTester {
 
-public StringEqualsIgnoreCaseTester(String attribute, String test) {
-    super(attribute, test);
-}
-public boolean test(String att) {
-    return att.equalsIgnoreCase(testValue);
-}
+    public StringEqualsIgnoreCaseTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public StringEqualsIgnoreCaseTester(String attribute, String test) {
+        super(attribute, test);
+    }
+    public boolean test(String att) {
+        return att.equalsIgnoreCase(testValue);
+    }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsTester.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+
 /**
  * Tests an <code>IPerson</code> attribute for String equality and  
  * answers true if any of the possibly multiple values of the 
@@ -29,11 +31,19 @@ package org.jasig.portal.groups.pags.testers;
 
 public class StringEqualsTester extends StringTester {
 
-public StringEqualsTester(String attribute, String test) {
-    super(attribute, test);
-}
-public boolean test(String att) {
-    return att.equals(testValue);
-}
+    public StringEqualsTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public StringEqualsTester(String attribute, String test) {
+        super(attribute, test);
+    }
+    public boolean test(String att) {
+        return att.equals(testValue);
+    }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringEqualsTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 
 public class StringEqualsTester extends StringTester {
 
+    /**
+     * @since 4.3
+     */
     public StringEqualsTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class StringEqualsTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public StringEqualsTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringTester.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.security.IPerson;
 
 /**
@@ -30,30 +31,38 @@ import org.jasig.portal.security.IPerson;
 
 public abstract class StringTester extends BaseAttributeTester {
 
-public StringTester(String attribute, String test) {
-    super(attribute, test);
-}
+    public StringTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
 
-public boolean test(IPerson person) {
-    boolean result = false;
-    Object[] atts = person.getAttributeValues(getAttributeName());
-    if ( atts != null )
-    {
-        for (int i=0; i<atts.length && result == false; i++)
-        { 
-            String att = (String)atts[i];
-            result = test(att); 
-            
-            // Assume that we should perform OR matching on multi-valued 
-            // attributes.  If the current attribute matches, return true
-            // for the person.
-            if (result) {
-                return true;
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
+    public StringTester(String attribute, String test) {
+        super(attribute, test);
+    }
+
+    public boolean test(IPerson person) {
+        boolean result = false;
+        Object[] atts = person.getAttributeValues(getAttributeName());
+        if ( atts != null )
+        {
+            for (int i=0; i<atts.length && result == false; i++)
+            { 
+                String att = (String)atts[i];
+                result = test(att); 
+                
+                // Assume that we should perform OR matching on multi-valued 
+                // attributes.  If the current attribute matches, return true
+                // for the person.
+                if (result) {
+                    return true;
+                }
             }
         }
+        return result;
     }
-    return result;
-}
-public boolean test(String att) { return false; }
+    public boolean test(String att) { return false; }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/StringTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.security.IPerson;
 
 public abstract class StringTester extends BaseAttributeTester {
 
+    /**
+     * @since 4.3
+     */
     public StringTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public abstract class StringTester extends BaseAttributeTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public StringTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ThemeNameEqualsIgnoreCaseTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ThemeNameEqualsIgnoreCaseTester.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.groups.pags.testers;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.StringUtils;
 import org.jasig.portal.IUserProfile;
 import org.jasig.portal.groups.pags.IPersonTester;
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.layout.profile.IProfileMapper;
 import org.jasig.portal.layout.IUserLayoutStore;
 import org.jasig.portal.layout.dao.IStylesheetDescriptorDao;
@@ -40,6 +42,7 @@ import org.springframework.context.ApplicationContext;
  * @author Shawn Connolly, sconnolly@unicon.net
  **/
 public class ThemeNameEqualsIgnoreCaseTester implements IPersonTester {
+
     protected Logger logger = LoggerFactory.getLogger(getClass());
     private String themeTestValue;
     private final ApplicationContext applicationContext;
@@ -48,6 +51,21 @@ public class ThemeNameEqualsIgnoreCaseTester implements IPersonTester {
     private final IUserLayoutStore userLayoutStore;
     private final IStylesheetDescriptorDao stylesheetDescriptorDao;
 
+    public ThemeNameEqualsIgnoreCaseTester(IPersonAttributesGroupTestDefinition definition) {
+        final String themeTestValue = definition.getTestValue();
+        assert StringUtils.isNotBlank(themeTestValue);
+        this.themeTestValue = themeTestValue;
+        this.applicationContext = ApplicationContextLocator.getApplicationContext();
+        this.portalRequestUtils = applicationContext.getBean(IPortalRequestUtils.class);
+        this.profileMapper = applicationContext.getBean("profileMapper", IProfileMapper.class);
+        this.userLayoutStore = applicationContext.getBean("userLayoutStore", IUserLayoutStore.class);
+        this.stylesheetDescriptorDao = applicationContext.getBean("stylesheetDescriptorDao", IStylesheetDescriptorDao.class);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public ThemeNameEqualsIgnoreCaseTester(String attribute, String themeTestValue) {
         assert StringUtils.isNotBlank(themeTestValue);
         this.themeTestValue = themeTestValue;

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ThemeNameEqualsIgnoreCaseTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ThemeNameEqualsIgnoreCaseTester.java
@@ -51,6 +51,9 @@ public class ThemeNameEqualsIgnoreCaseTester implements IPersonTester {
     private final IUserLayoutStore userLayoutStore;
     private final IStylesheetDescriptorDao stylesheetDescriptorDao;
 
+    /**
+     * @since 4.3
+     */
     public ThemeNameEqualsIgnoreCaseTester(IPersonAttributesGroupTestDefinition definition) {
         final String themeTestValue = definition.getTestValue();
         assert StringUtils.isNotBlank(themeTestValue);
@@ -66,6 +69,7 @@ public class ThemeNameEqualsIgnoreCaseTester implements IPersonTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public ThemeNameEqualsIgnoreCaseTester(String attribute, String themeTestValue) {
         assert StringUtils.isNotBlank(themeTestValue);
         this.themeTestValue = themeTestValue;
@@ -119,4 +123,5 @@ public class ThemeNameEqualsIgnoreCaseTester implements IPersonTester {
         }
         return testResult;
     }
+
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueExistsTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueExistsTester.java
@@ -31,6 +31,9 @@ import org.jasig.portal.groups.pags.testers.StringTester;
  */
 public class ValueExistsTester extends StringTester {
 
+    /**
+     * @since 4.3
+     */
     public ValueExistsTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -39,6 +42,7 @@ public class ValueExistsTester extends StringTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public ValueExistsTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueExistsTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueExistsTester.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.groups.pags.testers.StringTester;
 
 /**
@@ -30,6 +31,14 @@ import org.jasig.portal.groups.pags.testers.StringTester;
  */
 public class ValueExistsTester extends StringTester {
 
+    public ValueExistsTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public ValueExistsTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueMissingTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueMissingTester.java
@@ -30,6 +30,9 @@ import org.jasig.portal.security.IPerson;
  */
 public class ValueMissingTester extends BaseAttributeTester {
 
+    /**
+     * @since 4.3
+     */
     public ValueMissingTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
     }
@@ -38,6 +41,7 @@ public class ValueMissingTester extends BaseAttributeTester {
      * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
      * the single-argument constructor.
      */
+    @Deprecated
     public ValueMissingTester(String attribute, String test) {
         super(attribute, test);
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueMissingTester.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/testers/ValueMissingTester.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portal.groups.pags.testers;
 
+import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
 import org.jasig.portal.groups.pags.testers.BaseAttributeTester;
 import org.jasig.portal.security.IPerson;
 
@@ -29,6 +30,14 @@ import org.jasig.portal.security.IPerson;
  */
 public class ValueMissingTester extends BaseAttributeTester {
 
+    public ValueMissingTester(IPersonAttributesGroupTestDefinition definition) {
+        super(definition);
+    }
+
+    /**
+     * @deprecated use {@link EntityPersonAttributesGroupStore}, which leverages
+     * the single-argument constructor.
+     */
     public ValueMissingTester(String attribute, String test) {
         super(attribute, test);
     }


### PR DESCRIPTION
...s that accept a single IPersonAttributesGroupTestDefinition;  deprecate the ones that accept String,String

https://issues.jasig.org/browse/UP-4456