### PR TITLE
UP-4516:  Refactor the AnyUnblockedGrantPermissionPolicy to be readab…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/permission/IPermissionActivity.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/IPermissionActivity.java
@@ -32,16 +32,17 @@ package org.jasig.portal.permission;
 public interface IPermissionActivity extends Comparable<IPermissionActivity> {
 
     public Long getId();
-    
+
     /**
      * Get the unique, unchanging functional name for this permission activity.
-     * This identifier should not change over time and should consist of 
-     * a short, meaningful string.
-     * 
-     * @return
+     * This is the String against which permissions tests are made within
+     * {@link IAuthorizationService};  it must match the ACTIVITY column on
+     * UP_PERMISSION and the corresponding static field on IPermission, if
+     * applicable.  This identifier should not change over time and should
+     * consist of a short, meaningful string.
      */
     public String getFname();
-    
+
     /**
      * Set the functional name for this permission activity.
      * 

--- a/uportal-war/src/main/java/org/jasig/portal/permission/IPermissionOwner.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/IPermissionOwner.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * @since 3.3
  */
 public interface IPermissionOwner {
-	
+
     /**
      * Get the unique numerical identifier for this permission owner.  While
      * unique, this identifier should not be expected to be constant over time
@@ -49,16 +49,17 @@ public interface IPermissionOwner {
      * 
      * @return
      */
-	public Long getId();
+    public Long getId();
 
-	/**
-	 * Get the unique, unchanging functional name for this permission owner.
-	 * This identifier should not change over time and should consist of 
-	 * a short, meaningful string.
-	 * 
-	 * @return
-	 */
-	public String getFname();
+    /**
+     * Get the unique, unchanging functional name for this permission owner.
+     * This is the String against which permissions tests are made within
+     * {@link IAuthorizationService};  it must match the OWNER column on
+     * UP_PERMISSION and the corresponding static field on IPermission, if
+     * applicable.  This identifier should not change over time and should
+     * consist of a short, meaningful string.
+     */
+    public String getFname();
 
 	/**
 	 * Set the functional name for this permission owner.

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/IPermissionTarget.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/IPermissionTarget.java
@@ -28,20 +28,79 @@ package org.jasig.portal.permission.target;
  * @since 3.3
  */
 public interface IPermissionTarget {
-    
+
     /**
-     * Get the key of this permission target.  This key
-     * will be used as the actual target string of a permission assignment.
-     * 
-     * @return
+     * Indicates the nature of the target you're dealing with.  Allows code that
+     * does things with permissions (esp. checking) to approach its work
+     * intelligently.
+     *
+     * @author drewwills
+     * @since 4.3
+     */
+    public enum TargetType {
+
+        /**
+         * This target is a person and no other type.
+         */
+        PERSON,
+
+        /**
+         * This target is a group <em>of people</em> and no other type.
+         */
+        GROUP,
+
+        /**
+         * This target is a portlet and no other type.
+         */
+        PORTLET,
+
+        /**
+         * This target is a group <em>of portlets</em> (category) and no other type.
+         */
+        CATEGORY,
+
+        /**
+         * This target is a type of portlet (i.e. a CPD) and no other type.
+         */
+        PORTLET_TYPE,
+
+        /**
+         * This target is an attribute users may have (e.g. telephoneNumber) and no other type.
+         */
+        USER_ATTRIBUTE,
+
+        /**
+         * This target is not any of the other things listed in this enumeration.
+         */
+        OTHER;
+
+        /**
+         * Allows other code to make important connections with internal data structures
+         */
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+
+    }
+
+    /**
+     * Get the key of this permission target.  This is the String against which
+     * permissions tests are made within {@link IAuthorizationService};  it must
+     * match the TARGET column on UP_PERMISSION.
      */
     public String getKey();
-    
+
     /**
      * Get the human-readable name of this permission target.
      * 
      * @return
      */
     public String getName();
-    
+
+    /**
+     * Learn the nature of this target.  E.g. is it a portlet?
+     */
+    public TargetType getTargetType();
+
 }

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/PermissionTargetImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/PermissionTargetImpl.java
@@ -36,13 +36,13 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * @since 3.3
  */
 public class PermissionTargetImpl implements IPermissionTarget, Comparable<IPermissionTarget>, Serializable {
-    
+
     private static final long serialVersionUID = 1L;
 
     private final String key;
-    
     private final String name;
-    
+    private final TargetType type;
+
     /**
      * Construct a new PermissionTargetImpl with the specified key and 
      * human-readable name.
@@ -50,9 +50,10 @@ public class PermissionTargetImpl implements IPermissionTarget, Comparable<IPerm
      * @param key
      * @param name
      */
-    public PermissionTargetImpl(String key, String name) {
+    public PermissionTargetImpl(String key, String name, TargetType type) {
         this.key = key;
         this.name = name;
+        this.type = type;
     }
 
     /*
@@ -71,6 +72,10 @@ public class PermissionTargetImpl implements IPermissionTarget, Comparable<IPerm
         return name;
     }
 
+    public TargetType getTargetType() {
+        return type;
+    }
+
     /**
      * @see java.lang.Object#equals(Object)
      */
@@ -87,6 +92,7 @@ public class PermissionTargetImpl implements IPermissionTarget, Comparable<IPerm
         return new EqualsBuilder()
             .append(this.key, target.getKey())
             .append(this.name, target.getName())
+            .append(this.type, target.getTargetType())
             .isEquals();
     }
 
@@ -96,7 +102,7 @@ public class PermissionTargetImpl implements IPermissionTarget, Comparable<IPerm
     @Override
     public int hashCode() {
         return new HashCodeBuilder(464270933, -1074792143)
-                .append(this.key).append(this.name)
+                .append(this.key).append(this.name).append(this.type)
                 .toHashCode();
     }
 

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/PortletTypeTargetProviderImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/PortletTypeTargetProviderImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
+import org.jasig.portal.permission.target.IPermissionTarget.TargetType;
 import org.jasig.portal.portlet.om.IPortletType;
 import org.jasig.portal.portletpublishing.xml.PortletPublishingDefinition;
 import org.jasig.portal.portlets.portletadmin.xmlsupport.IChannelPublishingDefinitionDao;
@@ -34,7 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PortletTypeTargetProviderImpl implements IPermissionTargetProvider {
 
     public static final IPermissionTarget ALL_PORTLET_TYPES_TARGET = 
-            new PermissionTargetImpl(IPermission.ALL_PORTLET_TYPES, IPermission.ALL_PORTLET_TYPES);
+            new PermissionTargetImpl(IPermission.ALL_PORTLET_TYPES, 
+                    IPermission.ALL_PORTLET_TYPES, TargetType.PORTLET_TYPE);
 
     @Autowired
     private IChannelPublishingDefinitionDao channelPublishingDefinitionDao;
@@ -51,7 +53,7 @@ public class PortletTypeTargetProviderImpl implements IPermissionTargetProvider 
             final Map<IPortletType, PortletPublishingDefinition> cpds = channelPublishingDefinitionDao.getChannelPublishingDefinitions();
             for (Map.Entry<IPortletType, PortletPublishingDefinition> y : cpds.entrySet()) {
                 if (y.getKey().getName().equals(key)) {
-                    rslt = new PermissionTargetImpl(y.getKey().getName(), y.getKey().getName());
+                    rslt = new PermissionTargetImpl(y.getKey().getName(), y.getKey().getName(), TargetType.PORTLET_TYPE);
                 }
             }
         }
@@ -74,7 +76,7 @@ public class PortletTypeTargetProviderImpl implements IPermissionTargetProvider 
         final Map<IPortletType, PortletPublishingDefinition> cpds = channelPublishingDefinitionDao.getChannelPublishingDefinitions();
         for (Map.Entry<IPortletType, PortletPublishingDefinition> y : cpds.entrySet()) {
             if (y.getKey().getName().toLowerCase().contains(lowerTerm)) {
-                IPermissionTarget target = new PermissionTargetImpl(y.getKey().getName(), y.getKey().getName());
+                IPermissionTarget target = new PermissionTargetImpl(y.getKey().getName(), y.getKey().getName(), TargetType.PORTLET_TYPE);
                 rslt.add(target);
             }
         }

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/PortletTypeTargetProviderImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/PortletTypeTargetProviderImpl.java
@@ -34,6 +34,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class PortletTypeTargetProviderImpl implements IPermissionTargetProvider {
 
+    /**
+     * This is an example of a "collective target."  It represents all instances
+     * of a certain class of thing (portlet types, in this case).  NOTE:  There
+     * are other collective targets;  e.g. ALL_PORTLETS and ALL_GROUPS.
+     * Implementation of collective targets is uneven -- logic for most of them
+     * is baked into AnyUnblockedGrantPermissionPolicy, whereas the logic for
+     * this one is written in PortletAdministrationHelper.  (Arguably neither
+     * place is appropriate;  they might be better in the service layer for
+     * permissions:  AuthorizationImpl.)
+     */
     public static final IPermissionTarget ALL_PORTLET_TYPES_TARGET = 
             new PermissionTargetImpl(IPermission.ALL_PORTLET_TYPES, 
                     IPermission.ALL_PORTLET_TYPES, TargetType.PORTLET_TYPE);

--- a/uportal-war/src/main/java/org/jasig/portal/permission/target/UserAttributesTargetProviderImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/target/UserAttributesTargetProviderImpl.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import org.jasig.portal.permission.target.IPermissionTarget.TargetType;
 import org.jasig.services.persondir.IPersonAttributeDao;
 
 public class UserAttributesTargetProviderImpl implements
@@ -41,7 +42,7 @@ public class UserAttributesTargetProviderImpl implements
 
     @Override
     public IPermissionTarget getTarget(String key) {
-        return new PermissionTargetImpl(key, key);
+        return new PermissionTargetImpl(key, key, TargetType.USER_ATTRIBUTE);
     }
 
     @Override
@@ -51,7 +52,7 @@ public class UserAttributesTargetProviderImpl implements
         final List<IPermissionTarget> matches = new ArrayList<IPermissionTarget>();
         for (String attribute : attributes) {
             if (attribute.toLowerCase().contains(term)) {
-                matches.add(new PermissionTargetImpl(attribute, attribute));
+                matches.add(new PermissionTargetImpl(attribute, attribute, TargetType.USER_ATTRIBUTE));
             }
         }
         return matches;

--- a/uportal-war/src/main/java/org/jasig/portal/security/IPermissionPolicy.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/IPermissionPolicy.java
@@ -18,34 +18,40 @@
  */
 package org.jasig.portal.security;
 
+import org.jasig.portal.permission.IPermissionActivity;
+import org.jasig.portal.permission.IPermissionOwner;
+import org.jasig.portal.permission.target.IPermissionTarget;
+
 /**
  * Defines a pluggable strategy for evaluating the permissions associated
  * with a principal.
  * @author Dan Ellentuck
- * @version $Revision$
  * @see org.jasig.portal.security.IAuthorizationService
  * @see org.jasig.portal.security.IPermission
  */
 public interface IPermissionPolicy {
-/**
- * Answers if the owner has authorized the principal to perform the activity 
- * on the target, based on permissions provided by the service.  Params 
- * <code>service</code>, <code>owner</code> and <code>activity</code> must 
- * be non-null.
- *
- * @return boolean
- * @param service org.jasig.portal.security.IAuthorizationService
- * @param principal org.jasig.portal.security.IAuthorizationPrincipal
- * @param owner java.lang.String
- * @param activity java.lang.String
- * @param target java.lang.String
- * @exception org.jasig.portal.AuthorizationException
- */
-public boolean doesPrincipalHavePermission
-   (IAuthorizationService service,
-    IAuthorizationPrincipal principal, 
-    String owner, 
-    String activity, 
-    String target) 
-throws org.jasig.portal.AuthorizationException;
+
+    /**
+     * Answers if the owner has authorized the principal to perform the activity 
+     * on the target, based on permissions provided by the service.  Params 
+     * <code>service</code>, <code>owner</code> and <code>activity</code> must 
+     * be non-null.
+     *
+     * @param service org.jasig.portal.security.IAuthorizationService
+     * @param principal org.jasig.portal.security.IAuthorizationPrincipal
+     * @param owner The 'namespace' of the activity
+     * @param activity The behavior that requires permission
+     * @param target The object upon which the behavior will be invoked
+     * @return TRUE if the principal has permission to perform the specified
+     * activity on the specified target
+     * @exception org.jasig.portal.AuthorizationException
+     */
+    public boolean doesPrincipalHavePermission(
+            IAuthorizationService service,
+            IAuthorizationPrincipal principal,
+            IPermissionOwner owner,
+            IPermissionActivity activity,
+            IPermissionTarget target)
+        throws org.jasig.portal.AuthorizationException;
+
 }

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
@@ -181,10 +181,6 @@ public class AnyUnblockedGrantPermissionPolicy implements IPermissionPolicy {
 
     }
 
-    /*
-     * TODO:  It's looking like the following method is really what we need to cache.
-     */
-
     private boolean hasUnblockedPathToGrantWithCache(IAuthorizationService service,
             IAuthorizationPrincipal principal, IPermissionOwner owner,
             IPermissionActivity activity, IPermissionTarget target,

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
@@ -23,18 +23,25 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+
 import org.jasig.portal.AuthorizationException;
 import org.jasig.portal.groups.GroupsException;
-import org.jasig.portal.groups.IEntityGroup;
 import org.jasig.portal.groups.IGroupMember;
-import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.permission.IPermissionActivity;
+import org.jasig.portal.permission.IPermissionOwner;
+import org.jasig.portal.permission.dao.IPermissionOwnerDao;
+import org.jasig.portal.permission.target.IPermissionTarget;
+import org.jasig.portal.permission.target.IPermissionTargetProviderRegistry;
 import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IAuthorizationService;
 import org.jasig.portal.security.IPermission;
 import org.jasig.portal.security.IPermissionPolicy;
-import org.jasig.portal.services.GroupService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 /**
@@ -65,161 +72,211 @@ import org.springframework.stereotype.Service;
  *  Results in GRANT because there is an unblocked path to a GRANT.
  */
 @Service("anyUnblockedGrantPermissionPolicy")
-public class AnyUnblockedGrantPermissionPolicy
-    implements IPermissionPolicy {
+public class AnyUnblockedGrantPermissionPolicy implements IPermissionPolicy {
 
-    protected final Log log = LogFactory.getLog(getClass());
-    
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
-    public boolean doesPrincipalHavePermission(IAuthorizationService service, IAuthorizationPrincipal principal, String owner, String activity, String target) throws AuthorizationException {
-        // the API states that the service, owner, and activity arguments must 
-        // not be null. If for some reason they are null, log and fail closed
-        // The principal must also not be null.
+    @Autowired
+    private IPermissionOwnerDao permissionOwnerDao;
+
+    @Autowired
+    private IPermissionTargetProviderRegistry targetProviderRegistry;
+
+    @Autowired
+    @Qualifier(value="org.jasig.portal.security.provider.AnyUnblockedGrantPermissionPolicy.HAS_UNBLOCKED_GRANT")
+    private Cache hasUnblockedGrantCache;
+
+    public boolean doesPrincipalHavePermission(
+            IAuthorizationService service,
+            IAuthorizationPrincipal principal,
+            IPermissionOwner owner,
+            IPermissionActivity activity,
+            IPermissionTarget target) throws AuthorizationException {
+
+        /*
+         * The API states that the service, owner, and activity arguments must
+         * not be null. If for some reason they are null, log and fail closed.
+         * The principal must also not be null.
+         */
         if (service == null || principal == null || owner == null || activity == null) {
-
             log.error("Null argument to AnyUnblockedGrantPermissionPolicy doesPrincipalHavePermission() method " +
-                    "should not be possible.  This is indicative of a potentially serious bug in the " +
-                    "permissions and authorization infrastructure. " +
-                    "service= [" + service + "] principal = [" + principal + "] owner = [" + owner + "] activity = [" + activity + "] target = [" + target + "]");
-
+                    "should not be possible.  This is indicative of a potentially serious bug in the permissions " +
+                    "and authorization infrastructure;  service='{}', principal='{}', owner='{}', activity='{}', target='{}'",
+                    service, principal.getKey(), owner.getFname(), activity.getFname(), target.getKey());
             // fail closed
             return false;
         }
 
-        // if this user is a super-user, just return true
-        if (!IPermission.ALL_PERMISSIONS_ACTIVITY.equals(activity)
-                && doesPrincipalHavePermission(service, principal,
-                        IPermission.PORTAL_SYSTEM,
-                        IPermission.ALL_PERMISSIONS_ACTIVITY,
-                        IPermission.ALL_TARGET)) {
-            return true;
-        }
-        
-        // first check for explicit permissions for this Principal
-        IPermission[] perms = service.getPermissionsForPrincipal(principal, owner, activity, target);
-
-        Set<IPermission> activePermissions = activePermissions(perms);
-
-        if (containsType(activePermissions, IPermission.PERMISSION_TYPE_DENY)) {
-            if (log.isTraceEnabled()) {
-            	log.trace("Principal [" + principal + "] is explicitly denied permission to perform activity [" + activity + "] on target [" + target + "] under permission owning system [" + owner + "].");
-            }
-            return false;
-        }
-
-        if (containsType(activePermissions, IPermission.PERMISSION_TYPE_GRANT)) {
-            // explicit GRANT
-            if (log.isTraceEnabled()) {
-            	log.trace("Principal [" + principal + "] is granted permission to perform activity [" + activity + "] on target [" + target + "] under permission owning system [" + owner + "] because this principal has an excplicit GRANT and does not have an exlicit DENY.");
-            }
-            return true;
-        }
-
-        // if the target is formatted as a channel, check if the user has
-        // the ALL_CHANNELS permission
-        if (target.startsWith(IPermission.PORTLET_PREFIX)
-                    && doesPrincipalHavePermission(service, principal, owner,
-                            activity, IPermission.ALL_PORTLETS_TARGET)) {
-            return true;
-        }
-
-        // if this target corresponds to a group or category, check if the user
-        // has the ALL_CATEGORIES or ALL_GROUPS permissions
-        IEntityGroup targetGroup = GroupService.findGroup(target);
-        if (targetGroup != null) {
-            if ((targetGroup.getEntityType().equals(IPortletDefinition.class)
-                    && doesPrincipalHavePermission(service, principal, owner,
-                            activity, IPermission.ALL_CATEGORIES_TARGET) || doesPrincipalHavePermission(
-                    service, principal, owner, activity,
-                    IPermission.ALL_GROUPS_TARGET))) {
+        // Is this user a super-user?  (Should this logic be moved to AuthorizationImpl?)
+        final IPermissionActivity allPermissionsActivity = permissionOwnerDao.getPermissionActivity(IPermission.PORTAL_SYSTEM, IPermission.ALL_PERMISSIONS_ACTIVITY);
+        if (!activity.equals(allPermissionsActivity)) {  // NOTE:  Must check to avoid infinite recursion
+            final IPermissionOwner allPermissionsOwner = permissionOwnerDao.getPermissionOwner(IPermission.PORTAL_SYSTEM);
+            final IPermissionTarget allPermissionsTarget = targetProviderRegistry.getTargetProvider(allPermissionsActivity.getTargetProviderKey()).getTarget(IPermission.ALL_TARGET);
+            if (doesPrincipalHavePermission(service, principal, allPermissionsOwner, allPermissionsActivity, allPermissionsTarget)) {
+                // Stop checking;  just return true
                 return true;
             }
         }
 
-        // no explicit permission.  Search for an unblocked GRANT.
-        boolean hasUnblockedPathToGrant;
+        /*
+         * uPortal uses a few "special" targets that signal permission to
+         * perform the specified activity over an entire class of targets;
+         * see if one of those applies in this case.
+         */
+        IPermissionTarget collectiveTarget = null;  // The "collective noun" representing a class of thing
+        switch (target.getTargetType()) {
+            case PORTLET:
+                collectiveTarget = targetProviderRegistry.getTargetProvider(activity.getTargetProviderKey()).getTarget(IPermission.ALL_PORTLETS_TARGET);
+                break;
+            case CATEGORY:
+                collectiveTarget = targetProviderRegistry.getTargetProvider(activity.getTargetProviderKey()).getTarget(IPermission.ALL_CATEGORIES_TARGET);
+                break;
+            case GROUP:
+                collectiveTarget = targetProviderRegistry.getTargetProvider(activity.getTargetProviderKey()).getTarget(IPermission.ALL_GROUPS_TARGET);
+                break;
+            default:
+            // This sort of handling does not apply;  just pass through
+        }
+        /*
+         * NOTE:  Cannot generalize to a collective target if we are already on
+         * the collective target, else StackOverflowError.
+         */
+        if (collectiveTarget != null && !collectiveTarget.equals(target)) {
+            if (doesPrincipalHavePermission(service, principal, owner, activity, collectiveTarget)) {
+                /*
+                 * There is a collective for this class of target,
+                 * and the user DOES have this special permission
+                 */
+                return true;
+            }
+        }
+
+        // Search ourselves and all ancestors for an unblocked GRANT.
+        boolean rslt;
         try {
-            // track groups we've already explored to avoid infinite loop
-            Set<IGroupMember> seenGroups = new HashSet<IGroupMember>(100);
-            hasUnblockedPathToGrant = hasUnblockedPathToGrant(service, principal, owner, activity, target, seenGroups);
+            // Track groups we've already explored to avoid infinite loop
+            final Set<IGroupMember> seenGroups = new HashSet<IGroupMember>(100);
+            rslt = hasUnblockedPathToGrantWithCache(service, principal, owner, activity, target, seenGroups);
         } catch (Exception e) {
             log.error("Error searching for unblocked path to grant for principal [" + principal + "]", e);
             // fail closed
             return false;
         }
-        
+
         if (log.isTraceEnabled()) {
-        	if (hasUnblockedPathToGrant) {
-        		log.trace("Principal [" + principal + "] is granted permission to perform activity [" + activity + "] on target [" + target + "] under permission owning system [" + owner + "] because this principal has an unblocked path to a GRANT.");
-        	} else {
-        		log.trace("Principal [" + principal + "] is denied permission to perform activity [" + activity + "] on target [" + target + "] under permission owning system [" + owner + "] because this principal does not have an unblocked path to a GRANT.");
-        	}
+            if (rslt) {
+                log.trace("Principal '{}' is granted permission to perform activity "
+                        + "'{}' on target '{}' under permission owning system '{}' "
+                        + "because this principal has an unblocked path to a GRANT.",
+                        principal, activity.getFname(), target.getKey(), owner.getFname());
+            } else {
+                log.trace("Principal '{}' is denied permission to perform activity '{}' "
+                        + "on target '{}' under permission owning system '{}' because this "
+                        + "principal does not have an unblocked path to a GRANT.",
+                        principal, activity.getFname(), target.getKey(), owner.getFname());
+            }
         }
-        
-        return hasUnblockedPathToGrant;
+
+        return rslt;
 
     }
 
-    private boolean hasUnblockedPathToGrant(IAuthorizationService service, IAuthorizationPrincipal principal, String owner, String activity, String target, Set<IGroupMember> seenGroups) throws GroupsException {
+    /*
+     * TODO:  It's looking like the following method is really what we need to cache.
+     */
 
-    	if (log.isTraceEnabled()) {
-    		log.trace("Searching for unblocked path to GRANT for principal [" + principal + "] to [" + activity + "] on target [" + target + "] having already checked ["+ seenGroups + "]");
-    	}
-    	
-        IGroupMember principalAsGroupMember = service.getGroupMember(principal);
+    private boolean hasUnblockedPathToGrantWithCache(IAuthorizationService service,
+            IAuthorizationPrincipal principal, IPermissionOwner owner,
+            IPermissionActivity activity, IPermissionTarget target,
+            Set<IGroupMember> seenGroups) throws GroupsException {
 
-        if (seenGroups.contains(principalAsGroupMember)) {
-        	
-        	if (log.isTraceEnabled()) {
-        		log.trace("Declining to re-examine principal [" + principal + "] for permission to [" + activity + "] on [" + target + "] because this group is among already checked groups [" + seenGroups + "]");
-        	}
-        	
-            return false;
+        final CacheTuple cacheTuple = new CacheTuple(
+                principal.getPrincipalString(),
+                owner.getFname(),
+                activity.getFname(),
+                target.getKey());
+        Element element = hasUnblockedGrantCache.get(cacheTuple);
+        if (element == null) {
+            boolean answer = hasUnblockedPathToGrant(service, principal, owner, activity, target, seenGroups);
+            element = new Element(cacheTuple, answer);
+            hasUnblockedGrantCache.put(element);
+        }
+        return (Boolean) element.getObjectValue();
+
+    }
+
+    /**
+     * This method performs the actual, low-level checking of a single activity
+     * and target.  Is IS responsible for performing the same check for
+     * affiliated groups in the Groups hierarchy, but it is NOT responsible for
+     * understanding the nuances of relationships some activities and/or targets
+     * have with one another (e.g. MANAGE_APPROVED, ALL_PORTLETS, etc.).  It
+     * performs the following steps, in order:
+     *
+     * <ol>
+     *   <li>Find out if the specified principal is <em>specifically</em> granted or denied;  if an answer is found in this step, return it</li>
+     *   <li>Find out what groups this principal belongs to;  convert each one to a principal and seek an answer by invoking ourselves recursively;  if an answer is found in this step, return it</li>
+     *   <li>Return false (no explicit GRANT means no permission)</li>
+     * </ol>
+     */
+    private boolean hasUnblockedPathToGrant(IAuthorizationService service,
+            IAuthorizationPrincipal principal, IPermissionOwner owner,
+            IPermissionActivity activity, IPermissionTarget target,
+            Set<IGroupMember> seenGroups) throws GroupsException {
+
+        if (log.isTraceEnabled()) {
+            log.trace("Searching for unblocked path to GRANT for principal '{}' to "
+                    + "'{}' on target '{}' having already checked:  {}",
+                    principal.getKey(), activity.getFname(), target.getKey(), seenGroups);
         }
 
+        /*
+         * Step #1:  Specific GRANT/DENY attached to this principal
+         */
+        final IPermission[] permissions = service.getPermissionsForPrincipal(principal,
+                        owner.getFname(), activity.getFname(), target.getKey());
+
+        final Set<IPermission> activePermissions = removeInactivePermissions(permissions);
+        final boolean denyExists = containsType(activePermissions, IPermission.PERMISSION_TYPE_DENY);
+        if (denyExists) {
+            // We need go no further;  DENY trumps both GRANT & inherited permissions
+            return false;
+        }
+        final boolean grantExists = containsType(activePermissions, IPermission.PERMISSION_TYPE_GRANT);
+        if (grantExists) {
+            // We need go no further;  explicit GRANT at this level of the hierarchy
+            if (log.isTraceEnabled()) {
+                log.trace("Found unblocked path to this permission set including a GRANT:  {}",
+                        activePermissions);
+            }
+            return true;
+        }
+
+        /*
+         * Step #2:  Seek an answer from affiliated groups
+         */
+        IGroupMember principalAsGroupMember = service.getGroupMember(principal);
+        if (seenGroups.contains(principalAsGroupMember)) {
+            if (log.isTraceEnabled()) {
+                log.trace("Declining to re-examine principal '{}' for permission to '{}' "
+                        + "on '{}' because this group is among already checked groups:  {}",
+                        principal.getKey(), activity.getFname(), target.getKey(), seenGroups);
+            }
+            return false;
+        }
         seenGroups.add(principalAsGroupMember);
-
-
-
+        @SuppressWarnings("unchecked")
         Iterator<IGroupMember> immediatelyContainingGroups = principalAsGroupMember.getContainingGroups();
-
         while (immediatelyContainingGroups.hasNext()) {
             IGroupMember parentGroup = immediatelyContainingGroups.next();
             try {
                 if (parentGroup != null) {
                     IAuthorizationPrincipal parentPrincipal = service.newPrincipal( parentGroup );
-                    IPermission[] parentPermissions = service.getPermissionsForPrincipal(parentPrincipal, owner, activity, target);
-
-                    Set<IPermission> activeParentPermissions = activePermissions(parentPermissions);
-
-                    boolean parentPermissionsContainsDeny = containsType(activeParentPermissions, IPermission.PERMISSION_TYPE_DENY);
-                    boolean parentPermissionsContainsGrant = containsType(activeParentPermissions, IPermission.PERMISSION_TYPE_GRANT);
-
-                    if (parentPermissionsContainsGrant && ! parentPermissionsContainsDeny) {
-                        // there's a GRANT on this group to which we had an unblocked path, and
-                        // there's no DENY on this group.
-                    	
-                    	if (log.isTraceEnabled()) {
-                    		log.trace("Found unblocked path to this permission set including a GRANT: [" + activeParentPermissions + "]");
-                    	}
-                    	
+                    boolean parentHasUnblockedPathToGrant = hasUnblockedPathToGrantWithCache(service, parentPrincipal, owner, activity, target, seenGroups);
+                    if (parentHasUnblockedPathToGrant) {
                         return true;
                     }
-
-                    if (! parentPermissionsContainsDeny) {
-                        // there's no blocking deny, so recursively check to see if the parent has an unblocked path to a grant
-
-
-                        boolean parentHasUnblockedPathToGrant = hasUnblockedPathToGrant(service, parentPrincipal, owner, activity, target, seenGroups);
-                        if (parentHasUnblockedPathToGrant) {
-                            return true;
-                        }
-
-
-                        // parent didn't have a path to grant.  Fall through and try another parent if any
-                    }
-
-
+                    // Parent didn't have a path to grant, fall through and try another parent (if any)
                 }
             } catch (Exception e) {
                 // problem evaluating this path, but let's not let it stop
@@ -230,20 +287,26 @@ public class AnyUnblockedGrantPermissionPolicy
             }
 
         }
+
+        /*
+         * Step #3:  No explicit GRANT means no permission
+         */
         return false;
+
     }
 
     /**
      * Returns a Set containing those IPermission instances where the present
      * date is neither after the permission expiration if present nor before
-     * the permission start date if present.
-     * @param perms
-     * @return potentially empty non-null Set of active permissions.
+     * the permission start date if present.  Only permissions objects that have
+     * been filtered by this method should be checked.
+     *
+     * @return Potentially empty non-null Set of active permissions.
      */
-    private Set<IPermission> activePermissions(final IPermission[] perms) {
+    private Set<IPermission> removeInactivePermissions(final IPermission[] perms) {
         Date now = new Date();
 
-        Set<IPermission> activePermissions = new HashSet<IPermission>(1);
+        Set<IPermission> rslt = new HashSet<IPermission>(1);
 
         for (int i = 0; i < perms.length; i++) {
             IPermission p = perms[i];
@@ -252,48 +315,120 @@ public class AnyUnblockedGrantPermissionPolicy
                 (p.getEffective() == null || ! p.getEffective().after(now))
                 &&
                 (p.getExpires() == null || p.getExpires().after(now))
-               ) {
-
-                activePermissions.add(p);
-
-
+             ) {
+                rslt.add(p);
             }
 
         }
 
-        return activePermissions;
-
-
+        return rslt;
     }
 
     /**
      * Returns true if a set of IPermission instances contains a permission of
-     * the specified type.
-     * False otherwise.
-     * @param permissions
-     * @return true if the set contains a permission of the sought type, false otherwise
+     * the specified type, otherwise false.  Permissions passed to this method
+     * <em>must</em> already be filtered of inactive (expired) instances.
+     *
+     * @return True if the set contains a permission of the sought type, false otherwise
      * @throws IllegalArgumentException if input set or type is null.
      */
     private boolean containsType(final Set<IPermission> permissions, final String soughtType) {
 
+        // Assertions
         if (permissions == null) {
             throw new IllegalArgumentException("Cannot check null set for contents.");
         }
-
         if (soughtType == null) {
             throw new IllegalArgumentException("Cannot search for type null.");
         }
 
-        for (Iterator<IPermission> permissionIter = permissions.iterator(); permissionIter.hasNext(); ) {
-            IPermission permission = permissionIter.next();
+        boolean rslt = false;  // default
 
-            if (permission != null && soughtType.equals(permission.getType())) {
-                return true;
+        for (IPermission p : permissions) {
+            if (soughtType.equals(p.getType())) {
+                rslt = true;
             }
         }
 
-        return false;
+        return rslt;
 
+    }
+
+    /*
+     * Nested Types
+     */
+
+    private static final class CacheTuple {
+        private final String principalName;
+        private final String owner;
+        private final String activity;
+        private final String target;
+        public CacheTuple(String principalName, String owner, String activity, String target) {
+            this.principalName = principalName;
+            this.owner = owner;
+            this.activity = activity;
+            this.target = target;
+        }
+        @SuppressWarnings("unused")
+        public String getPrincipalName() {
+            return principalName;
+        }
+        @SuppressWarnings("unused")
+        public String getOwner() {
+            return owner;
+        }
+        @SuppressWarnings("unused")
+        public String getActivity() {
+            return activity;
+        }
+        @SuppressWarnings("unused")
+        public String getTarget() {
+            return target;
+        }
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result
+                    + ((activity == null) ? 0 : activity.hashCode());
+            result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+            result = prime * result
+                    + ((principalName == null) ? 0 : principalName.hashCode());
+            result = prime * result
+                    + ((target == null) ? 0 : target.hashCode());
+            return result;
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            CacheTuple other = (CacheTuple) obj;
+            if (activity == null) {
+                if (other.activity != null)
+                    return false;
+            } else if (!activity.equals(other.activity))
+                return false;
+            if (owner == null) {
+                if (other.owner != null)
+                    return false;
+            } else if (!owner.equals(other.owner))
+                return false;
+            if (principalName == null) {
+                if (other.principalName != null)
+                    return false;
+            } else if (!principalName.equals(other.principalName))
+                return false;
+            if (target == null) {
+                if (other.target != null)
+                    return false;
+            } else if (!target.equals(other.target))
+                return false;
+            return true;
+        }
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/DefaultPermissionPolicy.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/DefaultPermissionPolicy.java
@@ -24,6 +24,9 @@ import java.util.Iterator;
 import org.jasig.portal.AuthorizationException;
 import org.jasig.portal.groups.GroupsException;
 import org.jasig.portal.groups.IGroupMember;
+import org.jasig.portal.permission.IPermissionActivity;
+import org.jasig.portal.permission.IPermissionOwner;
+import org.jasig.portal.permission.target.IPermissionTarget;
 import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IAuthorizationService;
 import org.jasig.portal.security.IPermission;
@@ -58,15 +61,15 @@ public DefaultPermissionPolicy() {
  * @param target java.lang.String
  * @exception org.jasig.portal.AuthorizationException
  */
-public boolean doesPrincipalHavePermission
-   (IAuthorizationService service,
-    IAuthorizationPrincipal principal,
-    String owner,
-    String activity,
-    String target)
+public boolean doesPrincipalHavePermission (
+        IAuthorizationService service,
+        IAuthorizationPrincipal principal,
+        IPermissionOwner owner,
+        IPermissionActivity activity,
+        IPermissionTarget target)
 throws org.jasig.portal.AuthorizationException
 {
-   IPermission[] perms = service.getPermissionsForPrincipal(principal, owner, activity, target);
+   IPermission[] perms = service.getPermissionsForPrincipal(principal, owner.getFname(), activity.getFname(), target.getKey());
 
     // We found a permission associated with this principal.
     if ( perms.length == 1 )
@@ -117,13 +120,13 @@ private boolean permissionIsGranted(IPermission p)
  */
 private boolean primDoesPrincipalHavePermission(
     IAuthorizationPrincipal principal,
-    String owner,
-    String activity,
-    String target,
+    IPermissionOwner owner,
+    IPermissionActivity activity,
+    IPermissionTarget target,
     IAuthorizationService service)
 throws AuthorizationException
 {
-    IPermission[] perms = service.getPermissionsForPrincipal(principal, owner, activity, target);
+    IPermission[] perms = service.getPermissionsForPrincipal(principal, owner.getFname(), activity.getFname(), target.getKey());
 
     if ( perms.length == 0 )
         { return false; }

--- a/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/servicesContext.xml
@@ -229,6 +229,9 @@
                                 <bean class="org.jasig.portal.permission.target.PermissionTargetImpl">
                                     <constructor-arg value="DETAILS"/>
                                     <constructor-arg value="Stack Trace"/>
+                                    <constructor-arg>
+                                        <value type="org.jasig.portal.permission.target.IPermissionTarget.TargetType">OTHER</value>
+                                    </constructor-arg>
                                 </bean>
                             </util:list>
                         </property>
@@ -241,6 +244,9 @@
                                 <bean class="org.jasig.portal.permission.target.PermissionTargetImpl">
                                     <constructor-arg value="ALL"/>
                                     <constructor-arg value="All permissions"/>
+                                    <constructor-arg>
+                                        <value type="org.jasig.portal.permission.target.IPermissionTarget.TargetType">OTHER</value>
+                                    </constructor-arg>
                                 </bean>
                             </util:list>
                         </property>

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -176,7 +176,7 @@
      +-->
     <cache name="org.jasig.portal.security.provider.AuthorizationImpl.ENTITY_PARENTS_CACHE"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false" 
-        timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" />
+        timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true" />
 
     <!-- 
      | Caches user-specific permission checks in AuthorizationImpl
@@ -185,7 +185,7 @@
      +-->
     <cache name="org.jasig.portal.security.provider.AuthorizationImpl.PRINCIPAL_HAS_PERMISSION"
         eternal="false" maxElementsInMemory="50000" overflowToDisk="false" diskPersistent="false" 
-        timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory class="org.jasig.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=tagTrackingCacheEventListener" listenFor="local" />
     </cache>
 
@@ -196,7 +196,7 @@
      +-->
     <cache name="org.jasig.portal.security.provider.AnyUnblockedGrantPermissionPolicy.HAS_UNBLOCKED_GRANT"
         eternal="false" maxElementsInMemory="50000" overflowToDisk="false" diskPersistent="false" 
-        timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory class="org.jasig.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=tagTrackingCacheEventListener" listenFor="local" />
     </cache>
 

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -177,10 +177,10 @@
     <cache name="org.jasig.portal.security.provider.AuthorizationImpl.ENTITY_PARENTS_CACHE"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" />
-    
+
     <!-- 
-     | Caches principal specific permission checks
-     | 1 x principal x permission
+     | Caches user-specific permission checks in AuthorizationImpl
+     | 1 x user x permission
      | - not replicated - doesn't represent an updatable data store
      +-->
     <cache name="org.jasig.portal.security.provider.AuthorizationImpl.PRINCIPAL_HAS_PERMISSION"
@@ -188,8 +188,18 @@
         timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory class="org.jasig.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=tagTrackingCacheEventListener" listenFor="local" />
     </cache>
-    
-    
+
+    <!-- 
+     | Caches low-level permission checks in AnyUnblockedGrantPermissionPolicy
+     | 1 x principal x permission
+     | - not replicated - doesn't represent an updatable data store
+     +-->
+    <cache name="org.jasig.portal.security.provider.AnyUnblockedGrantPermissionPolicy.HAS_UNBLOCKED_GRANT"
+        eternal="false" maxElementsInMemory="50000" overflowToDisk="false" diskPersistent="false" 
+        timeToIdleSeconds="0" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.jasig.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=tagTrackingCacheEventListener" listenFor="local" />
+    </cache>
+
     <!-- 
      | Caches fragment layouts
      | - 1 x fragment layout

--- a/uportal-war/src/test/groovy/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicyTest.groovy
+++ b/uportal-war/src/test/groovy/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicyTest.groovy
@@ -1,0 +1,107 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.security.provider;
+
+import java.util.Date;
+
+import org.jasig.portal.security.IPermission;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+class AnyUnblockedGrantPermissionPolicyTest extends AnyUnblockedGrantPermissionPolicy {
+
+    private static final long TWENTY_FOUR_HOURS_IN_MILLIS = 24L * 60L * 60L * 1000L;
+
+    private IPermission activeGrantPermission = {
+        IPermission rslt = new PermissionImpl('UP_SYSTEM');
+        rslt.setPrincipal('local.0');
+        rslt.setActivity('CUSTOMIZE');
+        rslt.setType('GRANT');
+        return rslt;
+    }();
+    private IPermission activeDenyPermission = {
+        IPermission rslt = new PermissionImpl('UP_SYSTEM');
+        rslt.setPrincipal('local.0');
+        rslt.setActivity('CUSTOMIZE');
+        rslt.setType('DENY');
+        return rslt;
+    }();
+    private IPermission expiredGrantPermission = {
+        IPermission rslt = new PermissionImpl('UP_SYSTEM');
+        rslt.setPrincipal('local.0');
+        rslt.setActivity('CUSTOMIZE');
+        rslt.setType('GRANT');
+        rslt.setExpires(new Date(System.currentTimeMillis() - TWENTY_FOUR_HOURS_IN_MILLIS));
+        return rslt;
+    }();
+    private IPermission futureGrantPermission = {
+        IPermission rslt = new PermissionImpl('UP_SYSTEM');
+        rslt.setPrincipal('local.0');
+        rslt.setActivity('CUSTOMIZE');
+        rslt.setType('GRANT');
+        rslt.setEffective(new Date(System.currentTimeMillis() + TWENTY_FOUR_HOURS_IN_MILLIS));
+        return rslt;
+    }();
+
+    @Test
+    void testContainsType() {
+        Set<IPermission> onlyGrant = new HashSet([
+            activeGrantPermission
+        ]);
+        Set<IPermission> onlyDeny = new HashSet([
+            activeDenyPermission
+        ]);
+        Set<IPermission> bothGrantAndDeny = new HashSet([
+            activeGrantPermission,
+            activeDenyPermission
+        ]);
+
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(onlyGrant, 'GRANT'), true);
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(onlyDeny, 'GRANT'), false);
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(bothGrantAndDeny, 'GRANT'), true);
+
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(onlyGrant, 'DENY'), false);
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(onlyDeny, 'DENY'), true);
+        assertEquals('Incorrect output from containsType() -- ',
+            super.containsType(bothGrantAndDeny, 'DENY'), true);
+    }
+
+    @Test
+    void testRemoveInactivePermissions() {
+        IPermission[] activePermissions = [
+            activeGrantPermission
+        ];
+        IPermission[] inactivePermissions = [
+            expiredGrantPermission,
+            futureGrantPermission
+        ];
+
+        IPermission[] inpt = activePermissions + inactivePermissions;
+        Set<IPermission> filteredPermissions = super.removeInactivePermissions(inpt);
+        assertEquals('Incorrect output from removeInactivePermissions() -- ',
+            activePermissions, filteredPermissions.toArray(new IPermission[0]));
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/security/provider/AuthorizationTester.java
+++ b/uportal-war/src/test/java/org/jasig/portal/security/provider/AuthorizationTester.java
@@ -30,10 +30,12 @@ import junit.framework.TestCase;
 import junit.textui.TestRunner;
 
 import org.jasig.portal.AuthorizationException;
-import org.jasig.portal.concurrency.CachingException;
 import org.jasig.portal.groups.GroupServiceConfiguration;
 import org.jasig.portal.groups.GroupsException;
 import org.jasig.portal.groups.IGroupMember;
+import org.jasig.portal.permission.IPermissionActivity;
+import org.jasig.portal.permission.IPermissionOwner;
+import org.jasig.portal.permission.target.IPermissionTarget;
 import org.jasig.portal.properties.PropertiesManager;
 import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IAuthorizationService;
@@ -44,7 +46,6 @@ import org.jasig.portal.security.IPermissionStore;
 import org.jasig.portal.security.PortalSecurityException;
 import org.jasig.portal.services.AuthorizationService;
 import org.jasig.portal.services.GroupService;
-
 
 /**
  * Tests the authorization framework.
@@ -68,50 +69,47 @@ public class AuthorizationTester extends TestCase
     private IPermissionPolicy defaultPermissionPolicy;
     private IPermissionPolicy negativePermissionPolicy;
     private IPermissionPolicy positivePermissionPolicy;
-    private IPermission[] addedPermissions;
     private List testPermissions = new ArrayList();
 
     private static Class GROUP_CLASS;
     private static Class IPERSON_CLASS;
     private static String CR = "\n";
-    
+
     private Random random = new Random();
 
-    private class NegativePermissionPolicy implements IPermissionPolicy
-    {
+    private class NegativePermissionPolicy implements IPermissionPolicy {
         private NegativePermissionPolicy() { super(); }
         public boolean doesPrincipalHavePermission(
-            IAuthorizationService service,
-            IAuthorizationPrincipal principal,
-            String owner,
-            String activity,
-            String target)
-        throws AuthorizationException
-       {
-           return ! (service.equals(service)) &&
-                  (principal.equals(principal)) &&
-                  (owner.equals(owner)) &&
-                  (activity.equals(activity));
-       }
+                IAuthorizationService service,
+                IAuthorizationPrincipal principal,
+                IPermissionOwner owner,
+                IPermissionActivity activity,
+                IPermissionTarget target)
+        throws AuthorizationException {
+            // Seems the only value this method provides is NPE detection
+            return ! (service.equals(service)) &&
+                    (principal.equals(principal)) &&
+                    (owner.equals(owner)) &&
+                    (activity.equals(activity));
+        }
         public String toString() { return this.getClass().getName(); }
     }
 
-    private class PositivePermissionPolicy implements IPermissionPolicy
-    {
+    private class PositivePermissionPolicy implements IPermissionPolicy {
         private PositivePermissionPolicy() { super(); }
         public boolean doesPrincipalHavePermission(
-            IAuthorizationService service,
-            IAuthorizationPrincipal principal,
-            String owner,
-            String activity,
-            String target)
-        throws AuthorizationException
-       {
-           return (service.equals(service)) &&
-                  (principal.equals(principal)) &&
-                  (owner.equals(owner)) &&
-                  (activity.equals(activity));
-       }
+                IAuthorizationService service,
+                IAuthorizationPrincipal principal,
+                IPermissionOwner owner,
+                IPermissionActivity activity,
+                IPermissionTarget target)
+        throws AuthorizationException {
+            // Seems the only value this method provides is NPE detection
+            return (service.equals(service)) &&
+                    (principal.equals(principal)) &&
+                    (owner.equals(owner)) &&
+                    (activity.equals(activity));
+        }
         public String toString() { return this.getClass().getName(); }
     }
     
@@ -178,25 +176,7 @@ public class AuthorizationTester extends TestCase
 public AuthorizationTester(String name) {
     super(name);
 }
-/**
- * @return org.jasig.portal.security.IPermissionPolicy
- */
-private IPermissionPolicy getDefaultPermissionPolicy() throws AuthorizationException
-{
-    if ( defaultPermissionPolicy == null )
-        { initializeDefaultPermissionPolicy(); }
-    return defaultPermissionPolicy;
-}
-/**
- * @return org.jasig.portal.services.GroupService
- */
-private Collection getGroupMembers(IGroupMember gm) throws GroupsException
-{
-    Collection list = new ArrayList();
-    for( Iterator itr=gm.getMembers(); itr.hasNext(); )
-        { list.add(itr.next()); }
-    return list;
-}
+
 /**
  * @return org.jasig.portal.security.IPermissionPolicy
  */
@@ -279,32 +259,7 @@ private void initializeAuthorizationService() throws AuthorizationException
 			}
 	}
 }
-/**
- * Create the default implementation of IPermissionPolicy.
- */
-private void initializeDefaultPermissionPolicy() throws AuthorizationException
-{
-    String eMsg = null;
-    String policyName =
-      PropertiesManager.getProperty("org.jasig.portal.security.IPermissionPolicy.defaultImplementation");
-    if ( policyName == null )
-    {
-        eMsg = "AuthorizationTester.initializeDefaultPermissionPolicy(): No entry for org.jasig.portal.security.IPermissionPolicy.defaultImplementation in portal.properties.";
-        print (eMsg);
-        throw new AuthorizationException(eMsg);
-    }
 
-    try
-    {
-        defaultPermissionPolicy = (IPermissionPolicy)Class.forName(policyName).newInstance();
-    }
-    catch (Exception e)
-    {
-        eMsg = "AuthorizationTester.initializeDefaultPermissionPolicy(): Problem creating default permission policy... " + e.getMessage();
-        print(eMsg);
-        throw new AuthorizationException(eMsg);
-    }
-}
 /**
  * Create an implementation of IPermissionStore.
  */
@@ -477,7 +432,6 @@ public void testAlternativePermissionPolicies() throws Exception
     String activity = IPermission.PORTLET_SUBSCRIBER_ACTIVITY;
     String existingTarget = "CHAN_ID.1";
     String nonExistingTarget = "CHAN_ID.9999";
-    String everyoneKey = "local" + GROUP_SEPARATOR + "0";
 
     msg = "Creating a group member for everyone (" + EVERYONE_GROUP_PRINCIPAL_KEY + ").";
     print(msg);
@@ -568,7 +522,6 @@ public void testPermissionStore() throws Exception
 {
     print("***** ENTERING AuthorizationTester.testPermissionStore() *****");
     String msg = null;
-    boolean testResult = false;
     String activity = IPermission.PORTLET_SUBSCRIBER_ACTIVITY;
     String existingTarget = "CHAN_ID.1";
     String nonExistingTarget = "CHAN_ID.000";


### PR DESCRIPTION
…le and maintainable and improve the performance of permissions checking through additional caching

https://issues.jasig.org/browse/UP-4516

Based on some small sample size micro-benchmarking, this change improves the performance of some APIs by more than half.

Examples (performed by a non-admin):

 - /uPortal/api/portlets.json from 8495ms down to 3846ms (98 portlets in the registry)
 - /uPortal/api/v4-3/dlm/portletRegistry.json 2676ms down to 532ms (admin)