### PR TITLE
UP-4525 : Handle errors around profile selection event publication.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
@@ -354,12 +354,30 @@ public class PortalPreAuthenticatedProcessingFilter
         if (requestedProfile != null) {
 
             final ProfileSelectionEvent event = new ProfileSelectionEvent(this, requestedProfile, person, request);
-            this.eventPublisher.publishEvent(event);
+
+            try {
+                this.eventPublisher.publishEvent(event);
+            } catch (final Exception exceptionFiringProfileSelection) {
+                // failing to register a profile selection is bad,
+                // but preventing login entirely is worse.  Log the exception and continue.
+                logger.error("Exception on firing profile selection event " + event,
+                    exceptionFiringProfileSelection);
+            }
+
 
         } else if(swapperProfile != null) {
 
             final ProfileSelectionEvent event = new ProfileSelectionEvent(this, swapperProfile, person, request);
-            this.eventPublisher.publishEvent(event);
+
+            try {
+                this.eventPublisher.publishEvent(event);
+            } catch (final Exception exceptionFiringSwappedProfileSelection) {
+                // failing to swap as the desired profile selection is bad,
+                // but preventing login entirely is worse.  Log the exception and continue.
+                logger.error("Exception on firing profile selection event " + event,
+                    exceptionFiringSwappedProfileSelection);
+            }
+
 
         } else {
             if (logger.isTraceEnabled()) {


### PR DESCRIPTION
Fire the profile selection event safely, catching, logging, and ignoring exceptions that arise in response to the profile selection event, figuring that failing the entire login is an inappropriate escalation of a failure in honoring the user's expressed desire to use a particular profile.

(Safety added in response to an issue in MyUW where a glitch in the profile selection persistence code broke portal login for affected users, when those users would have been better off being able to log in even if not being able to switch among available profiles.)

See also [portal-dev@ thread](http://thread.gmane.org/gmane.comp.java.jasig.uportal.devel/6221).