### PR TITLE
Menu icon works with larger icons, doesn't collide

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -28,9 +28,6 @@
         .container {
             padding: 0;
         }
-        .menu-toggle {
-            top: 50px;
-        }
     }
 }
 
@@ -38,6 +35,7 @@
     /* TODO:  Convert the div.portal-global to be the div.region-pre-header
        (in the XSL) and move these styles to regions.less */
     padding: 6px 2px 2px 2px;
+    min-height: 43px;
     .gradient(@portal-global-background-color, @portal-global-background-gradient);
     border-bottom: 1px solid @portal-global-border-color;
     .drop-shadow;

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -21,9 +21,9 @@
     background: @navbar-background-color;
 
     .menu-toggle {
-        position: absolute;
-        top: 100px;
-        right: 20px;
+        position: fixed;
+        top: 6px;
+        left: 10px;
         padding: 0.5rem 1rem;
         background: @menu-toggle-background-color;
         border: 1px solid @menu-toggle-border-color;


### PR DESCRIPTION
Prevents the menu icon from moving over the uPortal logo on small mobile view.
The menu also works if a larger logo is chosen.
#UP-4475

![oldmenu](https://cloud.githubusercontent.com/assets/7514723/7866423/5aea3e4e-053d-11e5-9f78-63d7c352ac07.jpg)
![oldmenu2](https://cloud.githubusercontent.com/assets/7514723/7866424/5aea894e-053d-11e5-8026-6b9429698d6a.jpg)
![updatedmenu](https://cloud.githubusercontent.com/assets/7514723/7866426/5aecc9de-053d-11e5-9902-fdf6ab3eb91d.jpg)
![updatedmenu2](https://cloud.githubusercontent.com/assets/7514723/7866425/5aeba27a-053d-11e5-9756-ddd74c8d34da.jpg)



