### PR TITLE
UP-4643:  Bump commons-collections to 3.2.2 in a few more places

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <org.springframework.webflow.version>2.3.2.RELEASE</org.springframework.webflow.version>
         <oro.version>2.0.8</oro.version>
         <persistence-api.version>1.0</persistence-api.version>
-        <person-directory.version>1.7.1-M1</person-directory.version>
+        <person-directory.version>1.7.1</person-directory.version>
         <pluto.version>2.1.0-M3</pluto.version>
         <quartz.version>2.2.1</quartz.version>
         <resource-server.version>1.0.43</resource-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,10 @@
         <CalendarPortlet.version>2.3.1</CalendarPortlet.version>
         <cas-server.version>3.5.2.1</cas-server.version>
         <cas-proxy-test-portlet.version>1.0.0-RC3</cas-proxy-test-portlet.version>
-        <email-preview.version>2.2.0</email-preview.version>
+        <email-preview.version>2.2.1</email-preview.version>
         <FunctionalTestsPortlet.version>1.1.4</FunctionalTestsPortlet.version>
         <jasig-widget-portlets.version>2.2.1</jasig-widget-portlets.version>
-        <NewsReaderPortlet.version>4.0.0</NewsReaderPortlet.version>
+        <NewsReaderPortlet.version>4.0.1</NewsReaderPortlet.version>
         <NotificationPortlet.version>2.1.1</NotificationPortlet.version>
         <sakai-connector-portlet.version>1.5.2</sakai-connector-portlet.version>
         <SimpleContentPortlet.version>2.0.2</SimpleContentPortlet.version>

--- a/uportal-portlets-overlay/cas/pom.xml
+++ b/uportal-portlets-overlay/cas/pom.xml
@@ -63,6 +63,19 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         
+        <!--
+         | Replacing the 3.2 jar with the 3.2.2 version because of the
+         | deserialization vulnerability.  When the version of CAS is updated,
+         | this dependency can (probably) be removed.  Pegging this version to
+         | 3.2.2, rather than following uPortal's version, because if uPortal
+         | moves to a later version it may not work with this CAS.
+         +-->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
@@ -191,6 +204,7 @@
                             <artifactId>cas-server-webapp</artifactId>
                             <excludes>
                                 <exclude>WEB-INF/lib/cas-client-core-3.2.1.jar</exclude>
+                                <exclude>WEB-INF/lib/commons-collections*jar</exclude>
                                 <exclude>WEB-INF/lib/xml-apis-1.0.b2.jar</exclude>
                             </excludes>
                         </overlay>


### PR DESCRIPTION
## Ready to Merge

These changes should eliminate all instances of:
* 3.2.1
* 3.2
* 4.0