### PR TITLE
UP-4569 Add portlet webapp, name, and framework status to v4.3 layout.JSON

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rendering/PortletDefinitionAttributeSource.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/PortletDefinitionAttributeSource.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+
+import org.jasig.portal.layout.IUserLayoutManager;
+import org.jasig.portal.portlet.dao.IPortletDefinitionDao;
+import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.portlet.om.IPortletDescriptorKey;
+import org.jasig.portal.portlet.om.IPortletWindow;
+import org.jasig.portal.portlet.om.IPortletWindowId;
+import org.jasig.portal.portlet.registry.IPortletWindowRegistry;
+import org.jasig.portal.utils.cache.CacheKey;
+import org.jasig.portal.utils.cache.CacheKey.CacheKeyBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Base implementation of portlet definition source that adds the
+ * portlet webapp, name, and framework portlet info
+ * 
+ * @author James Wennmacher jwennmacher@unicon.net
+ */
+public class PortletDefinitionAttributeSource implements AttributeSource, BeanNameAware {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public static final QName PORTLET_FNAME_ATTR_NAME = new QName("fname");
+    public static final String WEBAPP_NAME_ATTRIBUTE = "webAppName";
+    public static final String PORTLET_NAME_ATTRIBUTE = "portletName";
+    public static final String FRAMEWORK_PORTLET_ATTRIBUTE = "frameworkPortlet";
+
+    private final XMLEventFactory xmlEventFactory = XMLEventFactory.newFactory();
+    private IPortletDefinitionDao portletDefinitionDao;
+    private IPortletWindowRegistry portletWindowRegistry;
+    private String name;
+
+    @Autowired
+    public void setPortletDefinitionDao(IPortletDefinitionDao portletDefinitionDao) {
+        this.portletDefinitionDao = portletDefinitionDao;
+    }
+
+    @Autowired
+    public void setPortletWindowRegistry(IPortletWindowRegistry portletWindowRegistry) {
+        this.portletWindowRegistry = portletWindowRegistry;
+    }
+
+    @Override
+    public void setBeanName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public final Iterator<Attribute> getAdditionalAttributes(HttpServletRequest request, HttpServletResponse response, StartElement event) {
+
+        final QName eventName = event.getName();
+        final String localEventName = eventName.getLocalPart();
+
+        //Only pay attention to channel events
+        if (!IUserLayoutManager.CHANNEL.equals(localEventName)) {
+            return null;
+        }
+
+        final Collection<Attribute> attributes = new LinkedList<Attribute>();
+
+        // Add the portlet's portlet name and either the webapp URL or framework flag to the list of attributes.
+        final Attribute fnameAttribute = event.getAttributeByName(PORTLET_FNAME_ATTR_NAME);
+        if (fnameAttribute != null) {
+            final String fname = fnameAttribute.getValue();
+            IPortletDefinition def = portletDefinitionDao.getPortletDefinitionByFname(fname);
+            IPortletDescriptorKey descriptorKey = def.getPortletDescriptorKey();
+            attributes.add(xmlEventFactory.createAttribute(PORTLET_NAME_ATTRIBUTE, descriptorKey.getPortletName()));
+            if (descriptorKey.isFrameworkPortlet()) {
+                attributes.add(xmlEventFactory.createAttribute(FRAMEWORK_PORTLET_ATTRIBUTE, "true"));
+            } else {
+                attributes.add(xmlEventFactory.createAttribute(WEBAPP_NAME_ATTRIBUTE, descriptorKey.getWebAppName()));
+            }
+        }
+
+        return attributes.iterator();
+    }
+
+    @Override
+    public final CacheKey getCacheKey(HttpServletRequest request, HttpServletResponse response) {
+        final CacheKeyBuilder cacheKeyBuilder = CacheKey.builder(this.name);
+
+        // We need something that makes for a unique cache key.  For lack of anything else useful,
+        // use the set of all layout portlet window ids in the user's layout.
+        final Set<IPortletWindow> portletWindows = this.portletWindowRegistry.getAllLayoutPortletWindows(request);
+
+        for (final IPortletWindow portletWindow : portletWindows) {
+            if(portletWindow != null) {
+                final IPortletWindowId portletWindowId = portletWindow.getPortletWindowId();
+                cacheKeyBuilder.add(portletWindowId);
+            } else {
+                this.logger.warn("portletWindowRegistry#getAllLayoutPortletWindows() returned a null portletWindow");
+            }
+        }
+
+        return cacheKeyBuilder.build();
+    }
+
+}

--- a/uportal-war/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
@@ -83,6 +83,12 @@
         <property name="attributeSource" ref="attributeSource"/>
     </bean>
 
+    <!-- portlet definition attribute incorporation -->
+    <bean id="jsonPortletDefinitionAttributeIncorporationComponent" class="org.jasig.portal.rendering.StAXAttributeIncorporationComponent">
+        <property name="wrappedComponent" ref="jsonPortletWindowAttributeIncorporationComponent" />
+        <property name="attributeSource" ref="portletDefinitionAttributeSource"/>
+    </bean>
+    <bean id="portletDefinitionAttributeSource" class="org.jasig.portal.rendering.PortletDefinitionAttributeSource"/>
 
     <!-- portlet rendering initiation.  Not needed for JSON layout.  We don't want to actually render the portlets
          since we don't need to incorporate the portlet's output into the response.  -->
@@ -92,7 +98,7 @@
     
     <!-- theme attribute incorporation -->
     <bean id="jsonThemeAttributeIncorporationComponent" class="org.jasig.portal.rendering.StAXAttributeIncorporationComponent">
-        <property name="wrappedComponent" ref="jsonPortletWindowAttributeIncorporationComponent" />
+        <property name="wrappedComponent" ref="jsonPortletDefinitionAttributeIncorporationComponent" />
         <property name="attributeSource" ref="themeAttributeSource" />
     </bean>
 

--- a/uportal-war/src/test/groovy/org/jasig/portal/rendering/PortletDefinitionAttributeSourceTest.groovy
+++ b/uportal-war/src/test/groovy/org/jasig/portal/rendering/PortletDefinitionAttributeSourceTest.groovy
@@ -1,0 +1,79 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering
+
+import org.jasig.portal.portlet.dao.IPortletDefinitionDao
+import org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl
+import org.jasig.portal.portlet.dao.jpa.PortletTypeImpl
+
+import javax.xml.stream.XMLEventFactory
+
+/**
+ * Tests PortletDefinitionAttributeSource.
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+
+class PortletDefinitionAttributeSourceTest extends GroovyTestCase {
+    void testGetAdditionalAttributesPortlet() {
+        def portletDefn = new PortletDefinitionImpl(new PortletTypeImpl('name', 'cpdUri'),
+            'theFname', 'name', 'title', 'webappName', 'portletName', false)
+        def portletDefinitionDao = [
+                getPortletDefinitionByFname: { String fname ->
+                    assert 'theFname' == fname
+                    portletDefn }] as IPortletDefinitionDao
+        def testClass = new PortletDefinitionAttributeSource()
+        testClass.setPortletDefinitionDao(portletDefinitionDao)
+        def factory = XMLEventFactory.newFactory()
+        def attr = factory.createAttribute('fname', 'theFname')
+        def element = factory.createStartElement('', '', 'channel',attr.iterator(), null)
+        def attrIterator = testClass.getAdditionalAttributes(null, null, element)
+        def attributeMap = [:]
+        while (attrIterator.hasNext()) {
+            def attrItem = attrIterator.next()
+            attributeMap[attrItem.getName().getLocalPart()] = attrItem.getValue()
+        }
+        assert attributeMap.size() == 2
+        assert attributeMap[PortletDefinitionAttributeSource.PORTLET_NAME_ATTRIBUTE] == 'portletName'
+        assert attributeMap[PortletDefinitionAttributeSource.WEBAPP_NAME_ATTRIBUTE] == 'webappName'
+    }
+
+    void testGetAdditionalAttributesFrameworkPortlet() {
+        def portletDefn = new PortletDefinitionImpl(new PortletTypeImpl('name', 'cpdUri'),
+                'theFname', 'name', 'title', null, 'portletName', true)
+        def portletDefinitionDao = [
+                getPortletDefinitionByFname: { String fname ->
+                    assert 'theFname' == fname
+                    portletDefn }] as IPortletDefinitionDao
+        def testClass = new PortletDefinitionAttributeSource()
+        testClass.setPortletDefinitionDao(portletDefinitionDao)
+        def factory = XMLEventFactory.newFactory()
+        def attr = factory.createAttribute('fname', 'theFname')
+        def element = factory.createStartElement('', '', 'channel',attr.iterator(), null)
+        def attrIterator = testClass.getAdditionalAttributes(null, null, element)
+        def attributeMap = [:]
+        while (attrIterator.hasNext()) {
+            def attrItem = attrIterator.next()
+            attributeMap[attrItem.getName().getLocalPart()] = attrItem.getValue()
+        }
+        assert attributeMap.size() == 2
+        assert attributeMap[PortletDefinitionAttributeSource.PORTLET_NAME_ATTRIBUTE] == 'portletName'
+        assert attributeMap[PortletDefinitionAttributeSource.FRAMEWORK_PORTLET_ATTRIBUTE] == 'true'
+    }
+}


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4569

Properties added to portlets in layout.json are:
"portletName": "EmergencyAlert"
and either
"webAppName": "/NotificationPortlet"
or
"frameworkPortlet": "true"

Allows the UI to do special handling if need be based on the portlet type.  Typically this information should not be needed by the UI but is available for special circumstances to allow the UI to do special hints or handling.

An example of possible special handling is the app launcher in the favorites; you want the app launcher to activate rather than display in maximized mode, especially if its behavior is to open the portlet in a new window.  This is added in part for the ngPortal support.