### PR TITLE
UP-4570:  Portlet Marketplace -- make it possible to publish the Mark…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/IMarketplaceService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/IMarketplaceService.java
@@ -26,7 +26,6 @@ import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IPerson;
 
 import java.util.Set;
-import java.util.concurrent.Future;
 
 /**
  * Marketplace service layer responsible for gathering and applying policy about what Marketplace entries
@@ -39,10 +38,12 @@ public interface IMarketplaceService {
      * Return the Marketplace entries visible to the user.
      * Marketplace entries are visible to the user when the user enjoys permission for the
      * UP_PORTLET_SUBSCRIBE.BROWSE or UP_PORTLET_PUBLISH.MANAGE activity on the portlet entity.
+     * @param user The non-null user
+     * @param categories Restricts the output to entries within the specified categories if non-empty
      * @throws IllegalArgumentException when passed in user is null
      * @since uPortal 4.2
      */
-    ImmutableSet<MarketplaceEntry> browseableMarketplaceEntriesFor(IPerson user);
+    ImmutableSet<MarketplaceEntry> browseableMarketplaceEntriesFor(IPerson user, final Set<PortletCategory> categories);
 
     /**
      * Return the potentially empty Set of portlet categories such that
@@ -51,10 +52,11 @@ public interface IMarketplaceService {
      * (That is, the category is not "empty" from the perspective of this user browsing).
      *
      * @param user non-null user
+     * @param categories Restricts the output to entries within the specified categories if non-empty
      * @return potentially empty non-null Set of browseable categories
      * @since uPortal 4.1
      */
-    Set<PortletCategory> browseableNonEmptyPortletCategoriesFor(IPerson user);
+    Set<PortletCategory> browseableNonEmptyPortletCategoriesFor(IPerson user, final Set<PortletCategory> categories);
 
     /**
      * Answers whether the given user may browse the portlet marketplace entry for the given portlet definition.
@@ -74,11 +76,12 @@ public interface IMarketplaceService {
      * The user MUST have BROWSE permission on all members of the Set.
      *
      * @param user the non-null user for whom featured portlets are desired.
+     * @param categories Restricts the output to entries within the specified categories if non-empty
      * @return non-null potentially empty Set of featured portlet MarketplaceEntries.
      *
      * @since uPortal 4.2
      */
-    Set<MarketplaceEntry> featuredEntriesForUser(IPerson user);
+    Set<MarketplaceEntry> featuredEntriesForUser(IPerson user, final Set<PortletCategory> categories);
 
     /**
      * Provides a {@link MarketplacePortletDefinition} object that corresponds to the specified portlet definition.

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portal.portlet.marketplace;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +42,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,13 +68,16 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     private boolean enableMarketplacePreloading = false;
 
     @Autowired
-    @Qualifier(value = "org.jasig.portal.portlet.marketplace.MarketplaceService.marketplacePortletDefinitionCache")
-    private Cache marketplacePortletDefinitionCache;
-    
-    @Autowired
     public void setAuthorizationService(IAuthorizationService service) {
         this.authorizationService = service;
     }
+
+    /**
+     * Used to store individual MarketplacePortletDefinition instances.
+     */
+    @Autowired
+    @Qualifier(value = "org.jasig.portal.portlet.marketplace.MarketplaceService.marketplacePortletDefinitionCache")
+    private Cache marketplacePortletDefinitionCache;
 
     /**
      * Cache of Username -> Future<Set<MarketplaceEntry>
@@ -79,6 +85,14 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     @Autowired
     @Qualifier(value = "org.jasig.portal.portlet.marketplace.MarketplaceService.marketplaceUserPortletDefinitionCache")
     private Cache marketplaceUserPortletDefinitionCache;
+
+    /**
+     * Caches objects related to the ability to limit the portlets displayed
+     * in a single publication of the Marketplace.
+     */
+    @Autowired
+    @Qualifier(value = "org.jasig.portal.portlet.marketplace.MarketplaceService.marketplaceCategoryCache")
+    private Cache marketplaceCategoryCache;
 
     @Value("${org.jasig.portal.portlets.marketplacePortlet.loadMarketplaceOnLogin:false}")
     public void setLoadMarketplaceOnLogin(final boolean enableMarketplacePreloading) {
@@ -95,8 +109,14 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     @Override
     public void onApplicationEvent(LoginEvent loginEvent) {
         if (enableMarketplacePreloading) {
-            IPerson person = loginEvent.getPerson();
-            loadMarketplaceEntriesFor(person);
+            final IPerson person = loginEvent.getPerson();
+            /*
+             * Passing an empty collection pre-loads an unfiltered collection;
+             * instances of PortletMarketplace that specify filtering will
+             * trigger a new collection to be loaded.
+             */
+            final Set<PortletCategory> empty = Collections.emptySet();
+            loadMarketplaceEntriesFor(person, empty);
         }
     }
 
@@ -110,23 +130,63 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
      * No protections have been provided against modifying the MarketplaceEntry itself,
      * so be careful when modifying the entities contained in the list.
      *
-     * @param user the non-null user
+     * @param user The non-null user
+     * @param categories Restricts the output to entries within the specified categories if non-empty
      * @return a Future that will resolve to a set of MarketplaceEntry objects
      *      the requested user has browse access to.
      * @throws java.lang.IllegalArgumentException if user is null
      * @since 4.2
      */
     @Async
-    public Future<ImmutableSet<MarketplaceEntry>> loadMarketplaceEntriesFor(final IPerson user) {
+    public Future<ImmutableSet<MarketplaceEntry>> loadMarketplaceEntriesFor(final IPerson user, final Set<PortletCategory> categories) {
 
         final IAuthorizationPrincipal principal = AuthorizationPrincipalHelper.principalFromUser(user);
 
-        final List<IPortletDefinition> allPortletDefinitions =
+        List<IPortletDefinition> allDisplayablePortletDefinitions =
                 this.portletDefinitionRegistry.getAllPortletDefinitions();
+
+        if (!categories.isEmpty()) {
+            // Indicates we plan to restrict portlets displayed in the Portlet
+            // Marketplace to those that belong to one or more specified groups.
+            Element portletDefinitionsElement = marketplaceCategoryCache.get(categories);
+            if (portletDefinitionsElement == null) {
+
+                /*
+                 * Collection not in cache -- need to recreate it
+                 */
+
+                // Gather the complete collection of allowable categories (specified categories & their descendants)
+                final Set<PortletCategory> allSpecifiedAndDecendantCategories = new HashSet<>();
+                for (PortletCategory pc : categories) {
+                    collectSpecifiedAndDescendantCategories(pc, allSpecifiedAndDecendantCategories);
+                }
+
+                // Filter portlets that match the criteria
+                Set<IPortletDefinition> filteredPortletDefinitions = new HashSet<>();
+                for (final IPortletDefinition portletDefinition : allDisplayablePortletDefinitions) {
+                    final Set<PortletCategory> parents = portletCategoryRegistry.getParentCategories(portletDefinition);
+                    boolean includeIt = false;  // default
+                    for (final PortletCategory parent : parents) {
+                        if (allSpecifiedAndDecendantCategories.contains(parent)) {
+                            includeIt = true;
+                            break;
+                        }
+                    }
+                    if (includeIt) {
+                        filteredPortletDefinitions.add(portletDefinition);
+                        break;
+                    }
+                }
+
+                portletDefinitionsElement = new Element(categories, new ArrayList<>(filteredPortletDefinitions));
+                marketplaceCategoryCache.put(portletDefinitionsElement);
+            }
+            allDisplayablePortletDefinitions = (List<IPortletDefinition>) portletDefinitionsElement.getObjectValue();
+        }
 
         final Set<MarketplaceEntry> visiblePortletDefinitions = new HashSet<>();
 
-        for (final IPortletDefinition portletDefinition : allPortletDefinitions) {
+        for (final IPortletDefinition portletDefinition : allDisplayablePortletDefinitions) {
 
             if (mayBrowsePortlet(principal, portletDefinition)) {
                 final MarketplacePortletDefinition marketplacePortletDefinition = getOrCreateMarketplacePortletDefinition(portletDefinition);
@@ -151,14 +211,14 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     }
 
     @Override
-    public ImmutableSet<MarketplaceEntry> browseableMarketplaceEntriesFor(final IPerson user) {
+    public ImmutableSet<MarketplaceEntry> browseableMarketplaceEntriesFor(final IPerson user, final Set<PortletCategory> categories) {
         Element cacheElement = marketplaceUserPortletDefinitionCache.get(user.getUserName());
         Future<ImmutableSet<MarketplaceEntry>> future = null;
         if (cacheElement == null) {
             // not in cache, load it and cache the results...
-            future = loadMarketplaceEntriesFor(user);
+            future = loadMarketplaceEntriesFor(user, categories);
         } else {
-            future = (Future<ImmutableSet<MarketplaceEntry>>)cacheElement.getObjectValue();
+            future = (Future<ImmutableSet<MarketplaceEntry>>) cacheElement.getObjectValue();
         }
 
         try {
@@ -171,10 +231,10 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     }
 
     @Override
-    public Set<PortletCategory> browseableNonEmptyPortletCategoriesFor(final IPerson user) {
+    public Set<PortletCategory> browseableNonEmptyPortletCategoriesFor(final IPerson user, final Set<PortletCategory> categories) {
         final IAuthorizationPrincipal principal = AuthorizationPrincipalHelper.principalFromUser(user);
 
-        final Set<MarketplaceEntry> browseablePortlets = browseableMarketplaceEntriesFor(user);
+        final Set<MarketplaceEntry> browseablePortlets = browseableMarketplaceEntriesFor(user, categories);
 
         final Set<PortletCategory> browseableCategories = new HashSet<PortletCategory>();
 
@@ -214,10 +274,10 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
     }
 
     @Override
-    public Set<MarketplaceEntry> featuredEntriesForUser(final IPerson user) {
+    public Set<MarketplaceEntry> featuredEntriesForUser(final IPerson user, final Set<PortletCategory> categories) {
         Validate.notNull(user, "Cannot determine relevant featured portlets for null user.");
 
-        final Set<MarketplaceEntry> browseablePortlets = browseableMarketplaceEntriesFor(user);
+        final Set<MarketplaceEntry> browseablePortlets = browseableMarketplaceEntriesFor(user, categories);
         final Set<MarketplaceEntry> featuredPortlets = new HashSet<>();
 
         for (final MarketplaceEntry entry : browseablePortlets) {
@@ -280,6 +340,17 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
                 IPermission.PORTLET_BROWSE_ACTIVITY,
                 targetId));
 
+    }
+
+    /**
+     * Called recursively to gather all specified categories and descendants 
+     */
+    private void collectSpecifiedAndDescendantCategories(PortletCategory specified, Set<PortletCategory> gathered) {
+        final Set<PortletCategory> children = portletCategoryRegistry.getAllChildCategories(specified);
+        for (PortletCategory child : children) {
+            collectSpecifiedAndDescendantCategories(child, gathered);
+        }
+        gathered.add(specified);
     }
 
     /**

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
@@ -165,16 +165,11 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
                 Set<IPortletDefinition> filteredPortletDefinitions = new HashSet<>();
                 for (final IPortletDefinition portletDefinition : allDisplayablePortletDefinitions) {
                     final Set<PortletCategory> parents = portletCategoryRegistry.getParentCategories(portletDefinition);
-                    boolean includeIt = false;  // default
                     for (final PortletCategory parent : parents) {
                         if (allSpecifiedAndDecendantCategories.contains(parent)) {
-                            includeIt = true;
+                            filteredPortletDefinitions.add(portletDefinition);
                             break;
                         }
-                    }
-                    if (includeIt) {
-                        filteredPortletDefinitions.add(portletDefinition);
-                        break;
                     }
                 }
 

--- a/uportal-war/src/main/java/org/jasig/portal/rest/MarketplaceRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/MarketplaceRESTController.java
@@ -19,6 +19,7 @@
 package org.jasig.portal.rest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import org.jasig.portal.portlet.dao.IMarketplaceRatingDao;
 import org.jasig.portal.portlet.marketplace.IMarketplaceRating;
 import org.jasig.portal.portlet.marketplace.IMarketplaceService;
 import org.jasig.portal.portlet.marketplace.MarketplacePortletDefinition;
+import org.jasig.portal.portlet.om.PortletCategory;
 import org.jasig.portal.rest.layout.MarketplaceEntry;
 import org.jasig.portal.rest.layout.MarketplaceEntryRating;
 import org.jasig.portal.security.IPerson;
@@ -71,7 +73,8 @@ public class MarketplaceRESTController {
     public ModelAndView marketplaceEntriesFeed(HttpServletRequest request) {
         final IPerson user = personManager.getPerson(request);
 
-        Set<MarketplaceEntry> marketplaceEntries = marketplaceService.browseableMarketplaceEntriesFor(user);
+        final Set<PortletCategory> empty = Collections.emptySet();  // Produces an complete/unfiltered collection
+        final Set<MarketplaceEntry> marketplaceEntries = marketplaceService.browseableMarketplaceEntriesFor(user, empty);
 
         return new ModelAndView("json", "portlets", marketplaceEntries);
     }

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1314,11 +1314,17 @@
            eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
            timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
 
-    <!-- caches MarketplacePortletDefinitions by user.  not replicated.  This cache holds Futures that are
+    <!-- Caches MarketplacePortletDefinitions by user.  not replicated.  This cache holds Futures that are
         not serializable, so don't overflow to disk.  -->
     <cache name="org.jasig.portal.portlet.marketplace.MarketplaceService.marketplaceUserPortletDefinitionCache"
            eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
            timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+
+    <!-- Caches a few odds and ends related to limiting which categories are
+         displayed in a single publication of the Marketplace;  not replicated -->
+    <cache name="org.jasig.portal.portlet.marketplace.MarketplaceService.marketplaceCategoryCache"
+           eternal="false" maxElementsInMemory="20" overflowToDisk="false" diskPersistent="false"
+           timeToIdleSeconds="0" timeToLiveSeconds="600" memoryStoreEvictionPolicy="LRU" statistics="true" />
 
     
     <!-- ********************************************************** -->

--- a/uportal-war/src/main/webapp/WEB-INF/portlet.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/portlet.xml
@@ -151,6 +151,13 @@
                 <name>PortletMarketplaceController.enableReviews</name>
                 <value>true</value>
             </preference>
+            <!--
+             | Optional, multi-valued preference that restricts which
+             | portlets may be displayed in the Marketplace (portlet)
+             +-->
+            <preference>
+                <name>permittedCategories</name>
+            </preference>
         </portlet-preferences>
     </portlet>
 


### PR DESCRIPTION
…etplace portlet multiple times, targeting different portlets each time

https://issues.jasig.org/browse/UP-4570

This is an optional setting for the Marketplace portlet.

This enhancement covers 2 Marketplace scenarios:
* I want to publish 2 or more copies of the Marketplace portlet, each with it's own collection of portlets (based on category)
* I want to publish the Marketplace portlet 1 time, but I want to limit the portlets that appear in it (based on category)