### PR TITLE
UP-4518 Add Lifecycle to portlet definition, rev portlet definition

### DIFF
--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -820,6 +820,9 @@
                         <include>io/subscribed-fragment/*.xsd</include>
                         <include>portlet-publishing/*.xsd</include>
                     </schemaIncludes>
+                    <schemaExcludes>
+                        <exclude>io/portlet-definition/portlet-definition-4.1.xsd</exclude>
+                    </schemaExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/uportal-war/src/main/binding/bindings.xjb
+++ b/uportal-war/src/main/binding/bindings.xjb
@@ -29,7 +29,7 @@
             <jaxb:package name="org.jasig.portal.io.xml" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
-    <jaxb:bindings schemaLocation="../resources/xsd/io/portlet-definition/portlet-definition-4.1.xsd">
+    <jaxb:bindings schemaLocation="../resources/xsd/io/portlet-definition/portlet-definition-4.3.xsd">
         <jaxb:bindings node="//xs:element[@name='portlet-definition']">
             <jaxb:class name="ExternalPortletDefinition"/>
         </jaxb:bindings>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/about-college-life.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/about-college-life.portlet-definition.xml
@@ -19,7 +19,7 @@
     under the License.
 
 -->
-<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.3" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.3.xsd">
     <title>About.com College Life</title>
     <name>About.com College Life</name>
     <fname>about-college-life</fname>
@@ -30,6 +30,10 @@
         <ns2:webAppName>/NewsReaderPortlet</ns2:webAppName>
         <ns2:portletName>news</ns2:portletName>
     </portlet-descriptor>
+    <lifecycle>
+        <approved user="system">2015-11-06T12:48:19.717-07:00</approved>
+        <published user="system">2015-11-06T12:48:19.717-07:00</published>
+    </lifecycle>
     <category>Entertainment</category>
     <category>News</category>
     <group>Everyone</group>

--- a/uportal-war/src/main/java/org/jasig/portal/UserInstance.java
+++ b/uportal-war/src/main/java/org/jasig/portal/UserInstance.java
@@ -26,7 +26,7 @@ import org.jasig.portal.user.IUserInstance;
 
 
 /**
- * A class handling holding all user state information. The class is also reponsible for
+ * A class handling holding all user state information. The class is also responsible for
  * request processing and orchestrating the entire rendering procedure.
  * (this is a replacement for the good old LayoutBean class)
  * @author Peter Kharchenko  {@link <a href="mailto:pkharchenko@interactivebusiness.com"">pkharchenko@interactivebusiness.com"</a>}

--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
@@ -368,7 +368,7 @@ public class PortletDefinitionImporterExporter
             if (username != null) {
                 return username;
             }
-            logger.warn("Invalid userID {} found when exporting a portlet; return system username instead");
+            logger.warn("Invalid userID {} found when exporting a portlet; return system username instead", id);
         }
         return systemUsername;
     }

--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
@@ -22,6 +22,7 @@ package org.jasig.portal.io.xml.portlet;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jasig.portal.EntityIdentifier;
+import org.jasig.portal.IUserIdentityStore;
 import org.jasig.portal.channel.IPortletPublishingService;
 import org.jasig.portal.groups.IEntity;
 import org.jasig.portal.groups.IEntityGroup;
@@ -55,6 +57,7 @@ import org.jasig.portal.portlet.om.IPortletDescriptorKey;
 import org.jasig.portal.portlet.om.IPortletPreference;
 import org.jasig.portal.portlet.om.IPortletType;
 import org.jasig.portal.portlet.om.PortletCategory;
+import org.jasig.portal.portlet.om.PortletLifecycleState;
 import org.jasig.portal.portlet.registry.IPortletCategoryRegistry;
 import org.jasig.portal.portlet.registry.IPortletTypeRegistry;
 import org.jasig.portal.security.*;
@@ -74,11 +77,16 @@ public class PortletDefinitionImporterExporter
         extends AbstractJaxbDataHandler<ExternalPortletDefinition> 
         implements IPortletPublishingService {
 
+
     private PortletPortalDataType portletPortalDataType;
     private IPortletTypeRegistry portletTypeRegistry;
     private IPortletDefinitionDao portletDefinitionDao;
     private IPortletCategoryRegistry portletCategoryRegistry;
+    private IUserIdentityStore userIdentityStore;
     private boolean errorOnChannel = true;
+
+    private IPerson systemUser = PersonFactory.createSystemPerson();
+    private String systemUsername = SystemPerson.INSTANCE.getUserName();
 
     @Value("${org.jasig.portal.io.errorOnChannel}")
 	public void setErrorOnChannel(boolean errorOnChannel) {
@@ -104,10 +112,15 @@ public class PortletDefinitionImporterExporter
     public void setPortletCategoryRegistry(IPortletCategoryRegistry portletCategoryRegistry) {
         this.portletCategoryRegistry = portletCategoryRegistry;
     }
-    
+
+    @Autowired
+    public void setUserIdentityStore(IUserIdentityStore identityStore) {
+        this.userIdentityStore = identityStore;
+    }
+
     @Override
     public Set<PortalDataKey> getImportDataKeys() {
-        return Collections.singleton(PortletPortalDataType.IMPORT_40_DATA_KEY);
+        return Collections.singleton(PortletPortalDataType.IMPORT_43_DATA_KEY);
     }
 
     @Override
@@ -227,15 +240,11 @@ public class PortletDefinitionImporterExporter
             def.setResourceTimeout(resourceTimeout.intValue());
         }
         def.setType(portletType);
-        
-        Date now = new Date();
-        IPerson systemUser = PersonFactory.createSystemPerson();
-        def.setApprovalDate(now);
-        def.setApproverId(systemUser.getID());
-        def.setPublishDate(now);
-        def.setPublisherId(systemUser.getID());     
-        
-        
+
+        handleLifecycleApproval(def, portletRep.getLifecycle());
+        handleLifecyclePublished(def, portletRep.getLifecycle());
+        handleLifecycleExpired(def, portletRep.getLifecycle());
+
         final Set<IPortletDefinitionParameter> parameters = new LinkedHashSet<IPortletDefinitionParameter>();
         for (ExternalPortletParameter param : portletRep.getParameters()) {
             parameters.add(new PortletDefinitionParameterImpl(param.getName(), param.getValue()));
@@ -256,14 +265,116 @@ public class PortletDefinitionImporterExporter
         }
         def.setPortletPreferences(preferenceList);
         
-        savePortletDefinition(def, PersonFactory.createSystemPerson(), categories, permissions);
+        savePortletDefinition(def, systemUser, categories, permissions);
+    }
+
+    // lifecycle not present: approved immediately
+    // lifecycle present, approval not present nor any later lifecycle: not approved (i.e created)
+    // lifecycle present, approval not present but later lifecycle is: approved at earliest later lifecycle datetime
+    // lifecycle present, approval specified: approved at indicated date
+    private void handleLifecycleApproval(IPortletDefinition def, Lifecycle lifecycle) {
+        if (lifecycle != null) {
+            if (lifecycle.getApproved() != null) {
+                LifecycleEntry lifecycleEntry = lifecycle.getApproved();
+                def.setApprovalDate(calculateEarliestApprovalDate(lifecycle));
+                def.setApproverId(getUserIdForUsername(lifecycleEntry.getUser(), def));
+            } else if (lifecycle.getPublished() != null || lifecycle.getExpiration() != null) {
+                def.setApprovalDate(calculateEarliestPubExpireDate(lifecycle));
+                def.setApproverId(systemUser.getID());
+            } else {
+                def.setApprovalDate(null);
+                def.setApproverId(-1);  // Using -1 to be consistent with PortletAdministrationHelper
+            }
+        } else {
+            def.setApprovalDate(new Date());
+            def.setApproverId(systemUser.getID());
+        }
+    }
+
+    // Handle improper data.  If the Approval date is after either the published or expire date, return the
+    // earlier of the latter two dates.
+    private Date calculateEarliestApprovalDate(Lifecycle lifecycle) {
+        Date publishOrExpireDate = calculateEarliestPubExpireDate(lifecycle);
+        return lifecycle.getApproved() != null
+                && publishOrExpireDate.after(lifecycle.getApproved().getValue().getTime()) ?
+                    lifecycle.getApproved().getValue().getTime() : publishOrExpireDate;
+    }
+
+    // Calculates the earliest of either the published Date or Expiration date, whichever is specified.
+    // If neither specified, returns current time.
+    private Date calculateEarliestPubExpireDate(Lifecycle lifecycle) {
+        Date now = new Date();
+        Date publishedDate = lifecycle.getPublished() != null && lifecycle.getPublished().getValue().before(now)?
+                lifecycle.getPublished().getValue().getTime() : now;
+        Date expiredDate = lifecycle.getExpiration() != null ? lifecycle.getExpiration().getValue().getTime() : now;
+        return publishedDate.after(expiredDate) ? expiredDate : publishedDate;
+    }
+
+    // lifecycle not present: published immediately
+    // lifecycle present, published not present nor any later lifecycle: not published
+    // lifecycle present, published not present but later lifecycle is: published at earliest later lifecycle datetime
+    // lifecycle present, published specified: published at indicated date
+    private void handleLifecyclePublished(IPortletDefinition def, Lifecycle lifecycle) {
+        if (lifecycle != null) {
+            if (lifecycle.getPublished() != null) {
+                LifecycleEntry lifecycleEntry = lifecycle.getPublished();
+                def.setPublishDate(calculateEarliestPubExpireDate(lifecycle));
+                def.setPublisherId(getUserIdForUsername(lifecycleEntry.getUser(), def));
+            } else if (lifecycle.getExpiration() != null) {
+                def.setPublishDate(calculateEarliestPubExpireDate(lifecycle));
+                def.setPublisherId(systemUser.getID());
+            } else {
+                def.setPublishDate(null);
+                def.setPublisherId(-1);  // Using -1 to be consistent with PortletAdministrationHelper
+            }
+        } else {
+            def.setPublishDate(new Date());
+            def.setPublisherId(systemUser.getID());
+        }
+    }
+
+    // lifecycle present and expired present: expired at indicated datetime
+    // else not expired
+    private void handleLifecycleExpired(IPortletDefinition def, Lifecycle lifecycle) {
+        if (lifecycle != null && lifecycle.getExpiration() != null) {
+            LifecycleEntry lifecycleEntry = lifecycle.getExpiration();
+            def.setExpirationDate(lifecycleEntry.getValue().getTime());
+            def.setExpirerId(getUserIdForUsername(lifecycleEntry.getUser(), def));
+        } else {
+            def.setExpirationDate(null);
+            def.setExpirerId(0);
+        }
+    }
+
+    // Returns the ID for the specified username or if not found the ID of the system user.
+    private int getUserIdForUsername (String username, IPortletDefinition def) {
+        if (username != null && !username.equals(systemUsername)) {
+            Integer id = userIdentityStore.getPortalUserId(username);
+            if (id != null) {
+                return id;
+            }
+            logger.warn("Invalid username {} in portlet lifecycle for fname={}, defaulting to system user",
+                    username, def.getFName());
+        }
+        // Note this returns 0 consistent with prior import behavior, not the id in the database.
+        // todo: Figure out if we should instead return the id of the system user in the DB
+        return systemUser.getID();
+    }
+
+    // Returns the username for a valid userId, else the system username
+    private String getUsernameForUserId(int id) {
+        if (id > 0) {
+            String username = userIdentityStore.getPortalUserName(id);
+            if (username != null) {
+                return username;
+            }
+            logger.warn("Invalid userID {} found when exporting a portlet; return system username instead");
+        }
+        return systemUsername;
     }
 
     /**
      * {@link String} id argument is treated as the portlet fname.
-     * 
-     * (non-Javadoc)
-     * @see org.jasig.portal.io.xml.IDataImporter#deleteData(java.lang.String)
      */
     @Transactional
     @Override
@@ -434,6 +545,13 @@ public class PortletDefinitionImporterExporter
         return BigInteger.valueOf(i);
     }
 
+    // Utility method to convert a date to a calendar.
+    private static Calendar getCalendar(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        return calendar;
+    }
+
     protected ExternalPortletDefinition convert(IPortletDefinition def) {
         ExternalPortletDefinition rep = new ExternalPortletDefinition();
          
@@ -447,6 +565,28 @@ public class PortletDefinitionImporterExporter
         rep.setResourceTimeout(convertToBigInteger(def.getResourceTimeout()));
         rep.setTitle(def.getTitle());
         rep.setType(def.getType().getName());
+
+        if (def.getLifecycleState().isEqualToOrAfter(PortletLifecycleState.APPROVED)) {
+            Lifecycle lifecycle = new Lifecycle();
+            LifecycleEntry approved = new LifecycleEntry();
+            approved.setUser(getUsernameForUserId(def.getApproverId()));
+            approved.setValue(getCalendar(def.getApprovalDate()));
+            lifecycle.setApproved(approved);
+            if (def.getLifecycleState().isEqualToOrAfter(PortletLifecycleState.PUBLISHED)) {
+                LifecycleEntry published = new LifecycleEntry();
+                published.setUser(getUsernameForUserId(def.getPublisherId()));
+                published.setValue(getCalendar(def.getPublishDate()));
+                lifecycle.setPublished(published);
+            }
+            if (def.getLifecycleState().isEqualToOrAfter(PortletLifecycleState.EXPIRED)) {
+                LifecycleEntry expired = new LifecycleEntry();
+                expired.setUser(getUsernameForUserId(def.getExpirerId()));
+                expired.setValue(getCalendar(def.getExpirationDate()));
+                lifecycle.setExpiration(expired);
+            }
+            // Maintenance mode is handled via a portlet publishing parameter and not a lifecycle
+            rep.setLifecycle(lifecycle);
+        }
          
          
         final org.jasig.portal.xml.PortletDescriptor portletDescriptor = new org.jasig.portal.xml.PortletDescriptor();

--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletPortalDataType.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletPortalDataType.java
@@ -44,11 +44,20 @@ public class PortletPortalDataType extends AbstractPortalDataType {
     @Deprecated
     public static final QName LEGACY_CHANNEL_DEFINITION_QNAME = new QName("channel-definition");
     
-    public static final PortalDataKey IMPORT_40_DATA_KEY = new PortalDataKey(
+    public static final PortalDataKey IMPORT_43_DATA_KEY = new PortalDataKey(
             PORTLET_DEFINITION_QNAME, 
             null,
+            "4.3");
+
+    /**
+     * @deprecated used for importing old data files
+     */
+    @Deprecated
+    public static final PortalDataKey IMPORT_40_DATA_KEY = new PortalDataKey(
+            PORTLET_DEFINITION_QNAME,
+            null,
             "4.0");
-    
+
     /**
      * @deprecated used for importing old data files
      */
@@ -85,7 +94,7 @@ public class PortletPortalDataType extends AbstractPortalDataType {
             "classpath://org/jasig/portal/io/import-channel_v3-2.crn",
             null);
 
-    private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_26_DATA_KEY, IMPORT_30_DATA_KEY, IMPORT_31_DATA_KEY, IMPORT_32_DATA_KEY, IMPORT_40_DATA_KEY);
+    private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_26_DATA_KEY, IMPORT_30_DATA_KEY, IMPORT_31_DATA_KEY, IMPORT_32_DATA_KEY, IMPORT_40_DATA_KEY, IMPORT_43_DATA_KEY);
     
     public PortletPortalDataType() {
         super(PORTLET_DEFINITION_QNAME);

--- a/uportal-war/src/main/java/org/jasig/portal/security/SystemPerson.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/SystemPerson.java
@@ -32,6 +32,7 @@ public final class SystemPerson implements IPerson {
     private static final long serialVersionUID = 1L;
     
     public static final IPerson INSTANCE = new SystemPerson();
+    private static final String USERNAME = "system";
 
     /* (non-Javadoc)
      * @see java.security.Principal#getName()
@@ -70,7 +71,7 @@ public final class SystemPerson implements IPerson {
      */
     @Override
     public String getUserName() {
-        return "system";
+        return USERNAME;
     }
 
     /* (non-Javadoc)

--- a/uportal-war/src/main/resources/org/jasig/portal/io/xml/portlet/upgradePortlet_40.xsl
+++ b/uportal-war/src/main/resources/org/jasig/portal/io/xml/portlet/upgradePortlet_40.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+                xmlns:portlet="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+                xmlns:ns2="https://source.jasig.org/schemas/uportal">
+
+    <xsl:output indent="yes"/>
+
+    <xsl:template match="/">
+        <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.3.xsd"
+                            version="4.3">
+
+            <!-- 4.3 is backwards-compatible with 4.0. It just has some optional additional features. -->
+            <xsl:apply-templates select="*"/>
+        </portlet-definition>
+    </xsl:template>
+    <xsl:template match="portlet:portlet-definition">
+        <xsl:copy-of select="child::*"/>
+    </xsl:template>
+</xsl:stylesheet>

--- a/uportal-war/src/main/resources/properties/contexts/importExportContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/importExportContext.xml
@@ -142,8 +142,8 @@
      +-->
     <bean id="portletDefinitionImporterExporter" class="org.jasig.portal.io.xml.portlet.PortletDefinitionImporterExporter">
         <property name="contextPath" value="org.jasig.portal.io.xml.portlet" />
-        <property name="schema" value="classpath:/xsd/io/portlet-definition/portlet-definition-4.1.xsd" />
-        <property name="schemaLocation" value="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd" />
+        <property name="schema" value="classpath:/xsd/io/portlet-definition/portlet-definition-4.3.xsd" />
+        <property name="schemaLocation" value="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.3.xsd" />
     </bean>
     <bean id="portletTypeImporterExporter" class="org.jasig.portal.io.xml.portlettype.PortletTypeImporterExporter">
         <property name="contextPath" value="org.jasig.portal.io.xml.portlettype" />
@@ -345,6 +345,14 @@
             </set>
         </property>
         <property name="xslResource" value="classpath:/org/jasig/portal/io/xml/portlet/upgradeChannel_32.xsl" />
+    </bean>
+    <bean id="portlet40DataUpgrader" class="org.jasig.portal.io.xml.XsltDataUpgrader">
+        <property name="portalDataKeys">
+            <set>
+                <util:constant static-field="org.jasig.portal.io.xml.portlet.PortletPortalDataType.IMPORT_40_DATA_KEY"/>
+            </set>
+        </property>
+        <property name="xslResource" value="classpath:/org/jasig/portal/io/xml/portlet/upgradePortlet_40.xsl" />
     </bean>
     <bean id="subscribedFragment32DataUpgrader" class="org.jasig.portal.io.xml.XsltDataUpgrader">
         <property name="portalDataKeys">

--- a/uportal-war/src/main/resources/xsd/io/common-io-types-4.0.xsd
+++ b/uportal-war/src/main/resources/xsd/io/common-io-types-4.0.xsd
@@ -47,4 +47,18 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+
+    <xs:complexType name="basePortalDataType43" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all 4.3 version data descriptor files. A copy of this type should be
+                created for each minor release of uPortal with the version field appropriately incremented.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="basePortalDataType">
+                <xs:attribute name="version" type="xs:string" use="required" fixed="4.3" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 </xs:schema>

--- a/uportal-war/src/main/resources/xsd/io/portlet-definition/portlet-definition-4.3.xsd
+++ b/uportal-war/src/main/resources/xsd/io/portlet-definition/portlet-definition-4.3.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<xs:schema
+    xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+    targetNamespace="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:up="https://source.jasig.org/schemas/uportal"
+    xmlns:io="https://source.jasig.org/schemas/uportal/io"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+
+    <xs:import namespace="https://source.jasig.org/schemas/uportal" schemaLocation="../../common-types-4.0.xsd"/>
+    <xs:import namespace="https://source.jasig.org/schemas/uportal/io" schemaLocation="../common-io-types-4.0.xsd"/>
+
+    <xs:element name="portlet-definition">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="io:basePortalDataType43">
+                    <xs:sequence>
+                        <xs:element name="title" type="xs:string"/>
+                        <!-- 'title' is the value that will be displayed in the portlet chrome and in
+                            navigation menus.  'name' is intended primarily for internal or admin usage.
+                            'name' can be used to distinguish between similar portlets that may share a title. -->
+                        <xs:element name="name" type="xs:string"/>
+                        <xs:element name="fname" type="up:fname-type"/>
+                        <xs:element name="desc" type="xs:string" minOccurs="0"/>
+                        <xs:element name="type" type="xs:string"/>
+                        <xs:element name="timeout" type="xs:positiveInteger"/>
+                        <xs:element name="actionTimeout" type="xs:positiveInteger" minOccurs="0"/>
+                        <xs:element name="eventTimeout" type="xs:positiveInteger" minOccurs="0"/>
+                        <xs:element name="renderTimeout" type="xs:positiveInteger" minOccurs="0"/>
+                        <xs:element name="resourceTimeout" type="xs:positiveInteger" minOccurs="0"/>
+                        
+                        <xs:element name="portlet-descriptor" type="up:portlet-descriptor"/>
+                        <xs:element name="lifecycle" type="lifecycle" minOccurs="0" maxOccurs="1"/>
+
+                        <xs:element name="category" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="group" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="user" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="permissions" type="externalPermissions" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="parameter" type="externalPortletParameter" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="portlet-preference" type="externalPortletPreference" minOccurs="0"
+                            maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+        <xs:unique name="unique-category">
+            <xs:selector xpath="category"/>
+            <xs:field xpath="."/>
+        </xs:unique>
+        <xs:unique name="unique-group">
+            <xs:selector xpath="group"/>
+            <xs:field xpath="."/>
+        </xs:unique>
+        <xs:unique name="unique-user">
+            <xs:selector xpath="user"/>
+            <xs:field xpath="."/>
+        </xs:unique>
+        <xs:unique name="unique-parameter">
+            <xs:selector xpath="parameter"/>
+            <xs:field xpath="name"/>
+        </xs:unique>
+        <xs:unique name="unique-preference">
+            <xs:selector xpath="portlet-preference"/>
+            <xs:field xpath="name"/>
+        </xs:unique>
+        <xs:unique name="unique-permission-group">
+            <xs:selector xpath="permissions/permission/group"/>
+            <xs:field xpath="group"/>
+        </xs:unique>
+    </xs:element>
+
+    <!-- Lifecycle is new with uPortal 4.3. If lifecycle is specified without child elements, the portlet
+         is created at the created lifecycle. -->
+    <xs:complexType name="lifecycle">
+        <xs:sequence>
+            <xs:element name="approved" type="lifecycleEntry" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="published" type="lifecycleEntry" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="expiration" type="lifecycleEntry" minOccurs="0" maxOccurs="1"/>
+            <!-- Maintenance mode is represented with a publishing parameter
+                 PortletLifecycleState.inMaintenanceMode=true. See PortletAdministrationHelper.java -->
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="lifecycleEntry">
+        <xs:simpleContent>
+            <!-- Date-time of the format [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]; see http://books.xmlschemata.org/relaxng/ch19-77049.html -->
+            <xs:extension base="xs:dateTime">
+                <!-- user attribute is optional. -->
+                <xs:attribute name="user" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="externalPortletParameter">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+            <xs:element name="description" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="externalPortletPreference">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+            <xs:element name="readOnly" type="xs:boolean" default="false" minOccurs="0"/>
+            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Portlet specific grants:
+      - system:  The permission manager name
+      - activity: The name of the permission to grant
+      - group:  the list of groups that will be granted the permission
+      -->
+    <xs:complexType name="externalPermissionMemberList">
+        <xs:sequence>
+            <xs:element name="group" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="system" type="xs:string" use="required"/>
+        <xs:attribute name="activity" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <!-- optional top level permissions tag -->
+    <xs:complexType name="externalPermissions">
+        <xs:sequence>
+            <xs:element name="permission" type="externalPermissionMemberList" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/uportal-war/src/test/java/org/jasig/portal/io/xml/BaseXsltDataUpgraderTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/io/xml/BaseXsltDataUpgraderTest.java
@@ -107,6 +107,7 @@ public abstract class BaseXsltDataUpgraderTest {
         }
 
         XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setNormalizeWhitespace(true);
         try {
             Diff d = new Diff(new InputStreamReader(expectedResultResource.getInputStream()), new StringReader(resultString));
             assertTrue("Upgraded data doesn't match expected data: " + d, d.similar());

--- a/uportal-war/src/test/java/org/jasig/portal/io/xml/portlet/PortletDataUpgradeTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/io/xml/portlet/PortletDataUpgradeTest.java
@@ -19,10 +19,8 @@
 package org.jasig.portal.io.xml.portlet;
 
 import org.jasig.portal.io.xml.BaseXsltDataUpgraderTest;
-import org.jasig.portal.io.xml.XmlTestException;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
-import org.xml.sax.SAXParseException;
 
 /**
  * @author Eric Dalquist
@@ -84,7 +82,17 @@ public class PortletDataUpgradeTest extends BaseXsltDataUpgraderTest {
                 new ClassPathResource("/org/jasig/portal/io/xml/portlet/test-portlet-1_32-40_expected.channel.xml"),
                 new ClassPathResource("/xsd/io/portlet-definition/portlet-definition-4.1.xsd"));
     }
-    
+
+    @Test
+    public void testUpgradeTestPortlet40to43() throws Exception {
+        testXsltUpgrade(
+                new ClassPathResource("/org/jasig/portal/io/xml/portlet/upgradePortlet_40.xsl"),
+                PortletPortalDataType.IMPORT_40_DATA_KEY,
+                new ClassPathResource("/org/jasig/portal/io/xml/portlet/test-portlet-1_40.portlet-definitionl.xml"),
+                new ClassPathResource("/org/jasig/portal/io/xml/portlet/test-portlet-1_40-43_expected.portlet-definition.xml"),
+                new ClassPathResource("/xsd/io/portlet-definition/portlet-definition-4.3.xsd"));
+    }
+
     @Test
     public void testUpgradeGroupsManagerChannel26to30() throws Exception {
         testXsltUpgrade(

--- a/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test-portlet-1_40-43_expected.portlet-definition.xml
+++ b/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test-portlet-1_40-43_expected.portlet-definition.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:ns2="https://source.jasig.org/schemas/uportal"
+                    xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.3.xsd" version="4.3">
+    <title>Test Portlet 1</title>
+    <name>Test Portlet 1</name>
+    <fname>test-portlet-1</fname>
+    <desc>Test portlet 1 from Apache Pluto</desc>
+    <type>Portlet</type>
+    <timeout>600000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/pluto-testsuite</ns2:webAppName>
+        <ns2:portletName>TestPortlet1</ns2:portletName>
+    </portlet-descriptor>
+    <category>Development</category>
+    <group>Everyone</group>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>secure</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>locale</name>
+        <value>false</value>
+    </parameter>
+    <portlet-preference>
+        <name>TestName4</name>
+        <readOnly>true</readOnly>
+        <value>TestValue4</value>
+    </portlet-preference>
+    <portlet-preference>
+        <name>cdata</name>
+        <readOnly>true</readOnly>
+        <value>
+            &lt;div&gt;To preview My UW-Madison, use one of these example accounts:&lt;/div&gt;
+            &lt;table&gt;
+                &lt;tbody&gt;
+                    &lt;tr&gt;
+                        &lt;td&gt;
+                            &lt;form action="/portal/Login" method="post"&gt;
+                                &lt;input value="admin" name="userName" type="hidden"/&gt;
+                                &lt;input value="admin" name="password" type="hidden"/&gt;
+                                &lt;input value="Login as a 'admin'" name="Login" class="uportal-button" type="submit"/&gt;
+                            &lt;/form&gt;
+                        &lt;/td&gt;
+                    &lt;/tr&gt;
+                    &lt;tr&gt;
+                        &lt;td&gt;
+                            &lt;form action="/portal/Login" method="post"&gt;
+                                &lt;input value="staff" name="userName" type="hidden"/&gt;
+                                &lt;input value="staff" name="password" type="hidden"/&gt;
+                                &lt;input value="Login as an 'staff'" name="Login" class="uportal-button" type="submit"/&gt;
+                            &lt;/form&gt;
+                        &lt;/td&gt;
+                    &lt;/tr&gt;
+                    &lt;tr&gt;
+                        &lt;td&gt;
+                            &lt;form action="/portal/Login" method="post"&gt;
+                                &lt;input value="student" name="userName" type="hidden"/&gt;
+                                &lt;input value="student" name="password" type="hidden"/&gt;
+                                &lt;input value="Login as an 'student'" name="Login" class="uportal-button" type="submit"/&gt;
+                            &lt;/form&gt;
+                        &lt;/td&gt;
+                    &lt;/tr&gt;
+                    &lt;tr&gt;
+                        &lt;td&gt;
+                            &lt;form action="/portal/Login" method="post"&gt;
+                                &lt;input value="faculty" name="userName" type="hidden"/&gt;
+                                &lt;input value="faculty" name="password" type="hidden"/&gt;
+                                &lt;input value="Login as an 'faculty'" name="Login" class="uportal-button" type="submit"/&gt;
+                            &lt;/form&gt;
+                        &lt;/td&gt;
+                    &lt;/tr&gt;
+                &lt;/tbody&gt;
+            &lt;/table&gt;
+        </value>
+
+    </portlet-preference>
+</portlet-definition>

--- a/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test-portlet-1_40.portlet-definitionl.xml
+++ b/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test-portlet-1_40.portlet-definitionl.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:ns2="https://source.jasig.org/schemas/uportal"
+                    xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd" version="4.0">
+    <title>Test Portlet 1</title>
+    <name>Test Portlet 1</name>
+    <fname>test-portlet-1</fname>
+    <desc>Test portlet 1 from Apache Pluto</desc>
+    <type>Portlet</type>
+    <timeout>600000</timeout>
+    <portlet-descriptor>
+        <ns2:webAppName>/pluto-testsuite</ns2:webAppName>
+        <ns2:portletName>TestPortlet1</ns2:portletName>
+    </portlet-descriptor>
+    <category>Development</category>
+    <group>Everyone</group>
+    <parameter>
+        <name>editable</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasHelp</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>hasAbout</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>secure</name>
+        <value>false</value>
+    </parameter>
+    <parameter>
+        <name>locale</name>
+        <value>false</value>
+    </parameter>
+    <portlet-preference> 
+        <name>TestName4</name>
+        <readOnly>true</readOnly>
+        <value>TestValue4</value>
+    </portlet-preference>
+    <portlet-preference> 
+        <name>cdata</name>
+        <readOnly>true</readOnly>
+        <value>
+            &lt;div&gt;To preview My UW-Madison, use one of these example accounts:&lt;/div&gt;
+            &lt;table&gt;
+            &lt;tbody&gt;
+              &lt;tr&gt;
+                &lt;td&gt;
+                  &lt;form action="/portal/Login" method="post"&gt;
+                    &lt;input value="admin" name="userName" type="hidden"/&gt;
+                    &lt;input value="admin" name="password" type="hidden"/&gt;
+                    &lt;input value="Login as a 'admin'" name="Login" class="uportal-button" type="submit"/&gt;
+                  &lt;/form&gt;
+                &lt;/td&gt;
+               &lt;/tr&gt;
+               &lt;tr&gt;
+                &lt;td&gt;
+                  &lt;form action="/portal/Login" method="post"&gt;
+                    &lt;input value="staff" name="userName" type="hidden"/&gt;
+                    &lt;input value="staff" name="password" type="hidden"/&gt;
+                    &lt;input value="Login as an 'staff'" name="Login" class="uportal-button" type="submit"/&gt;
+                  &lt;/form&gt;
+                &lt;/td&gt;
+              &lt;/tr&gt;
+               &lt;tr&gt;
+                &lt;td&gt;
+                  &lt;form action="/portal/Login" method="post"&gt;
+                    &lt;input value="student" name="userName" type="hidden"/&gt;
+                    &lt;input value="student" name="password" type="hidden"/&gt;
+                    &lt;input value="Login as an 'student'" name="Login" class="uportal-button" type="submit"/&gt;
+                  &lt;/form&gt;
+                &lt;/td&gt;
+              &lt;/tr&gt;
+               &lt;tr&gt;
+                &lt;td&gt;
+                  &lt;form action="/portal/Login" method="post"&gt;
+                    &lt;input value="faculty" name="userName" type="hidden"/&gt;
+                    &lt;input value="faculty" name="password" type="hidden"/&gt;
+                    &lt;input value="Login as an 'faculty'" name="Login" class="uportal-button" type="submit"/&gt;
+                  &lt;/form&gt;
+                &lt;/td&gt;
+              &lt;/tr&gt;
+            &lt;/tbody&gt;
+            &lt;/table&gt;
+        </value>
+       
+    </portlet-preference>
+</portlet-definition>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4518

Add support for optional lifecycle element.  In a portlet definition, you can add a lifecycle element:

Bumped portlet-definition to 4.3.  Added optional lifecycle element:

```xml
    <lifecycle>
        <approved>2015-11-06T12:48:19.717-07:00</approved>
        <published user="admin">2015-11-06T12:48:19.717-07:00</published>
        <expiration user="admin">2015-12-16T12:48:19.717-07:00</expiration>
    </lifecycle>
```
* lifecycle with no children: created
* user is optional, defaults to system
* expiration can be in the past (expired) or future (scheduled expiration)
* prior elements not necessary; e.g. can specify just published and approved will be defaulted appropriately

