### PR TITLE
UP-4549: DLM - Allow Fragment Owners to alter fragments that have DLM restrictions

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -160,15 +160,6 @@
       </xsl:choose>
     </xsl:variable>
 
-    <!-- Applied in the case of DLM fragment owners only;  tells the UI to
-         permit the fragment admin to manage content even when it it locked. -->
-    <xsl:variable name="FRAGMENT_OWNER_CSS">
-      <xsl:choose>
-        <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
-        <xsl:otherwise></xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-
     <xsl:variable name="PORTLET_CHROME"> <!-- Test to determine if the portlet has been given the highlight flag. -->
       <xsl:choose>
         <xsl:when test="./parameter[@name='chromeStyle']/@value='no-chrome'">no-chrome</xsl:when>

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -151,6 +151,15 @@
       </xsl:choose>
     </xsl:variable>
 
+    <!-- Applied in the case of DLM fragment owners only;  tells the UI to
+         permit the fragment admin to manage content even when it it locked. -->
+    <xsl:variable name="FRAGMENT_OWNER_CSS">
+      <xsl:choose>
+        <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
     <xsl:variable name="PORTLET_CHROME"> <!-- Test to determine if the portlet has been given the highlight flag. -->
       <xsl:choose>
         <xsl:when test="./parameter[@name='chromeStyle']/@value='no-chrome'">no-chrome</xsl:when>
@@ -177,7 +186,7 @@
 
     <!-- ****** PORTLET CONTAINER ****** -->
     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
-    <section id="portlet_{@ID}" class="up-portlet-wrapper {@fname} {$PORTLET_LOCKED} {$DELETABLE} {$PORTLET_CHROME} {$PORTLET_ALTERNATE} {$PORTLET_HIGHLIGHT}"> <!-- Main portlet container.  The unique ID is needed for drag and drop.  The portlet fname is also written into the class attribute to allow for unique rendering of the portlet presentation. -->
+    <section id="portlet_{@ID}" class="up-portlet-wrapper {@fname} {$PORTLET_LOCKED} {$DELETABLE} {$FRAGMENT_OWNER_CSS} {$PORTLET_CHROME} {$PORTLET_ALTERNATE} {$PORTLET_HIGHLIGHT}"> <!-- Main portlet container.  The unique ID is needed for drag and drop.  The portlet fname is also written into the class attribute to allow for unique rendering of the portlet presentation. -->
 
     <!-- Start of the Marketplace Modal Section -->
         <xsl:variable name="saveRatingPortletUrl">
@@ -194,7 +203,7 @@
                 </xsl:with-param>
             </xsl:call-template>
         </xsl:variable>
-        
+
       <xsl:variable name="getRatingPortletUrl">
             <xsl:call-template name="portalUrl">
                 <xsl:with-param name="url">
@@ -364,13 +373,11 @@
       </xsl:variable>
 
       <div class="portlet-controls">
-          <!-- Test to determine if the portlet is locked in the layout. If not provide a grab handle the user could
-               see.  Otherwise, just provide an empty div for the grab-handle.  The 'grab-handle' class must be
-               present on every portlet else fluid will error when it encounters a portlet without the class. -->
+          <!-- The 'grab-handle' class must be present on every portlet else fluid
+               will error when it encounters a portlet without the class.  Grab
+               handles for locked portlets will remain hidden. -->
           <div class="grab-handle hidden">
-              <xsl:if test="$PORTLET_LOCKED='movable'">
-                  <i class="fa fa-arrows"></i>
-              </xsl:if>
+              <i class="fa fa-arrows"></i>
           </div>
 
     <div class="portlet-options-menu btn-group hidden">  <!-- Start out hidden.  jQuery will unhide if there are menu options -->
@@ -455,7 +462,7 @@
               </xsl:choose>
           </xsl:if>
 
-          <xsl:if test="$PORTLET_LOCKED='movable'">
+          <xsl:if test="$PORTLET_LOCKED='movable' or $IS_FRAGMENT_ADMIN_MODE='true'">
               <xsl:variable name="moveText"><xsl:value-of select="upMsg:getMessage('move.this.portlet', $USER_LANG)"/></xsl:variable>
               <li>
                   <a id="movePortlet_{@ID}" title="{$moveText}" href="javascript:void(0);" class="up-portlet-control move" data-move-text="{$moveText}" data-cancel-move-text="{upMsg:getMessage('cancel.portlet.move', $USER_LANG)}"><xsl:value-of select="$moveText"/></a>
@@ -653,7 +660,7 @@
     </div>
   </div>
   </xsl:template>
-  
+
   <xsl:template name="focused-fragment-header">
     <xsl:if test="//tab[@focusedFragment='true']">
         <div id="focused-fragment-header" class="container">

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -116,7 +116,16 @@
           </xsl:choose>
         </xsl:variable>
 
-        <div id="column_{@ID}" class="portal-page-column {$POSITION_CSS_CLASS} {$WIDTH_CSS_CLASS} {$MOVABLE} {$DELETABLE} {$EDITABLE} {$CAN_ADD_CHILDREN}"> <!-- Unique column_ID needed for drag and drop. -->
+        <!-- Applied in the case of DLM fragment owners only;  tells the UI to
+             permit the fragment admin to manage content even when it it locked. -->
+        <xsl:variable name="FRAGMENT_OWNER_CSS">
+          <xsl:choose>
+            <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
+            <xsl:otherwise></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+
+        <div id="column_{@ID}" class="portal-page-column {$POSITION_CSS_CLASS} {$WIDTH_CSS_CLASS} {$MOVABLE} {$DELETABLE} {$EDITABLE} {$CAN_ADD_CHILDREN} {$FRAGMENT_OWNER_CSS}"> <!-- Unique column_ID needed for drag and drop. -->
           <div id="inner-column_{@ID}" class="portal-page-column-inner"> <!-- Column inner div for additional presentation/formatting options.  -->
             <xsl:if test="$IS_FRAGMENT_ADMIN_MODE='true'">
                 <div class="column-permissions"><a class="button portal-column-permissions-link" href="javascript:;"><span class="icon permissions"></span><xsl:value-of select="upMsg:getMessage('edit.column.x.permissions', $USER_LANG, $NUMBER)"/></a></div>
@@ -479,15 +488,15 @@
               </li>
           </xsl:if>
 
-          <!-- Remove Icon -->
-          <!-- note: deleteAllowed will either be false or not present if set from
-           the admin ui;  not certain the last (3rd) criteria is needed or
-           appropriate -->
-          <xsl:if test="not(@dlm:deleteAllowed='false') and not(//focused) and not(/layout/navigation/tab[@activeTab='true']/@immutable='true')">
-            <!-- calls a layout api on click that removes the current node from the layout -->
-            <li>
-              <a id="removePortlet_{@ID}" title="{upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)}" href="javascript:void(0);" class="up-portlet-control remove"><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></a>
-            </li>
+          <!-- 'Remove' Menu Option -->
+          <!-- note: deleteAllowed will either be false or not present if set from the admin ui -->
+          <xsl:if test="not(@dlm:deleteAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
+            <xsl:if test="not(//focused)"><!-- Don't offer 'Remove' in MAXIMIZED window state -->
+              <!-- calls a layout api on click that removes the current node from the layout -->
+              <li>
+                <a id="removePortlet_{@ID}" title="{upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)}" href="javascript:void(0);" class="up-portlet-control remove"><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></a>
+              </li>
+            </xsl:if>
           </xsl:if>
 
       <!-- Focus Icon -->

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -179,6 +179,14 @@
         <xsl:otherwise></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
+    <!-- Applied in the case of DLM fragment owners only;  tells the UI to
+         permit the fragment admin to manage content even when it it locked. -->
+    <xsl:variable name="FRAGMENT_OWNER_CSS">
+      <xsl:choose>
+        <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:variable name="NAV_TRANSIENT">
       <xsl:choose>
         <xsl:when test="@transient='true'">disabled</xsl:when>
@@ -233,7 +241,7 @@
             <xsl:otherwise></xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <li id="portalNavigation_{@ID}" class="portal-navigation {$NAV_POSITION} {$NAV_ACTIVE} {$NAV_MOVABLE} {$NAV_EDITABLE} {$NAV_DELETABLE} {$NAV_CAN_ADD_CHILDREN}"> <!-- Each navigation menu item.  The unique ID can be used in the CSS to give each menu item a unique icon, color, or presentation. -->
+    <li id="portalNavigation_{@ID}" class="portal-navigation {$NAV_POSITION} {$NAV_ACTIVE} {$NAV_MOVABLE} {$NAV_EDITABLE} {$NAV_DELETABLE} {$NAV_CAN_ADD_CHILDREN} {$FRAGMENT_OWNER_CSS}"> <!-- Each navigation menu item.  The unique ID can be used in the CSS to give each menu item a unique icon, color, or presentation. -->
       <xsl:variable name="tabLinkUrl">
         <!-- For transient tabs, don't try to calculate an URL.  It display an exception in the logs. Use a safe URL. -->
         <xsl:choose>
@@ -262,7 +270,7 @@
         </a> <!-- Drag & drop gripper handle. -->
       </xsl:if>
       <xsl:if test="$AUTHENTICATED='true' and @activeTab='true' and $NAV_POSITION != 'single' and not($PORTAL_VIEW='focused')">
-        <xsl:if test="not(@dlm:deleteAllowed='false')">
+        <xsl:if test="not(@dlm:deleteAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
           <a href="javascript:;" class="nav-tab-controls portal-navigation-delete" title="{upMsg:getMessage('remove.this.tab', $USER_LANG)}">
             <i class="fa fa-times"></i>
             <span><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></span>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -193,11 +193,11 @@
         <xsl:otherwise></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="NAV_INLINE_EDITABLE"><!--Determine which navigation tab has edit permissions and is the active tab. Class name is leveraged by the fluid inline editor component.-->
+    <xsl:variable name="NAV_INLINE_EDITABLE"><!--Determine whether the activeTab is editable. Class name is leveraged by the fluid inline editor component.-->
         <xsl:choose>
             <xsl:when test="$AUTHENTICATED='true'">
                 <xsl:choose>
-                    <xsl:when test="not(@dlm:editAllowed='false')">
+                    <xsl:when test="not(@dlm:editAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
                         <xsl:choose>
                             <xsl:when test="@activeTab='true'">flc-inlineEditable</xsl:when>
                             <xsl:otherwise></xsl:otherwise>
@@ -209,11 +209,11 @@
             <xsl:otherwise></xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="NAV_INLINE_EDIT_TEXT"><!--Determine which navigation tab has edit permissions and is the active tab. Class name is leveraged by the fluid inline editor component.-->
+    <xsl:variable name="NAV_INLINE_EDIT_TEXT"><!--Determine whether the activeTab is editable. Class name is leveraged by the fluid inline editor component.-->
         <xsl:choose>
             <xsl:when test="$AUTHENTICATED='true'">
                 <xsl:choose>
-                    <xsl:when test="not(@dlm:editAllowed='false')">
+                    <xsl:when test="not(@dlm:editAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
                         <xsl:choose>
                             <xsl:when test="@activeTab='true'">flc-inlineEdit-text</xsl:when>
                             <xsl:otherwise></xsl:otherwise>
@@ -225,11 +225,11 @@
             <xsl:otherwise></xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="NAV_INLINE_EDIT_TITLE"><!--Determine which navigation tab has edit permissions and is the active tab. Class name is leveraged by the fluid inline editor component.-->
+    <xsl:variable name="NAV_INLINE_EDIT_TITLE"><!--Determine whether the activeTab is editable. Class name is leveraged by the fluid inline editor component.-->
         <xsl:choose>
             <xsl:when test="$AUTHENTICATED='true'">
                 <xsl:choose>
-                    <xsl:when test="not(@dlm:editAllowed='false')">
+                    <xsl:when test="not(@dlm:editAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
                         <xsl:choose>
                             <xsl:when test="@activeTab='true'">Click to edit tab name</xsl:when>
                             <xsl:otherwise></xsl:otherwise>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -179,14 +179,6 @@
         <xsl:otherwise></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <!-- Applied in the case of DLM fragment owners only;  tells the UI to
-         permit the fragment admin to manage content even when it it locked. -->
-    <xsl:variable name="FRAGMENT_OWNER_CSS">
-      <xsl:choose>
-        <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
-        <xsl:otherwise></xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
     <xsl:variable name="NAV_TRANSIENT">
       <xsl:choose>
         <xsl:when test="@transient='true'">disabled</xsl:when>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -263,11 +263,13 @@
         </span>
         <i class="fa fa-chevron-right visible-xs"></i>
       </a> <!-- Navigation item link. -->
-      <xsl:if test="$AUTHENTICATED='true' and not($PORTAL_VIEW='focused') and not(dlm:moveAllowed='false')">
-        <a href="javascript:;" class="nav-tab-controls portal-navigation-gripper {$NAV_ACTIVE}" title="{upMsg:getMessage('move.this.tab', $USER_LANG)}">
-          <i class="fa fa-align-justify"></i>
-          <span><xsl:value-of select="upMsg:getMessage('move', $USER_LANG)"/></span>
-        </a> <!-- Drag & drop gripper handle. -->
+      <xsl:if test="$AUTHENTICATED='true' and not($PORTAL_VIEW='focused')">
+        <xsl:if test="not(@dlm:moveAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">
+          <a href="javascript:;" class="nav-tab-controls portal-navigation-gripper {$NAV_ACTIVE}" title="{upMsg:getMessage('move.this.tab', $USER_LANG)}">
+            <i class="fa fa-align-justify"></i>
+            <span><xsl:value-of select="upMsg:getMessage('move', $USER_LANG)"/></span>
+          </a> <!-- Drag & drop gripper handle. -->
+        </xsl:if>
       </xsl:if>
       <xsl:if test="$AUTHENTICATED='true' and @activeTab='true' and $NAV_POSITION != 'single' and not($PORTAL_VIEW='focused')">
         <xsl:if test="not(@dlm:deleteAllowed='false') or $IS_FRAGMENT_ADMIN_MODE='true'">

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -185,8 +185,18 @@
 <xsl:param name="EXTERNAL_LOGIN_URL"></xsl:param>
 <xsl:variable name="IS_FRAGMENT_ADMIN_MODE">
   <xsl:choose>
+    <!-- This is a strange thing to test;  is there no signal sent from the structure transform? -->
     <xsl:when test="//channel[@fname = 'fragment-admin-exit']">true</xsl:when>
     <xsl:otherwise>false</xsl:otherwise>
+  </xsl:choose>
+</xsl:variable>
+<!-- In the case of DLM fragment owners, this CSS class will be applied to
+     columns and portlets;  it tells the UI to permit the fragment owner to
+     manage content, even when it it locked. -->
+<xsl:variable name="FRAGMENT_OWNER_CSS">
+  <xsl:choose>
+    <xsl:when test="$IS_FRAGMENT_ADMIN_MODE='true'">up-fragment-admin</xsl:when>
+    <xsl:otherwise></xsl:otherwise>
   </xsl:choose>
 </xsl:variable>
 <xsl:param name="USE_AJAX" select="'true'"/>

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-fragment-permissions-manager.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-fragment-permissions-manager.js
@@ -267,11 +267,9 @@ var up = up || {};
             listeners: {
                 onUpdatePermissions: function(element, newPermissions) {
                     if (!newPermissions.movable) {
-                        element.addClass("locked").removeClass("fl-reorderer-movable-default");
-                        element.find("[id*=toolbar_]").removeClass("ui-draggable");
+                        element.addClass("locked");
                     } else {
-                        element.removeClass("locked").addClass("fl-reorderer-movable-default");
-                        element.find("[id*=toolbar_]").addClass("ui-draggable");
+                        element.removeClass("locked");
                     }
                     // TODO: Apply portlet permissions: 
                     // includes refreshing reorderer and displaying/hiding delete

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-draggable-manager.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-draggable-manager.js
@@ -143,7 +143,7 @@ var up = up || {};
      * @param {Object} target - reference to a DOM element. Specifically, a portal column.
      */
     var dragOverHandler = function (that, target) {
-        var column, portlets, portlet_locked, portlet_movable, children, dropTarget;
+        var column, portlets, portlet_locked, firstMovablePortlet, children, dropTarget;
         
         // Obtain reference to column, contained portlets and the dropTarget.
         column = $(target);
@@ -159,8 +159,8 @@ var up = up || {};
                 dropTarget.insertAfter(portlet_locked);
             } else {
                 // Insert drop target before the first movable portlet.
-                portlet_movable = column.find(that.options.selectors.firstPortletMovable);
-                dropTarget.insertBefore(portlet_movable);
+                firstMovablePortlet = column.find(that.options.selectors.portletMovable).first();
+                dropTarget.insertBefore(firstMovablePortlet);
             }//end:if.
         } else {
             // Column does not contain portlets. Does the column contain any children
@@ -415,9 +415,8 @@ var up = up || {};
             accept: ".portlet",
             canAddChildren: ".canAddChildren",
             portlet: "[id*=portlet_]",
-            lastPortletLocked: "[id*=portlet_].locked:last",
-            firstPortletMovable: "[id*=portlet_].movable:first",
-            portletMovable: "[id*=portlet_].movable"
+            lastPortletLocked: "[id*=portlet_].locked:not(.up-fragment-admin):last",   // Fragment owners get the up-fragment-admin class,
+            portletMovable: "[id*=portlet_].movable,[id*=portlet_].up-fragment-admin"  // which allows them to bypass the restrictions.
         },
         styles: {
             pseudoDropTarget: "layout-draggable-drop-target",

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-draggable-manager.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-draggable-manager.js
@@ -413,7 +413,7 @@ var up = up || {};
             pseudoDropTarget: ".layout-draggable-drop-target",
             loader: "#galleryLoader",
             accept: ".portlet",
-            canAddChildren: ".canAddChildren",
+            canAddChildren: ".canAddChildren,.up-fragment-admin",
             portlet: "[id*=portlet_]",
             lastPortletLocked: "[id*=portlet_].locked:not(.up-fragment-admin):last",   // Fragment owners get the up-fragment-admin class,
             portletMovable: "[id*=portlet_].movable,[id*=portlet_].up-fragment-admin"  // which allows them to bypass the restrictions.

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-gallery.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-gallery.js
@@ -507,7 +507,7 @@ var up = up || {};
             that.options.isOpen = true;
             that.locate("galleryHandle").addClass('handle-arrow-up');
             that.locate("galleryInner").slideDown(that.options.openSpeed);
-            if ($("#portalPageBodyColumns .portal-page-column").hasClass("canAddChildren")) {
+            if ($("#portalPageBodyColumns .portal-page-column").filter(".canAddChildren,.up-fragment-admin")) {
                 that.showPane("add-content");
             } else {
                 that.showPane("use-content");
@@ -548,7 +548,7 @@ var up = up || {};
         };
 
         that.refreshPaneLink = function (key) {
-            if ($("#portalPageBodyColumns .portal-page-column").hasClass("canAddChildren")) {
+            if ($("#portalPageBodyColumns .portal-page-column").filter(".canAddChildren,.up-fragment-admin")) {
                 that.showPaneLink("add-content");
             } else {
                 that.hidePaneLink("add-content");

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
@@ -32,6 +32,12 @@ var uportal = uportal || {};
        { nameKey: "sixColumn", columns: [17, 17, 16, 16, 17, 17] }
    ];
 
+    /*
+     * A deletable column must either:
+     *   (1) be marked deletable and contain no locked children; or
+     *   (2) be marked up-fragment-admin, indicating the user is the fragment owner 
+     */
+    var deletableColumnsSelector = ".deletable:not(:has(.locked)),.up-fragment-admin";
 
     /*
      * GENERAL UTILITY METHODS
@@ -103,10 +109,7 @@ var uportal = uportal || {};
      */
     var getDeletableColumns = function() {
         var columns = $('#portalPageBodyColumns > [id^=column_]');
-
-        // a deletable column must be marked deletable and contain no locked
-        // children
-        var deletableColumns = columns.filter(".deletable:not(:has(.locked))");
+        var deletableColumns = columns.filter(deletableColumnsSelector);
 
         var contentColumns = deletableColumns.filter(":has(.up-portlet-wrapper)");
         if (contentColumns.size() > 0) {
@@ -125,10 +128,7 @@ var uportal = uportal || {};
 
         var canAddColumns = $("#portalNavigation_" + getActiveTabId()).hasClass("canAddChildren");
         var columns = $('#portalPageBodyColumns > [id^=column_]');
-
-        // a deletable column must be marked deletable and contain no locked
-        // children
-        var deletableColumns = columns.filter(".deletable:not(:has(.locked))");
+        var deletableColumns = columns.filter(deletableColumnsSelector);
 
         // set the minimum number of columns according to how
         // many deletable columns the layout currently contains

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
@@ -113,7 +113,7 @@ var uportal = uportal || {};
 
         var contentColumns = deletableColumns.filter(":has(.up-portlet-wrapper)");
         if (contentColumns.size() > 0) {
-            var acceptorColumns = columns.filter(".canAddChildren");
+            var acceptorColumns = columns.filter(".canAddChildren,.up-fragment-admin");
             // if there are no acceptor columns, mark any columns that
             // have content as undeletable
             if (acceptorColumns.size() == 0) {
@@ -126,7 +126,7 @@ var uportal = uportal || {};
 
     var getPermittedLayouts = function() {
 
-        var canAddColumns = $("#portalNavigation_" + getActiveTabId()).hasClass("canAddChildren");
+        var canAddColumns = $("#portalNavigation_" + getActiveTabId()).filter(".canAddChildren,.up-fragment-admin");
         var columns = $('#portalPageBodyColumns > [id^=column_]');
         var deletableColumns = columns.filter(deletableColumnsSelector);
 
@@ -136,7 +136,7 @@ var uportal = uportal || {};
 
         var contentColumns = deletableColumns.filter(":has(.up-portlet-wrapper)");
         if (contentColumns.size() > 0) {
-            var acceptorColumns = columns.filter(".canAddChildren");
+            var acceptorColumns = columns.filter(".canAddChildren,.up-fragment-admin");
             // if there are no acceptor columns, mark any columns that
             // have content as undeletable
             if (acceptorColumns.size() == 0) {
@@ -183,7 +183,7 @@ var uportal = uportal || {};
                 post.deleted.push(up.defaultNodeIdExtractor(deletables[deletables.length-i-1]));
             }
 
-            var acceptors = $("#portalPageBodyColumns > [id^=column_].canAddChildren");
+            var acceptors = $("#portalPageBodyColumns > [id^=column_]").filter(".canAddChildren,.up-fragment-admin");
             var acceptor = acceptors.filter(":first");
             post.acceptor = up.defaultNodeIdExtractor(acceptor);
         }
@@ -194,12 +194,13 @@ var uportal = uportal || {};
                 // add any new columns to the page
                 $(data.newColumnIds).each(function(){
                     var id = this;
-                    $("#portalPageBodyColumns")
-                        .append(
-                            $(document.createElement('div')).attr("id", 'column_' + id)
-                                .addClass("portal-page-column movable deletable editable canAddChildren")
-                                .html("<div id=\"inner-column_" + id + "\" class=\"portal-page-column-inner\"></div>")
-                        );
+                    var newColumn = $(document.createElement('div')).attr("id", 'column_' + id)
+                            .addClass("portal-page-column movable deletable editable canAddChildren")
+                            .html("<div id=\"inner-column_" + id + "\" class=\"portal-page-column-inner\"></div>");
+                    if ($("#portalPageBodyColumns").has(".up-fragment-admin")) {
+                        newColumn.addClass("up-fragment-admin");
+                    }
+                    $("#portalPageBodyColumns").append(newColumn);
                 });
 
                 // remove any deleted columns from the page

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-preferences.js
@@ -296,8 +296,9 @@ var uportal = uportal || {};
                                         options = { action: 'addPortlet', channelID: portlet.id };
 
                                         // get the first channel element that's
-                                        // unlocked
-                                        firstChannel = $("[id^=portlet_].movable:first");
+                                        // unlocked;  fragment owners may bypass
+                                        // these restrictions
+                                        firstChannel = $("[id^=portlet_].movable,[id^=portlet_].up-fragment-admin").first();
 
                                         // if the page has no content just add
                                         //  the new portlet to the tab
@@ -535,7 +536,7 @@ var uportal = uportal || {};
                     selectors: {
                         columns: ".portal-page-column-inner",
                         modules: ".up-portlet-wrapper",
-                        lockedModules: ".locked",
+                        lockedModules: ".locked:not(.up-fragment-admin)",
                         dropWarning: $("#portalDropWarning"),
                         grabHandle: "[id*=toolbar_] .grab-handle"
                      },

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-tab-manager.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-tab-manager.js
@@ -287,7 +287,7 @@ var up = up || {};
         // Find the last instance of a locked tab and add a 'locked' class name
         // to all previous tabs. Hide all drag & drop grab handles from 'locked' tabs.
         tabList = that.locate("tabList");
-        lastLockedTab = tabList.find(that.options.selectors.lockedModules + ":last");
+        lastLockedTab = tabList.find(that.options.selectors.lockedModules).last();
         
         if (lastLockedTab.length > 0) {
             lastLockedTab.find(that.options.selectors.grabHandle).hide();
@@ -336,8 +336,8 @@ var up = up || {};
             remove: ".portal-navigation-delete",
             add: ".portal-navigation-add",
             columns: ".flc-reorderer-column",
-            modules: ".movable",
-            lockedModules: ".locked",
+            modules: ".movable,.up-fragment-admin",
+            lockedModules: ".locked:not(.up-fragment-admin)",
             grabHandle: ".portal-navigation-gripper",
             tabList: "#portalNavigationList",
             tabListItems: ".portal-navigation",


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4549

This update applies to the following restrictions:

- dlm:moveAllowed
- dlm:deleteAllowed
- dlm:editAllowed
- dlm:addChildAllowed

Historically a fragment admin would have to remove these restrictions, make changes, then reinstate them.  That's non-intuitive, so this update allows fragment owners to ignore restrictions when changing fragment layouts.
