### PR TITLE
UP-4492: Node data loading limited to grandchildren. Remove bug where …

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
@@ -315,6 +315,19 @@
          * Ad Hoc Groups (jsTree)
          */
 
+        $("#groupName").on('input', function () {
+            var nameRegex = /^[\w ]{5,500}$/;
+            if (nameRegex.test($(this).val())) {
+                $("#${n}saveAdHocButton").removeAttr('disabled');
+                $(this).removeClass("invalid");
+            } else {
+                $("#${n}saveAdHocButton").attr('disabled', 'disabled');
+                $(this).addClass("invalid");
+            }
+        });
+
+
+
         var setGroupDescription = function() {
             var includes, excludes, description;
             descInput = $("#groupDesc");
@@ -370,6 +383,8 @@
         var resetAdHocDialog = function () {
             console.log("resetting ad hoc dialog");
             $("#groupName").val("");
+            $("#groupName").removeClass("invalid");
+            $("#${n}saveAdHocButton").attr('disabled', 'disabled');
 
             $(":jstree").each(function () {
                 $(this).jstree("deselect_all",false);

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/entity-selector.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/entity-selector.js
@@ -559,35 +559,34 @@ var up = up || {};
 
         if (that.options.enableAdHocGroups) {
             var jsTreeIncludes = false, jsTreeExcludes = false;
+
             var entityToJSTreeNode = function (entity) {
-                var child, childNodes;
-                childNodes = [];
-                $.each(entity.children, function (idx, obj) {
-                    // re-acquire child to get it's children
-                    if (obj.entityType == "GROUP") {
-                        child = that.registry.getEntity(obj.entityType, obj.id);
-                        childNodes.push(entityToJSTreeNode(child));
+                var childNodes = [];
+                $.each(entity.children, function (idx, child) {
+                    if (child.entityType == "GROUP") {
+                        childNodes.push( { "id" : getKey(child), "text" : child.name, "state" : { "loaded" : false}  } );
                     }
                 });
                 return { "id" : getKey(entity), "text" : entity.name, "children" : childNodes };
             };
 
             var callback = function (obj, cb) {
-                var key, entity, childNodes;
-                if (obj && obj.id && obj.id.length > 5) {
-                    key = obj.id;
-                    entity = that.registry.getEntity(getTypeFromKey(key), getIdFromKey(key));
-                    childNodes = [];
-                    $.each(entity.children, function (idx, obj) {
-                        childNodes.push(entityToJSTreeNode(obj));
-                    });
-                } else {
+               var key, entity, childNodes = [];
+               if (obj.id === '#') {
                     // root tree node, so send back initial node
-                    key = that.options.initialFocusedEntity;
-                    entity = that.registry.getEntity(getTypeFromKey(key), getIdFromKey(key));
-                    childNodes = [ entityToJSTreeNode(entity) ];
-                }
-                cb.call(this, childNodes);
+                   key = that.options.initialFocusedEntity;
+                   entity = that.registry.getEntity(getTypeFromKey(key), getIdFromKey(key));
+                   childNodes.push(entityToJSTreeNode(entity));
+               } else {
+                   key = obj.id;
+                   entity = that.registry.getEntity(getTypeFromKey(key), getIdFromKey(key));
+                   $.each(entity.children, function (idx, child) {
+                       if (child.entityType == "GROUP") {
+                           childNodes.push(entityToJSTreeNode(child));
+                       }
+                   });
+               }
+               cb.call(this, childNodes);
             };
 
             var displayResponseMessage = function(xmlhttp) {

--- a/uportal-war/src/main/webapp/media/skins/common/less/entity-selector.less
+++ b/uportal-war/src/main/webapp/media/skins/common/less/entity-selector.less
@@ -366,4 +366,10 @@
         }
     }
 
+    .modal {
+        .invalid {
+            background-color: #fdd;
+        }
+    }
+
 }


### PR DESCRIPTION
…non-group children were loaded sometimes. Add group name validation.

I am not thrilled with the light red background when the group name is invalid. Any suggestions on a different indication to the user when the group name is invalid?

Also, should there be some text under group name label or a tool tip for the input?