### PR TITLE
UP-4578:  Portlet Manager -- provide a configuration setting to disab…

### DIFF
--- a/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
+++ b/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
@@ -117,6 +117,19 @@
             </single-choice-parameter-input>
         </parameter>
 
+        <parameter>
+            <name>disablePortletEvents</name>
+            <label>disable.portlet.events</label>
+            <description>
+                This portlet may not fire or receive events
+            </description>
+            <single-choice-parameter-input display="select">
+                <default>false</default>
+                <option value="false" label="false"/>
+                <option value="true" label="true"/>
+            </single-choice-parameter-input>
+        </parameter>
+
     </step>
 
 </portlet-publishing-definition>

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -168,6 +168,7 @@ description=Description
 deselect=De-select
 directory=Directory
 disable.dynamic.title=Disable Dynamic Title
+disable.portlet.events=Disable Portlet Events
 disk.store.object.count=Disk store object count
 display.icon.url=Display Icon URL
 display.mobile.icon.url=Display Mobile Icon URL


### PR DESCRIPTION
…le portlet events (inbound and outbound)

https://issues.jasig.org/browse/UP-4578

uPortal supports JSR-286 Portlet Events and provides a uportal-search-api component based on it.  It's working as designed, but there are circumstances where using it can place undue hardship on the server.

Portlet Events use portlet renderer threads to do their work.  If you have events with...
  - (1) org.jasig.portal.globalEvent (container option);  and
  - (2) large numbers (100+) of portlet definitions that support them

You have a recipe for performance issues.

Currently the only way to enable/disable support for events is in portlet.xml, which is per-project.  There are plenty of circumstances where you may want to use a portlet project that is event-capable but have no intention to use (or require in any way) the Portlet Event capabilities it implements.

This enhancement allows admins to disable event support on a per-definition (portlet-definition) basis.