### PR TITLE
UP-4586:  Resource Aggregation is broken in Respondr

### DIFF
--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -975,6 +975,24 @@
                 <version>${resource-server.version}</version>
                 <executions>
                     <execution>
+                        <id>aggregate-respondr-skins</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>batch-aggregate</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <displayJsWarnings>false</displayJsWarnings>
+                            <includes>
+                                <!-- Do we need to list skins individually
+                                     because we have common/ as a sibling of the
+                                     skins?  Do we need to move that directory? -->
+                                <include>media/skins/respondr/defaultSkin/skin.xml</include>
+                            </includes>
+                            <sharedJavaScriptDirectory>media/skins/respondr</sharedJavaScriptDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>aggregate-muniversality-skins</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
+++ b/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
@@ -117,6 +117,19 @@
             </single-choice-parameter-input>
         </parameter>
 
+        <parameter>
+            <name>disablePortletEvents</name>
+            <label>disable.portlet.events</label>
+            <description>
+                This portlet may not fire or receive events
+            </description>
+            <single-choice-parameter-input display="select">
+                <default>false</default>
+                <option value="false" label="false"/>
+                <option value="true" label="true"/>
+            </single-choice-parameter-input>
+        </parameter>
+
     </step>
 
 </portlet-publishing-definition>

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -168,6 +168,7 @@ description=Description
 deselect=De-select
 directory=Directory
 disable.dynamic.title=Disable Dynamic Title
+disable.portlet.events=Disable Portlet Events
 disk.store.object.count=Disk store object count
 display.icon.url=Display Icon URL
 display.mobile.icon.url=Display Mobile Icon URL


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4586

It looks as though a critical piece of the Resource Aggregation setup was omitted in Respondr: you have to use (apparently) the resource-server-plugin to aggregate the resources in the build process.
I have prepared a patch (will create a PR) – and have demonstrated that the patch makes aggregation in Respondr work as well as it did in Universality – but I'm confused as to why some resources get aggregated while others don't.
The uPortal JS in skins/common/javascript/uportal/ DOES get aggregated, but none of the other JS libs (e.g. jQuery, etc.) do, and none of the CSS does.