### PR TITLE
UP-4577 Add grab handle for Move Portlet functionality

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -356,6 +356,18 @@
 
   <!-- This template renders portlet controls.  Each control has a unique class for assigning icons or other specific presentation. -->
   <xsl:template name="controls">
+      <xsl:variable name="PORTLET_LOCKED"> <!-- Test to determine if the portlet is locked in the layout. -->
+          <xsl:choose>
+              <xsl:when test="@dlm:moveAllowed='false'">locked</xsl:when>
+              <xsl:otherwise>movable</xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
+
+      <div class="portlet-controls">
+      <xsl:if test="$PORTLET_LOCKED='movable'">  <!-- Test to determine if the portlet is locked in the layout. -->
+          <div class="grab-handle hidden"><i class="fa fa-arrows"></i></div>
+      </xsl:if>
+
     <div class="portlet-options-menu btn-group hidden">  <!-- Start out hidden.  jQuery will unhide if there are menu options -->
       <a class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#"><xsl:value-of select="upMsg:getMessage('portlet.menu.option', $USER_LANG)"/> <span class="{upMsg:getMessage('portlet.menu.option.caretclass', $USER_LANG)}"></span></a>
       <ul class="dropdown-menu" style="right: 0; left: auto;">
@@ -396,33 +408,75 @@
           </li>
       </xsl:if>
 
-          <!-- Help Icon -->
-      <xsl:if test="$hasHelp='true'">
-        <xsl:variable name="portletHelpUrl">
-          <xsl:call-template name="portalUrl">
-            <xsl:with-param name="url">
-                <url:portal-url>
-                    <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="HELP" copyCurrentRenderParameters="true" />
-                </url:portal-url>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:variable>
-        <li>
-          <a href="{$portletHelpUrl}#{@ID}" title="{upMsg:getMessage('view.help.for.portlet', $USER_LANG)}" class="up-portlet-control help"><xsl:value-of select="upMsg:getMessage('help', $USER_LANG)"/></a>
-        </li>
-      </xsl:if>
+          <!-- Favorites -->
+          <xsl:if test="$hasFavorites='true'">
+              <xsl:choose>
+                  <xsl:when test="$isInFavorites!='true'"><!-- Add to favorite. -->
+                      <li>
+                          <a href="javascript:;" title="{upMsg:getMessage('add.this.portlet.to.my.favorite', $USER_LANG)}"
+                             class="addToFavoriteLink{@chanID}">
+                              <span><xsl:value-of select="upMsg:getMessage('add.to.my.favorites', $USER_LANG)"/></span>
+                          </a>
+                          <!-- used for the ajax call to add to favorites in up-favorite.js-->
+                          <script type="text/javascript">
+                              (function($) {
+                              $( document ).ready(function() {
+                              $('.addToFavoriteLink<xsl:value-of
+                              select="@chanID"/>').click({
+                              portletId : '<xsl:value-of select="@chanID"/>',
+                              context : '<xsl:value-of select="$CONTEXT_PATH"/>'}, up.addToFavorite);
+                              });
+                              })(up.jQuery);
+                          </script>
+                      </li>
+                  </xsl:when>
+                  <xsl:otherwise><!-- Remove From favorites. -->
+                      <li>
+                          <a href="javascript:;"
+                             title="{upMsg:getMessage('remove.this.portlet.from.my.favorite', $USER_LANG)}"
+                             class="removeFromFavoriteLink{@chanID}">
+                              <span><xsl:value-of select="upMsg:getMessage('remove.from.my.favorites', $USER_LANG)"/></span>
+                          </a>
+                          <!-- used for the ajax call to remove from favorites in up-favorite.js-->
+                          <script type="text/javascript">
+                              (function($) {
+                              $( document ).ready(function() {
+                              $('.removeFromFavoriteLink<xsl:value-of select="@chanID"/>').click({portletId : '<xsl:value-of select="@chanID"/>', context : '<xsl:value-of select="$CONTEXT_PATH"/>'}, up.removeFromFavorite);
+                              });
+                              })(up.jQuery);
+                          </script>
+                      </li>
+                  </xsl:otherwise>
+              </xsl:choose>
+          </xsl:if>
 
-      <!-- Remove Icon -->
-      <!-- note: deleteAllowed will either be false or not present if set from
+          <xsl:if test="$PORTLET_LOCKED='movable'">
+              <xsl:variable name="moveText"><xsl:value-of select="upMsg:getMessage('move.this.portlet', $USER_LANG)"/></xsl:variable>
+              <li>
+                  <a id="movePortlet_{@ID}" title="{$moveText}" href="#" class="up-portlet-control move" data-move-text="{$moveText}" data-cancel-move-text="{upMsg:getMessage('cancel.portlet.move', $USER_LANG)}"><xsl:value-of select="$moveText"/></a>
+              </li>
+          </xsl:if>
+
+          <!-- Add to Layout Icon -->
+          <xsl:if test="//focused[@in-user-layout='no'] and upGroup:isChannelDeepMemberOf(//focused/channel/@fname, 'local.1')"> <!-- Add to layout. -->
+              <li>
+                  <a id="focusedContentDialogLink" href="javascript:;"
+                     title="{upMsg:getMessage('add.this.portlet.to.my.layout', $USER_LANG)}" class="up-portlet-control add">
+                      <span><xsl:value-of select="upMsg:getMessage('add.to.my.layout', $USER_LANG)"/></span>
+                  </a>
+              </li>
+          </xsl:if>
+
+          <!-- Remove Icon -->
+          <!-- note: deleteAllowed will either be false or not present if set from
            the admin ui;  not certain the last (3rd) criteria is needed or
            appropriate -->
-      <xsl:if test="not(@dlm:deleteAllowed='false') and not(//focused) and not(/layout/navigation/tab[@activeTab='true']/@immutable='true')">
-        <!-- calls a layout api on click that removes the current node from the layout -->
-        <li>
-          <a id="removePortlet_{@ID}" title="{upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)}" href="#" class="up-portlet-control remove"><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></a>
-        </li>
-      </xsl:if>
+          <xsl:if test="not(@dlm:deleteAllowed='false') and not(//focused) and not(/layout/navigation/tab[@activeTab='true']/@immutable='true')">
+            <!-- calls a layout api on click that removes the current node from the layout -->
+            <li>
+              <a id="removePortlet_{@ID}" title="{upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)}" href="#" class="up-portlet-control remove"><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></a>
+            </li>
+          </xsl:if>
 
       <!-- Focus Icon -->
       <xsl:if test="not(//focused) and not(//layout_fragment) and @windowState!='minimized'">
@@ -496,23 +550,6 @@
           </xsl:if>
       </xsl:if>
 
-      <!-- About Icon -->
-      <xsl:if test="$hasAbout='true'">
-        <xsl:variable name="portletAboutUrl">
-          <xsl:call-template name="portalUrl">
-            <xsl:with-param name="url">
-                <url:portal-url>
-                    <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="ABOUT" copyCurrentRenderParameters="true" />
-                </url:portal-url>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:variable>
-        <li>
-          <a href="{$portletAboutUrl}#{@ID}" title="{upMsg:getMessage('view.information.about.portlet', $USER_LANG)}" class="up-portlet-control about"><xsl:value-of select="upMsg:getMessage('view.information.about.portlet', $USER_LANG)"/></a>
-        </li>
-      </xsl:if>
-
       <!-- Edit Icon -->
       <xsl:if test="$editable='true'">
         <xsl:variable name="portletEditUrl">
@@ -566,58 +603,41 @@
         </li>
       </xsl:if>
 
-      <!-- Add to Layout Icon -->
-      <xsl:if test="//focused[@in-user-layout='no'] and upGroup:isChannelDeepMemberOf(//focused/channel/@fname, 'local.1')"> <!-- Add to layout. -->
-        <li>
-            <a id="focusedContentDialogLink" href="javascript:;"
-            title="{upMsg:getMessage('add.this.portlet.to.my.layout', $USER_LANG)}" class="up-portlet-control add">
-                <span><xsl:value-of select="upMsg:getMessage('add.to.my.layout', $USER_LANG)"/></span>
-            </a>
-        </li>
-      </xsl:if>
-      <!-- Favorites -->
-      <xsl:if test="$hasFavorites='true'">
-          <xsl:choose>
-          <xsl:when test="$isInFavorites!='true'"><!-- Add to favorite. -->
-            <li>
-                <a href="javascript:;" title="{upMsg:getMessage('add.this.portlet.to.my.favorite', $USER_LANG)}"
-                class="addToFavoriteLink{@chanID}">
-                    <span><xsl:value-of select="upMsg:getMessage('add.to.my.favorites', $USER_LANG)"/></span>
-                </a>
-                    <!-- used for the ajax call to add to favorites in up-favorite.js-->
-                    <script type="text/javascript">
-                        (function($) {
-                            $( document ).ready(function() {
-                                $('.addToFavoriteLink<xsl:value-of
-                                    select="@chanID"/>').click({
-                                        portletId : '<xsl:value-of select="@chanID"/>',
-                                        context : '<xsl:value-of select="$CONTEXT_PATH"/>'}, up.addToFavorite);
-                             });
-                         })(up.jQuery);
-                    </script>
-            </li>
-          </xsl:when>
-          <xsl:otherwise><!-- Remove From favorites. -->
-            <li>
-                <a href="javascript:;"
-                   title="{upMsg:getMessage('remove.this.portlet.from.my.favorite', $USER_LANG)}"
-                   class="removeFromFavoriteLink{@chanID}">
-                    <span><xsl:value-of select="upMsg:getMessage('remove.from.my.favorites', $USER_LANG)"/></span>
-                </a>
-                <!-- used for the ajax call to remove from favorites in up-favorite.js-->
-                <script type="text/javascript">
-                    (function($) {
-                        $( document ).ready(function() {
-                            $('.removeFromFavoriteLink<xsl:value-of select="@chanID"/>').click({portletId : '<xsl:value-of select="@chanID"/>', context : '<xsl:value-of select="$CONTEXT_PATH"/>'}, up.removeFromFavorite);
-                        });
-                    })(up.jQuery);
-                </script>
-            </li>
-          </xsl:otherwise>
-          </xsl:choose>
-      </xsl:if>
-      
-        <xsl:if test="$IS_FRAGMENT_ADMIN_MODE='true'">
+          <!-- About Icon -->
+          <xsl:if test="$hasAbout='true'">
+              <xsl:variable name="portletAboutUrl">
+                  <xsl:call-template name="portalUrl">
+                      <xsl:with-param name="url">
+                          <url:portal-url>
+                              <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
+                              <url:portlet-url mode="ABOUT" copyCurrentRenderParameters="true" />
+                          </url:portal-url>
+                      </xsl:with-param>
+                  </xsl:call-template>
+              </xsl:variable>
+              <li>
+                  <a href="{$portletAboutUrl}#{@ID}" title="{upMsg:getMessage('view.information.about.portlet', $USER_LANG)}" class="up-portlet-control about"><xsl:value-of select="upMsg:getMessage('view.information.about.portlet', $USER_LANG)"/></a>
+              </li>
+          </xsl:if>
+
+          <!-- Help Icon -->
+          <xsl:if test="$hasHelp='true'">
+              <xsl:variable name="portletHelpUrl">
+                  <xsl:call-template name="portalUrl">
+                      <xsl:with-param name="url">
+                          <url:portal-url>
+                              <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
+                              <url:portlet-url mode="HELP" copyCurrentRenderParameters="true" />
+                          </url:portal-url>
+                      </xsl:with-param>
+                  </xsl:call-template>
+              </xsl:variable>
+              <li>
+                  <a href="{$portletHelpUrl}#{@ID}" title="{upMsg:getMessage('view.help.for.portlet', $USER_LANG)}" class="up-portlet-control help"><xsl:value-of select="upMsg:getMessage('help', $USER_LANG)"/></a>
+              </li>
+          </xsl:if>
+
+          <xsl:if test="$IS_FRAGMENT_ADMIN_MODE='true'">
           <li>
             <a class="up-portlet-control permissions portlet-permissions-link" href="javascript:;"
                title="{upMsg:getMessage('edit.permissions.for.this.portlet', $USER_LANG)}">
@@ -626,6 +646,7 @@
         </xsl:if>
         </ul>
     </div>
+  </div>
   </xsl:template>
   
   <xsl:template name="focused-fragment-header">

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -364,9 +364,14 @@
       </xsl:variable>
 
       <div class="portlet-controls">
-      <xsl:if test="$PORTLET_LOCKED='movable'">  <!-- Test to determine if the portlet is locked in the layout. -->
-          <div class="grab-handle hidden"><i class="fa fa-arrows"></i></div>
-      </xsl:if>
+          <!-- Test to determine if the portlet is locked in the layout. If not provide a grab handle the user could
+               see.  Otherwise, just provide an empty div for the grab-handle.  The 'grab-handle' class must be
+               present on every portlet else fluid will error when it encounters a portlet without the class. -->
+          <div class="grab-handle hidden">
+              <xsl:if test="$PORTLET_LOCKED='movable'">
+                  <i class="fa fa-arrows"></i>
+              </xsl:if>
+          </div>
 
     <div class="portlet-options-menu btn-group hidden">  <!-- Start out hidden.  jQuery will unhide if there are menu options -->
       <a class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#"><xsl:value-of select="upMsg:getMessage('portlet.menu.option', $USER_LANG)"/> <span class="{upMsg:getMessage('portlet.menu.option.caretclass', $USER_LANG)}"></span></a>

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -303,6 +303,19 @@
           // If portlet chrome is configured to not show (shows on hover) and the portlet is not movable, the portlet chrome
           // is hidden.  However if there are option items to display, allow the portlet chrome to show on hover.
           $('div.hover-toolbar').filter('.hidden').has('li').removeClass('hidden');
+
+          // Attach behavior to the Move Portlet options menu
+          $('.portlet-options-menu .up-portlet-control.move').click(function() {
+             // If Move Portlet, unhide the grab handle and change the menu text
+             if ($(this).text() === $(this).attr('data-move-text')) {
+                $(this).parents('.up-portlet-titlebar').find('.grab-handle').removeClass('hidden');
+                $(this).text($(this).attr('data-cancel-move-text'));
+             } else {
+                // Else cancel the move by hiding the grab handle and reverting the text
+                $(this).parents('.up-portlet-titlebar').find('.grab-handle').addClass('hidden');
+                $(this).text($(this).attr('data-move-text'));
+             }
+          })
       });
 
     })(up.jQuery);

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -102,6 +102,7 @@ cache.property=Cache Property
 cache.statistics=Cache Statistics
 campus.web=Campus Web
 cancel=Cancel
+cancel.portlet.move=Cancel move portlet
 caption=Caption
 categories=Categories
 categories.membership.which=Which categories {0} belongs to

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
@@ -537,7 +537,7 @@ var uportal = uportal || {};
 	                    modules: ".up-portlet-wrapper",
 	                    lockedModules: ".locked",
 	                    dropWarning: $("#portalDropWarning"),
-	                    grabHandle: "[id*=toolbar_]"
+	                    grabHandle: "[id*=toolbar_] .grab-handle"
 	                 },
 	                 listeners: {
 	                     afterMove: function(movedNode) {
@@ -553,6 +553,11 @@ var uportal = uportal || {};
 	                         }
 	                         var columns = $('#portalPageBodyColumns > [id^=column_]');
 	                         that.persistence.update({ action: 'movePortlet', method: method, elementID: up.defaultNodeIdExtractor(target), sourceID: up.defaultNodeIdExtractor(movedNode) });
+
+                             // Now revert the Move Portlet menu item and hide the grab handle
+                             var moveOptionsItem = $(movedNode).find(".up-portlet-control.move");
+                             moveOptionsItem.text(moveOptionsItem.attr('data-move-text'));
+                             $(movedNode).find(".up-portlet-titlebar .grab-handle").addClass('hidden');
 	                     }
 	                 },
 	                 styles: {

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -63,10 +63,6 @@
 
 .portlet-title {
     .border-radiuses-top(5px);
-
-    .btn-group {
-
-    }
 }
 
 .portlet-content {
@@ -132,7 +128,7 @@ section h4 {
         }
     }
 
-    .btn-group {
+    .portlet-controls {
         position: absolute;
         top: 2px;
         right: 0;
@@ -152,6 +148,12 @@ section h4 {
                     border-top-color: @portlet-options-link-hover-color;
                 }
             }
+        }
+
+        .grab-handle {
+            display: inline-block;
+            font-size: 18px;
+            margin-left: 3px;
         }
     }
 }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
@@ -45,7 +45,7 @@
                 }
             }
 
-            .btn-group {
+            .portlet-controls {
                 position: relative;
                 top: 0;
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4575

When using mobile web view on a mobile device, it is too easy to accidentally move portlets around when attempting to scroll vertically.  Add a drag handle activated on command.  Add a 'Move this portlet' to the options.

![image](https://cloud.githubusercontent.com/assets/1479823/11170596/77e822ce-8b96-11e5-9ec4-8418c1396db2.png)

When active, display grab handles and 'Cancel portlet move'.

![image](https://cloud.githubusercontent.com/assets/1479823/11170602/a30e8c54-8b96-11e5-99f8-93dd7e7bedc7.png)

Note: I also took the liberty of re-ordering the menu to a more logical flow, encouraging desired operations (rating, favoriting, adding to layout) on the top of the menu.
