### PR TITLE
Pass through -Denv on `ant data-import`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -671,6 +671,7 @@
         </echo>
 
         <antcall target="up-shell">
+            <param name="-Denv" value="${env}" />
             <param name="script" value="${portal-shell-script}" />
         </antcall>
     </target>


### PR DESCRIPTION
I've run into this a few times and it makes it quite painful to run a single import with a separate *.properties file. This should fix at least the data-import task.