### PR TITLE
UP-4656:  Improve performance by caching the results of GroupMemberIm…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/RDBMUserIdentityStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/RDBMUserIdentityStore.java
@@ -596,7 +596,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
     protected void updateUser(final int userId, final IPerson person, final TemplateUser templateUser) throws Exception {
         // Remove my existing group memberships
         IGroupMember me = GroupService.getGroupMember(person.getEntityIdentifier());
-        Iterator myExistingGroups = me.getContainingGroups();
+        Iterator myExistingGroups = me.getParentGroups();
         while (myExistingGroups.hasNext()) {
             IEntityGroup eg = (IEntityGroup)myExistingGroups.next();
             ILockableEntityGroup leg = getSafeLockableGroup(eg, me);
@@ -607,7 +607,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
 
         // Copy template user's groups memberships
         IGroupMember template = GroupService.getEntity(templateUser.getUserName(), org.jasig.portal.security.IPerson.class);
-        Iterator templateGroups = template.getContainingGroups();
+        Iterator templateGroups = template.getParentGroups();
         while (templateGroups.hasNext()) {
             IEntityGroup eg = (IEntityGroup)templateGroups.next();
             ILockableEntityGroup leg = getSafeLockableGroup(eg, me);
@@ -728,7 +728,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
         // Copy template user's groups memberships
         IGroupMember me = GroupService.getGroupMember(person.getEntityIdentifier());
         IGroupMember template = GroupService.getEntity(templateUser.getUserName(), Class.forName("org.jasig.portal.security.IPerson"));
-        Iterator templateGroups = template.getContainingGroups();
+        Iterator templateGroups = template.getParentGroups();
         while (templateGroups.hasNext()) {
             IEntityGroup eg = (IEntityGroup)templateGroups.next();
             ILockableEntityGroup leg = getSafeLockableGroup(eg, me);

--- a/uportal-war/src/main/java/org/jasig/portal/api/groups/ApiGroupsService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/api/groups/ApiGroupsService.java
@@ -80,7 +80,7 @@ public class ApiGroupsService implements GroupsService {
                 if(entityIdentifier.getType().equals(EntityEnum.PERSON.getClazz())) {
                     IGroupMember groupMember = GroupService.getGroupMember(entityIdentifier);
                     if(memberName.equalsIgnoreCase(groupMember.getKey())) {
-                        Iterator it = GroupService.findContainingGroups(groupMember);
+                        Iterator it = GroupService.findParentGroups(groupMember);
                         while(it.hasNext()) {
                             IEntityGroup g = (IEntityGroup)it.next();
                             Entity e = EntityFactory.createEntity(g,EntityEnum.getEntityEnum(g.getEntityType(),true));

--- a/uportal-war/src/main/java/org/jasig/portal/api/permissions/ApiPermissionsService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/api/permissions/ApiPermissionsService.java
@@ -82,7 +82,7 @@ public class ApiPermissionsService implements PermissionsService {
         
         if (includeInherited) {
             IGroupMember member = GroupService.getGroupMember(authP.getKey(), authP.getType());
-            for (@SuppressWarnings("unchecked") Iterator<IEntityGroup> iter = member.getAllContainingGroups(); iter.hasNext();) {
+            for (@SuppressWarnings("unchecked") Iterator<IEntityGroup> iter = member.getAncestorGroups(); iter.hasNext();) {
                 IEntityGroup parent = iter.next();
 
                 IAuthorizationPrincipal parentPrincipal = this.authorizationService.newPrincipal(parent);

--- a/uportal-war/src/main/java/org/jasig/portal/concurrency/caching/RequestCacheAspect.java
+++ b/uportal-war/src/main/java/org/jasig/portal/concurrency/caching/RequestCacheAspect.java
@@ -49,12 +49,10 @@ import org.springframework.jmx.export.MBeanExportOperations;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;
 
-
 /**
  * Aspect that caches the results of a method invocation in the current {@link RequestAttributes}
  * 
  * @author Eric Dalquist
- * @version $Revision$
  */
 @Aspect
 @Component("requestCacheAspect")
@@ -138,7 +136,7 @@ public class RequestCacheAspect implements InitializingBean {
         }
         
         try {
-            //Execute the annotated emthod
+            //Execute the annotated method
             result = pjp.proceed();
             final long time = System.nanoTime() - start;
             cacheStatistics.recordMissAndLoad(time);

--- a/uportal-war/src/main/java/org/jasig/portal/events/PortalEventFactoryImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/PortalEventFactoryImpl.java
@@ -565,7 +565,7 @@ public class PortalEventFactoryImpl implements IPortalEventFactory, ApplicationE
         final IGroupMember member = GroupService.getGroupMember(person.getEntityIdentifier());
 
         final Set<String> groupKeys = new LinkedHashSet<String>();
-        for (@SuppressWarnings("unchecked") final Iterator<IGroupMember> groupItr = member.getAllContainingGroups(); groupItr.hasNext();) {
+        for (@SuppressWarnings("unchecked") final Iterator<IGroupMember> groupItr = member.getAncestorGroups(); groupItr.hasNext();) {
             final IGroupMember group = groupItr.next();
             final String groupKey = group.getKey();
             

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/JpaEventSessionDao.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/JpaEventSessionDao.java
@@ -215,7 +215,7 @@ public class JpaEventSessionDao extends BaseAggrEventsJpaDao implements EventSes
             final String userName = event.getUserName();
             final IGroupMember groupMember = this.compositeGroupService.getGroupMember(userName, IPerson.class);
             for (@SuppressWarnings("unchecked")
-            final Iterator<IEntityGroup> containingGroups = this.compositeGroupService.findContainingGroups(groupMember); containingGroups.hasNext(); ) {
+            final Iterator<IEntityGroup> containingGroups = this.compositeGroupService.findParentGroups(groupMember); containingGroups.hasNext(); ) {
                 final IEntityGroup group = containingGroups.next();
                 final AggregatedGroupMapping groupMapping = this.aggregatedGroupLookupDao.getGroupMapping(group.getServiceName().toString(), group.getName());
                 groupMappings.add(groupMapping);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/EntityGroupImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/EntityGroupImpl.java
@@ -227,22 +227,7 @@ public void delete() throws GroupsException
 {
     getLocalGroupService().deleteGroup(this);
 }
-/**
- * @param obj the Object to compare with
- * @return true if these Objects are equal; false otherwise.
- * @see java.util.Hashtable
- */
-public boolean equals(Object obj)
-{
-    if ( obj == null )
-        return false;
-    if ( obj == this )
-        return true;
-    if ( ! ( obj instanceof EntityGroupImpl))
-        return false;
 
-    return this.getKey().equals(((IGroupMember)obj).getKey());
-}
 /**
  * @return java.util.HashMap
  */
@@ -483,17 +468,7 @@ public boolean hasDeletes()
 {
     return (removedMembers != null) && (removedMembers.size() > 0);
 }
-/**
- * Generates a hash code for the receiver.
- * This method is supported primarily for
- * hash tables, such as those provided in java.util.
- * @return an integer hash code for the receiver
- * @see java.util.Hashtable
- */
-public int hashCode()
-{
-    return getKey().hashCode();
-}
+
 /**
  * @return boolean
  */
@@ -729,7 +704,7 @@ public void updateMembers() throws GroupsException {
     clearPendingUpdates();
 
     // Invalidate objects that changed their relationship with us
-    this.invalidateInContainingGroupsCache(invalidate);
+    this.invalidateInParentGroupsCache(invalidate);
 
 }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/EntityGroupImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/EntityGroupImpl.java
@@ -53,7 +53,6 @@ import org.jasig.portal.services.GroupService;
  * or by synchronizing access from the caller.  
  *  
  * @author Dan Ellentuck
- * @version $Revision$
  * @see org.jasig.portal.groups.IEntityGroup
  * 
  * 
@@ -163,7 +162,7 @@ protected void clearPendingUpdates()
  */
 private Set copyMemberEntityKeys() throws GroupsException
 {
-   return castAndCopyHashSet(getMemberEntityKeys());
+   return new HashSet(getMemberEntityKeys());
 }
 /**
  * Clone the member group keys.
@@ -171,7 +170,7 @@ private Set copyMemberEntityKeys() throws GroupsException
  */
 private Set copyMemberGroupKeys() throws GroupsException
 {
-   return castAndCopyHashSet(getMemberGroupKeys());
+   return new HashSet(getMemberGroupKeys());
 }
 /**
  * Checks if <code>GroupMember</code> gm is a member of this.
@@ -451,12 +450,6 @@ public HashMap getRemovedMembers()
     return removedMembers;
 }
 /**
- * @return IGroupService
- */
-protected GroupService getService() throws GroupsException {
-    return GroupService.instance();
-}
-/**
  * Returns the Name of the group service of origin.
  * @return javax.naming.Nme
  */
@@ -725,9 +718,18 @@ public void update() throws GroupsException
 /**
  * Delegate to the factory.
  */
-public void updateMembers() throws GroupsException
-{
+public void updateMembers() throws GroupsException {
+
+    // Track objects to invalidate
+    Set<IGroupMember> invalidate = new HashSet<>();
+    invalidate.addAll(getAddedMembers().values());
+    invalidate.addAll(getRemovedMembers().values());
+
     getLocalGroupService().updateGroupMembers(this);
     clearPendingUpdates();
+
+    // Invalidate objects that changed their relationship with us
+    this.invalidateInContainingGroupsCache(invalidate);
+
 }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/EntityImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/EntityImpl.java
@@ -44,22 +44,7 @@ public EntityImpl(EntityIdentifier ei) throws GroupsException
     String key = id + "." + ei.getKey();
     entityIdentifier = new EntityIdentifier(key, org.jasig.portal.EntityTypes.LEAF_ENTITY_TYPE);
 }
-/**
- * @param obj the Object to compare with
- * @return true if these Objects are equal; false otherwise.
- * @see java.util.Hashtable
- */
-public boolean equals(Object obj)
-{
-    if ( obj == null )
-        return false;
-    if ( obj == this )
-        return true;
-    if ( ! ( obj instanceof EntityImpl))
-        return false;
 
-    return this.getEntityIdentifier().equals( ((IEntity) obj).getEntityIdentifier() );
-}
 /**
  * @return org.jasig.portal.EntityIdentifier
  */

--- a/uportal-war/src/main/java/org/jasig/portal/groups/GroupMemberImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/GroupMemberImpl.java
@@ -51,7 +51,7 @@ public abstract class GroupMemberImpl implements IGroupMember {
     private EntityIdentifier underlyingEntityIdentifier;
 
     private final Cache parentGroupsCache;
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
 /**
  * GroupMemberImpl constructor

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ICompositeGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ICompositeGroupService.java
@@ -42,7 +42,7 @@ public interface ICompositeGroupService extends IComponentGroupService {
    * Returns the groups that contain the <code>IGroupMember</code>.
    * @param gm IGroupMember
    */
-  public Iterator findContainingGroups(IGroupMember gm) throws GroupsException;
+  public Iterator findParentGroups(IGroupMember gm) throws GroupsException;
   /**
    * Returns a pre-existing <code>IEntityGroup</code> or null if it does not
    * exist.

--- a/uportal-war/src/main/java/org/jasig/portal/groups/IEntityGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/IEntityGroupStore.java
@@ -53,7 +53,7 @@ public IEntityGroup find(String key) throws GroupsException;
  * @return java.util.Iterator
  * @param gm org.jasig.portal.groups.IEntityGroup
  */
-public Iterator findContainingGroups(IGroupMember gm) throws GroupsException;
+public Iterator findParentGroups(IGroupMember gm) throws GroupsException;
 /**
  * Returns an <code>Iterator</code> over the <code>Collection</code> of
  * <code>IEntities</code> that are members of this <code>IEntityGroup</code>.

--- a/uportal-war/src/main/java/org/jasig/portal/groups/IGroupMember.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/IGroupMember.java
@@ -44,7 +44,6 @@ import org.jasig.portal.IBasicEntity;
  * that duplicates returned from "deep" methods can  be recognized.
  *
  * @author Dan Ellentuck
- * @version $Revision$
  */
 public interface IGroupMember extends IBasicEntity {
 /**
@@ -72,7 +71,7 @@ public boolean equals(Object o);
  *
  * @return java.util.Iterator
  */
-public Iterator getAllContainingGroups() throws GroupsException;
+public Iterator getAncestorGroups() throws GroupsException;
 /**
  * Returns an <code>Iterator</code> over the <code>Set</code> of this
  * <code>IGroupMember's</code> recursively-retrieved members that are
@@ -90,7 +89,7 @@ public Iterator getAllMembers() throws GroupsException;
  * Returns an <code>Iterator</code> over this <code>IGroupMember's</code> parent groups.
  * @return java.util.Iterator
  */
-public Iterator getContainingGroups() throws GroupsException;
+public Iterator getParentGroups() throws GroupsException;
 /**
  * Returns an <code>Iterator</code> over this <code>IGroupMember's</code>
  * members that are <code>IEntities</code>.

--- a/uportal-war/src/main/java/org/jasig/portal/groups/IGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/IGroupService.java
@@ -94,7 +94,7 @@ public interface IGroupService {
    * Returns the containing groups for the <code>IGroupMember</code>
    * @param gm IGroupMember
    */
-  public Iterator findContainingGroups(IGroupMember gm) throws GroupsException;
+  public Iterator findParentGroups(IGroupMember gm) throws GroupsException;
 
   /**
    * Returns the member groups for the <code>IEntityGroup</code>

--- a/uportal-war/src/main/java/org/jasig/portal/groups/LockableEntityGroupImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/LockableEntityGroupImpl.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portal.groups;
 
+import java.util.Collections;
+
 import org.jasig.portal.concurrency.IEntityLock;
 
     /**
@@ -73,7 +75,7 @@ private void primUpdate(boolean renewLock) throws GroupsException
 {
     getLockableGroupService().updateGroup(this, renewLock);
     clearPendingUpdates();
-    setGroupKeysInitialized(false);
+    this.invalidateInParentGroupsCache(Collections.singleton((IGroupMember) this));
 }
 
 /**
@@ -86,7 +88,7 @@ private void primUpdateMembers(boolean renewLock) throws GroupsException
 {
     getLockableGroupService().updateGroupMembers(this, renewLock);
     clearPendingUpdates();
-    setGroupKeysInitialized(false);
+    this.invalidateInParentGroupsCache(Collections.singleton((IGroupMember) this));
 }
 
 /**

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceCompositeGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceCompositeGroupService.java
@@ -60,7 +60,7 @@ public ReferenceCompositeGroupService() throws GroupsException
  * a membership for this member.
  * @param gm IGroupMember
  */
-public Iterator findContainingGroups(IGroupMember gm) throws GroupsException
+public Iterator findParentGroups(IGroupMember gm) throws GroupsException
 {
     Collection allGroups = new ArrayList();
     IIndividualGroupService service = null;
@@ -72,7 +72,7 @@ public Iterator findContainingGroups(IGroupMember gm) throws GroupsException
           getComponentService(((IEntityGroup)gm).getServiceName()) == service )
         {
             {
-                for ( Iterator groups = service.findContainingGroups(gm); groups.hasNext(); )
+                for ( Iterator groups = service.findParentGroups(gm); groups.hasNext(); )
                     { allGroups.add((IEntityGroup) groups.next()); }
             }
         }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceGroupService.java
@@ -129,11 +129,11 @@ public void deleteGroup(ILockableEntityGroup group) throws GroupsException
  * Returns and caches the containing groups for the <code>IGroupMember</code>
  * @param gm IGroupMember
  */
-public Iterator findContainingGroups(IGroupMember gm) throws GroupsException
+public Iterator findParentGroups(IGroupMember gm) throws GroupsException
 {
     Collection groups = new ArrayList(10);
     IEntityGroup group = null;
-    for ( Iterator it = getGroupStore().findContainingGroups(gm); it.hasNext(); )
+    for ( Iterator it = getGroupStore().findParentGroups(gm); it.hasNext(); )
     {
         group = (IEntityGroup) it.next();
         groups.add(group);

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceIndividualGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceIndividualGroupService.java
@@ -20,6 +20,7 @@ package org.jasig.portal.groups;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -106,7 +107,7 @@ public void deleteGroup(IEntityGroup group) throws GroupsException
  * fail anyway.
  * @param group ILockableEntityGroup
  */
-private void removeDeletedGroupFromContainingGroups(ILockableEntityGroup group)
+private void removeDeletedGroupFromParentGroups(ILockableEntityGroup group)
 throws GroupsException
 {
     Iterator itr;
@@ -117,7 +118,7 @@ throws GroupsException
     try
     {
         String lockOwner = group.getLock().getLockOwner();
-        for ( itr=group.getContainingGroups(); itr.hasNext(); )
+        for ( itr=group.getParentGroups(); itr.hasNext(); )
         {
             containingGroup = (IEntityGroup) itr.next();
             lockableGroup=
@@ -148,7 +149,7 @@ throws GroupsException
             catch (LockingException le)
             {
                 log.error(
-                    "ReferenceIndividualGroupService.removeDeletedGroupFromContainingGroups(): " +
+                    "ReferenceIndividualGroupService.removeDeletedGroupFromParentGroups(): " +
                     "Problem unlocking parent group", le);
             }
         }
@@ -167,7 +168,7 @@ public void deleteGroup(ILockableEntityGroup group) throws GroupsException
     {
         if ( group.getLock().isValid() )
         {
-            removeDeletedGroupFromContainingGroups(group);
+            removeDeletedGroupFromParentGroups(group);
             deleteGroup( (IEntityGroup)group );
         }
         else
@@ -199,12 +200,12 @@ public void deleteGroup(ILockableEntityGroup group) throws GroupsException
  * Returns and caches the containing groups for the <code>IGroupMember</code>
  * @param gm IGroupMember
  */
-public Iterator findContainingGroups(IGroupMember gm) throws GroupsException
+public Iterator findParentGroups(IGroupMember gm) throws GroupsException
 {
     log.debug("Finding containing groups for member {}", gm.getKey());
     Collection groups = new ArrayList(10);
     IEntityGroup group = null;
-    for ( Iterator it = getGroupStore().findContainingGroups(gm); it.hasNext(); )
+    for ( Iterator it = getGroupStore().findParentGroups(gm); it.hasNext(); )
     {
         group = (IEntityGroup) it.next();
         group.setLocalGroupService(this);
@@ -811,7 +812,7 @@ throws GroupsException
     for (Iterator it=group.getMembers(); it.hasNext();)
     {
         gmi = (GroupMemberImpl) it.next();
-        gmi.removeGroup(group);
+        gmi.invalidateInParentGroupsCache(Collections.singleton((IGroupMember) gmi));
         if ( cacheInUse() )
            { cacheUpdate(gmi); }
     }
@@ -832,7 +833,7 @@ throws GroupsException
     for (Iterator it=egi.getAddedMembers().values().iterator(); it.hasNext();)
     {
         gmi = (GroupMemberImpl) it.next();
-        gmi.addGroup(egi);
+        gmi.invalidateInParentGroupsCache(Collections.singleton((IGroupMember) gmi));
         if ( cacheInUse() )
            { cacheUpdate(gmi); }
     }
@@ -840,7 +841,7 @@ throws GroupsException
     for (Iterator it=egi.getRemovedMembers().values().iterator(); it.hasNext();)
     {
         gmi = (GroupMemberImpl) it.next();
-        gmi.removeGroup(egi);
+        gmi.invalidateInParentGroupsCache(Collections.singleton((IGroupMember) gmi));
         if ( cacheInUse() )
            { cacheUpdate(gmi); }
     }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceIndividualGroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ReferenceIndividualGroupService.java
@@ -855,20 +855,27 @@ throws GroupsException
  * @param group org.jasig.portal.groups.IEntityGroup
  * @param member org.jasig.portal.groups.IGroupMember
  */
-public boolean contains(IEntityGroup group, IGroupMember member) 
-throws GroupsException 
-{
-    return ( isForeign(member) && ! isEditable() )
-      ? false
-      : getGroupStore().contains(group, member);
+public boolean contains(IEntityGroup group, IGroupMember member) throws GroupsException {
+    boolean rslt;
+    if (!member.getLeafType().equals(group.getLeafType())) {
+        // Group does not contain the type of thing that member is
+        rslt = false;
+    } else if (isForeignGroup(member) && !isEditable()) {
+        // Member is a group from another system, and there's
+        // no way to add it as a child in this one
+        rslt = false;
+    } else {
+        // This is an allowable relationship;  defer to the Group Store
+        rslt = getGroupStore().contains(group, member);
+    }
+    return rslt;
 }
 /**
  * A foreign member is a group from a different service.
  * @param member IGroupMember
  * @return boolean
  */
-protected boolean isForeign(IGroupMember member)
-{
+private boolean isForeignGroup(IGroupMember member) {
     if (member.isEntity())
         { return false; }
     else

--- a/uportal-war/src/main/java/org/jasig/portal/groups/filesystem/FileSystemGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/filesystem/FileSystemGroupStore.java
@@ -286,11 +286,11 @@ public IEntityGroup find(String key) throws GroupsException
  * @return java.util.Iterator
  * @param ent org.jasig.portal.groups.IEntityGroup
  */
-protected Iterator findContainingGroups(IEntity ent) throws GroupsException
+protected Iterator findParentGroups(IEntity ent) throws GroupsException
 {
     if (log.isDebugEnabled())
         log.debug(
-                DEBUG_CLASS_NAME + ".findContainingGroups(): for " + ent);
+                DEBUG_CLASS_NAME + ".findParentGroups(): for " + ent);
 
     List groups = new ArrayList();
     File root = getFileRoot(ent.getType());
@@ -319,11 +319,11 @@ protected Iterator findContainingGroups(IEntity ent) throws GroupsException
  * @return java.util.Iterator
  * @param group org.jasig.portal.groups.IEntityGroup
  */
-protected Iterator findContainingGroups(IEntityGroup group) throws GroupsException
+protected Iterator findParentGroups(IEntityGroup group) throws GroupsException
 {
     if (log.isDebugEnabled())
         log.debug(
-                DEBUG_CLASS_NAME + ".findContainingGroups(): for " + group);
+                DEBUG_CLASS_NAME + ".findParentGroups(): for " + group);
 
     List groups = new ArrayList();
     {
@@ -354,17 +354,17 @@ protected Iterator findContainingGroups(IEntityGroup group) throws GroupsExcepti
  * @return java.util.Iterator
  * @param gm org.jasig.portal.groups.IEntityGroup
  */
-public Iterator findContainingGroups(IGroupMember gm) throws GroupsException
+public Iterator findParentGroups(IGroupMember gm) throws GroupsException
 {
     if ( gm.isGroup() )
     {
         IEntityGroup group = (IEntityGroup) gm;
-        return findContainingGroups(group);
+        return findParentGroups(group);
     }
     else
     {
         IEntity ent = (IEntity) gm;
-        return findContainingGroups(ent);
+        return findParentGroups(ent);
     }
 }
 /**

--- a/uportal-war/src/main/java/org/jasig/portal/groups/grouper/GrouperEntityGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/grouper/GrouperEntityGroupStore.java
@@ -75,7 +75,6 @@ import edu.internet2.middleware.grouperClient.ws.beans.WsSubjectLookup;
  * 
  * @author Bill Brown
  * @author Jen Bourey, jbourey@unicon.net
- * @version $Revision$
  */
 public class GrouperEntityGroupStore implements IEntityGroupStore,
         IEntityStore, IEntitySearcher {
@@ -160,10 +159,10 @@ public class GrouperEntityGroupStore implements IEntityGroupStore,
     }
 
     /* (non-Javadoc)
-     * @see org.jasig.portal.groups.IEntityGroupStore#findContainingGroups(org.jasig.portal.groups.IGroupMember)
+     * @see org.jasig.portal.groups.IEntityGroupStore#findParentGroups(org.jasig.portal.groups.IGroupMember)
      */
     @SuppressWarnings("unchecked")
-    public Iterator findContainingGroups(IGroupMember gm)
+    public Iterator findParentGroups(IGroupMember gm)
             throws GroupsException {
         
         final List<IEntityGroup> parents = new LinkedList<IEntityGroup>();

--- a/uportal-war/src/main/java/org/jasig/portal/groups/ldap/LDAPGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/ldap/LDAPGroupStore.java
@@ -502,7 +502,7 @@ public class LDAPGroupStore implements IEntityGroupStore, IEntityStore, IEntityS
   public IEntityGroup find(String key) throws GroupsException {
     return makeGroup((GroupShadow)this.groups.get(key));
   }
-  public Iterator findContainingGroups(IGroupMember gm) throws GroupsException {
+  public Iterator findParentGroups(IGroupMember gm) throws GroupsException {
      ArrayList al = new ArrayList();
      String key;
      GroupShadow[] shadows = getGroupShadows();

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/PersonAttributesGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/PersonAttributesGroupStore.java
@@ -220,7 +220,7 @@ public class PersonAttributesGroupStore implements IEntityGroupStore, IEntitySto
    private java.util.Set<IEntityGroup> primGetAllContainingGroups(IEntityGroup group, Set<IEntityGroup> s)
    throws GroupsException
    {
-       Iterator i = findContainingGroups(group);
+       Iterator i = findParentGroups(group);
        while ( i.hasNext() )
        {
            IEntityGroup parentGroup = (IEntityGroup) i.next();
@@ -230,7 +230,7 @@ public class PersonAttributesGroupStore implements IEntityGroupStore, IEntitySto
        return s;
    }
 
-   public Iterator findContainingGroups(IGroupMember member) 
+   public Iterator findParentGroups(IGroupMember member) 
    throws GroupsException 
    {
       return (member.isEntity()) 

--- a/uportal-war/src/main/java/org/jasig/portal/groups/smartldap/SmartLdapGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/smartldap/SmartLdapGroupStore.java
@@ -200,7 +200,7 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
      * @return java.util.Iterator
      * @param gm org.jasig.portal.groups.IEntityGroup
      */
-    public Iterator findContainingGroups(IGroupMember gm) throws GroupsException {
+    public Iterator findParentGroups(IGroupMember gm) throws GroupsException {
 
         if (isTreeRefreshRequired()) {
             refreshTree();

--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
@@ -431,7 +431,7 @@ public class PortletDefinitionImporterExporter
             // Delete existing category memberships for this channel
             if (!newChannel) {
                 @SuppressWarnings("unchecked")
-                final Iterator<IEntityGroup> iter = portletDefEntity.getAllContainingGroups();
+                final Iterator<IEntityGroup> iter = portletDefEntity.getAncestorGroups();
                 while (iter.hasNext()) {
                     final IEntityGroup group = iter.next();
                     group.removeMember(portletDefEntity);
@@ -502,7 +502,7 @@ public class PortletDefinitionImporterExporter
         String portletDefinitionId = portletDefinition.getPortletDefinitionId().getStringId();
         IEntity channelDefEntity = GroupService.getEntity(portletDefinitionId, IPortletDefinition.class);
         @SuppressWarnings("unchecked")
-        Iterator<IEntityGroup> iter = channelDefEntity.getAllContainingGroups();
+        Iterator<IEntityGroup> iter = channelDefEntity.getAncestorGroups();
         while (iter.hasNext()) {
             IEntityGroup group = iter.next();
             group.removeMember(channelDefEntity);
@@ -629,7 +629,7 @@ public class PortletDefinitionImporterExporter
         final List<String> categoryList = rep.getCategories();
         final IGroupMember gm = GroupService.getGroupMember(def.getPortletDefinitionId().getStringId(), IPortletDefinition.class);
         @SuppressWarnings("unchecked")
-        final Iterator<IEntityGroup> categories = GroupService.getCompositeGroupService().findContainingGroups(gm);
+        final Iterator<IEntityGroup> categories = GroupService.getCompositeGroupService().findParentGroups(gm);
         while (categories.hasNext()) {
             IEntityGroup category = categories.next();
             categoryList.add(category.getName());

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/registry/PortletCategoryRegistryImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/registry/PortletCategoryRegistryImpl.java
@@ -200,7 +200,7 @@ public class PortletCategoryRegistryImpl implements IPortletCategoryRegistry {
         Set<PortletCategory> parents = new HashSet<PortletCategory>();
 
         @SuppressWarnings("unchecked")
-        Iterator<IGroupMember> iter = childGroup.getContainingGroups();
+        Iterator<IGroupMember> iter = childGroup.getParentGroups();
         while (iter.hasNext()) {
             IGroupMember gm = iter.next();
             if (gm.isGroup()) {
@@ -221,7 +221,7 @@ public class PortletCategoryRegistryImpl implements IPortletCategoryRegistry {
         Set<PortletCategory> parents = new HashSet<PortletCategory>();
 
         @SuppressWarnings("unchecked")
-        Iterator<IGroupMember> iter = childEntity.getContainingGroups();
+        Iterator<IGroupMember> iter = childEntity.getParentGroups();
         while (iter.hasNext()) {
             IGroupMember gm = iter.next();
             if (gm.isGroup()) {

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/account/UserAccountHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/account/UserAccountHelper.java
@@ -179,7 +179,7 @@ public class UserAccountHelper {
     public List<JsonEntityBean> getParentGroups(String target) {
         IGroupMember member = GroupService.getEntity(target, IPerson.class);
         @SuppressWarnings("unchecked")
-        Iterator<IGroupMember> iterator = (Iterator<IGroupMember>) member.getAllContainingGroups();
+        Iterator<IGroupMember> iterator = (Iterator<IGroupMember>) member.getAncestorGroups();
         List<JsonEntityBean> parents = new ArrayList<JsonEntityBean>();
         while (iterator.hasNext()) {
             parents.add(groupListHelper.getEntity(iterator.next()));

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/groupadmin/GroupAdministrationHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/groupadmin/GroupAdministrationHelper.java
@@ -114,7 +114,7 @@ public class GroupAdministrationHelper {
 		// remove this group from the membership list of any current parent
 		// groups
 		@SuppressWarnings("unchecked")
-		Iterator<IEntityGroup> iter = (Iterator<IEntityGroup>) group.getContainingGroups();
+		Iterator<IEntityGroup> iter = (Iterator<IEntityGroup>) group.getParentGroups();
 		while (iter.hasNext()) {
 			IEntityGroup parent = (IEntityGroup) iter.next();
 			parent.removeMember(group);

--- a/uportal-war/src/main/java/org/jasig/portal/rest/permissions/PermissionsRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/permissions/PermissionsRESTController.java
@@ -298,7 +298,7 @@ public class PermissionsRESTController {
         Set<UniquePermission> inheritedAssignments = new HashSet<UniquePermission>();
         if (includeInherited) {
             IGroupMember member = GroupService.getGroupMember(p.getKey(), p.getType());
-            for (Iterator<IEntityGroup> iter = member.getAllContainingGroups(); iter.hasNext();) {
+            for (Iterator<IEntityGroup> iter = member.getAncestorGroups(); iter.hasNext();) {
                 IEntityGroup parent = iter.next();
 
                 IAuthorizationPrincipal parentPrincipal = this.authorizationService.newPrincipal(parent);
@@ -364,7 +364,7 @@ public class PermissionsRESTController {
         Set<UniquePermission> inheritedAssignments = new HashSet<UniquePermission>();
         if (includeInherited) {
             IGroupMember member = GroupService.getGroupMember(p.getKey(), p.getType());
-            for (@SuppressWarnings("unchecked") Iterator<IEntityGroup> iter = member.getAllContainingGroups(); iter.hasNext();) {
+            for (@SuppressWarnings("unchecked") Iterator<IEntityGroup> iter = member.getAncestorGroups(); iter.hasNext();) {
                 IEntityGroup parent = iter.next();
 
                 IAuthorizationPrincipal parentPrincipal = this.authorizationService.newPrincipal(parent);

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
@@ -287,7 +287,7 @@ public class AnyUnblockedGrantPermissionPolicy implements IPermissionPolicy {
         }
         seenGroups.add(principalAsGroupMember);
         @SuppressWarnings("unchecked")
-        Iterator<IGroupMember> immediatelyContainingGroups = principalAsGroupMember.getContainingGroups();
+        Iterator<IGroupMember> immediatelyContainingGroups = principalAsGroupMember.getParentGroups();
         while (immediatelyContainingGroups.hasNext()) {
             IGroupMember parentGroup = immediatelyContainingGroups.next();
             try {

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/AuthorizationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/AuthorizationImpl.java
@@ -661,7 +661,7 @@ private Iterator getGroupsForPrincipal(IAuthorizationPrincipal principal)
 throws GroupsException
 {
     IGroupMember gm = getGroupMemberForPrincipal(principal);
-    return gm.getAllContainingGroups();
+    return gm.getAncestorGroups();
 }
 
 /**
@@ -1007,7 +1007,7 @@ throws AuthorizationException
                     }
 
                     if (targetEntity != null) {
-                        for (Iterator containing = targetEntity.getAllContainingGroups(); containing.hasNext();) {
+                        for (Iterator containing = targetEntity.getAncestorGroups(); containing.hasNext();) {
                             containingGroups.add(((IEntityGroup)containing.next()).getKey());
                         }
                     }

--- a/uportal-war/src/main/java/org/jasig/portal/security/remoting/PermissionAssignmentMapController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/remoting/PermissionAssignmentMapController.java
@@ -270,7 +270,7 @@ public class PermissionAssignmentMapController extends AbstractPermissionsContro
         }
 
         AuthorizationService authService = AuthorizationService.instance();
-        Iterator<?> it = GroupService.getCompositeGroupService().findContainingGroups(member);
+        Iterator<?> it = GroupService.getCompositeGroupService().findParentGroups(member);
         if (it.hasNext()) {
             // This member must be nested within its parent(s)...
             while (it.hasNext()) {

--- a/uportal-war/src/main/java/org/jasig/portal/services/GroupService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/services/GroupService.java
@@ -77,10 +77,10 @@ public final class GroupService implements IGroupConstants {
      * Returns the groups that contain the <code>IGroupMember</code>.
      * @param gm IGroupMember
      */
-    public static Iterator findContainingGroups(IGroupMember gm) throws GroupsException
+    public static Iterator findParentGroups(IGroupMember gm) throws GroupsException
     {
-        LOGGER.trace("Invoking findContainingGroups for IGroupMember [{}]", gm);
-        return instance().ifindContainingGroups(gm);
+        LOGGER.trace("Invoking findParentGroups for IGroupMember [{}]", gm);
+        return instance().ifindParentGroups(gm);
     }
 
     /**
@@ -238,9 +238,9 @@ private GroupServiceConfiguration getServiceConfiguration() throws GroupsExcepti
      * Returns the groups that contain the <code>IGroupMember</code>.
      * @param gm IGroupMember
      */
-    private Iterator ifindContainingGroups(IGroupMember gm) throws GroupsException
+    private Iterator ifindParentGroups(IGroupMember gm) throws GroupsException
     {
-        return compositeGroupService.findContainingGroups(gm);
+        return compositeGroupService.findParentGroups(gm);
     }
 
     /**

--- a/uportal-war/src/main/java/org/jasig/portal/services/entityproperties/ContainingGroupsFinder.java
+++ b/uportal-war/src/main/java/org/jasig/portal/services/entityproperties/ContainingGroupsFinder.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.LogFactory;
  * for any entity
  *
  * @author Alex Vigdor av317@columbia.edu
- * @version $Revision$
  */
 
 public class ContainingGroupsFinder implements IEntityPropertyFinder {
@@ -51,7 +50,7 @@ public class ContainingGroupsFinder implements IEntityPropertyFinder {
       StringBuffer buf = new StringBuffer();
       if (name.equals(names[0])){
         IGroupMember gm = GroupService.getGroupMember(entityID);
-        Iterator i = gm.getContainingGroups();
+        Iterator i = gm.getParentGroups();
         int x = 0;
         while (i.hasNext()){
           if (x > 0){

--- a/uportal-war/src/main/java/org/jasig/portal/utils/threading/DoubleCheckedCreator.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/threading/DoubleCheckedCreator.java
@@ -30,13 +30,12 @@ import org.apache.commons.logging.LogFactory;
  * Implementation of double-checked locking for object creation using a {@link ReadWriteLock}
  * 
  * @author Eric Dalquist
- * @version $Revision$
  */
 public abstract class DoubleCheckedCreator<T> {
-	private static String LOGGER_NAME = DoubleCheckedCreator.class.getName();
-	
+    private static String LOGGER_NAME = DoubleCheckedCreator.class.getName();
+
     private Log logger;
-    
+
     /**
      * Inits and/or returns already initialized logger.  <br>
      * You have to use this method in order to use the logger,<br> 
@@ -55,7 +54,7 @@ public abstract class DoubleCheckedCreator<T> {
 	  }
 	  return l;
 	}
-    
+
     private final ReadWriteLock readWriteLock;
     protected final Lock readLock;
     protected final Lock writeLock;
@@ -109,9 +108,9 @@ public abstract class DoubleCheckedCreator<T> {
             final T value = this.retrieve(args);
             if (!this.invalid(value, args)) {
                 if (getLogger().isDebugEnabled()) {
-                	getLogger().debug("Using retrieved Object='" + value + "'");
+                    getLogger().debug("Using retrieved (first attempt) Object='" + value + "'");
                 }
-                
+
                 return value;
             }
         }
@@ -119,26 +118,25 @@ public abstract class DoubleCheckedCreator<T> {
             //Release the read lock
             this.readLock.unlock();
         }
-        
-        
+
         //Object must not be valid, switch to a write lock
         this.writeLock.lock();
         try {
             //Check again if the object exists and is valid
             T value = this.retrieve(args);
             if (this.invalid(value, args)) {
-                
+
                 //Object is not valid, create it
                 value = this.create(args);
-                
+
                 if (getLogger().isDebugEnabled()) {
-                	getLogger().debug("Created new Object='" + value + "'");
+                    getLogger().debug("Created new Object='" + value + "'");
                 }
             }
             else if (getLogger().isDebugEnabled()) {
-            	getLogger().debug("Using retrieved Object='" + value + "'");
+                getLogger().debug("Using retrieved (second attempt) Object='" + value + "'");
             }
-            
+
             return value;
         }
         finally {

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -394,7 +394,7 @@
      | - 1 x group member (channels, users, groups)
      | - replicated by invalidation
      +-->
-    <cache name="org.jasig.portal.groups.GroupMemberImpl.containingGroups"
+    <cache name="org.jasig.portal.groups.GroupMemberImpl.parentGroups"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1917,6 +1917,8 @@
      | logical group existed simultaneously in memory.  Due to recent changes, that
      | shouldn't be a major issue (but it's still a good idea to cache them).  Not
      | replicated.
+     |
+     | - 1 x PAGS groups in the portal
      +-->
     <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.entityGroup"
            eternal="false" overflowToDisk="false" diskPersistent="false"
@@ -1924,14 +1926,20 @@
 
     <!--
      | Stores objects of type PagsGroup, which are used to test users' attributes for
-     | membership.  (It may make sens to refactor this class out of the picture when
+     | membership.  (It may make sense to refactor this class out of the picture when
      | we have an opportunity.)  Not replicated.
+     |
+     | - 1 x PAGS groups in the portal
      +-->
     <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.pagsGroup"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="300" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>
 
-    <!-- Remembers membership decisions calculated by EntityPersonAttributesGroupStore -->
+    <!--
+     | Remembers membership decisions calculated by EntityPersonAttributesGroupStore
+     |
+     | - 1 x PAGS groups in the portal x concurrent users since TTL
+     +-->
     <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="50000" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -372,12 +372,31 @@
 
     <!--
      | Caches IEntity objects
-     | - 1 x group member (channels, users)
+     | - 1 x group member (channels, users, groups)
      | - replicated by invalidation
      +-->
     <cache name="org.jasig.portal.groups.IEntity"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory
+            class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
+            properties="replicateAsynchronously=true,
+                replicatePuts=false,
+                replicateUpdates=true, replicateUpdatesViaCopy=false,
+                replicateRemovals=true "/>
+    </cache>
+
+    <!--
+     | Caches containing groups for GroupMemberImpl objects.  There is code to
+     | invalidate (and replicate) them when they change, but the GaP code is
+     | bloated and hard to follow.  TTL is set to 5 min in case invalidation
+     | doesn't cover all paths that make changes to relationships.
+     | - 1 x group member (channels, users, groups)
+     | - replicated by invalidation
+     +-->
+    <cache name="org.jasig.portal.groups.GroupMemberImpl.containingGroups"
+        eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
+        timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1910,10 +1910,28 @@
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="100" timeToIdleSeconds="60" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true"/>
 
-    <!-- PAGS Group Definition Cache, not replicated -->
-    <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore"
+    <!--
+     | Stores objects of type IEntityGroup (concrete class EntityGroupImpl), which are
+     | the things emitted by this flavor of GaP (or any flavor) and used by the rest
+     | of the portal.  Historically, it was a big problem if multiple copies of the same
+     | logical group existed simultaneously in memory.  Due to recent changes, that
+     | shouldn't be a major issue (but it's still a good idea to cache them).  Not
+     | replicated.
+     +-->
+    <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.entityGroup"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="300" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>
+
+    <!--
+     | Stores objects of type PagsGroup, which are used to test users' attributes for
+     | membership.  (It may make sens to refactor this class out of the picture when
+     | we have an opportunity.)  Not replicated.
+     +-->
+    <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.pagsGroup"
+           eternal="false" overflowToDisk="false" diskPersistent="false"
+           maxElementsInMemory="300" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>
+
+    <!-- Remembers membership decisions calculated by EntityPersonAttributesGroupStore -->
     <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="50000" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -395,6 +395,26 @@
      | - replicated by invalidation
      +-->
     <cache name="org.jasig.portal.groups.GroupMemberImpl.parentGroups"
+        eternal="false" maxElementsInMemory="5000" overflowToDisk="false" diskPersistent="false"
+        timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory
+            class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
+            properties="replicateAsynchronously=true,
+                replicatePuts=false,
+                replicateUpdates=true, replicateUpdatesViaCopy=false,
+                replicateRemovals=true "/>
+    </cache>
+
+    <!--
+     | Caches members for EntityGroupImpl objects.  (This cache is the
+     | opposite of parentGroups, above) There is code to invalidate (and
+     | replicate) them when they change, but the GaP code is bloated and hard to
+     | follow.  TTL is set to 5 min in case invalidation doesn't cover all paths
+     | that make changes to relationships.
+     | - 1 x group (both of users and channels)
+     | - replicated by invalidation
+     +-->
+    <cache name="org.jasig.portal.groups.EntityGroupImpl.children"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory

--- a/uportal-war/src/test/groovy/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporterTest.groovy
+++ b/uportal-war/src/test/groovy/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporterTest.groovy
@@ -158,7 +158,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
             };
             1 * compositeGroupService.getEntity(_, _, _) >> portletDefEntity;
 
-            1 * portletDefEntity.getAllContainingGroups() >> [].iterator();
+            1 * portletDefEntity.getAncestorGroups() >> [].iterator();
 
             1 * authorizationService.newUpdatingPermissionManager(_) >> updatingPermissionManager;
             1 * updatingPermissionManager.getPermissions(ExternalPermissionDefinition.SUBSCRIBE.getActivity(), _) >> [];
@@ -222,7 +222,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
         };
         1 * compositeGroupService.getEntity(_, _, _) >> portletDefEntity;
 
-        1 * portletDefEntity.getAllContainingGroups() >> [].iterator();
+        1 * portletDefEntity.getAncestorGroups() >> [].iterator();
 
         1 * authorizationService.newUpdatingPermissionManager(_) >> updatingPermissionManager;
         1 * updatingPermissionManager.getPermissions(ExternalPermissionDefinition.SUBSCRIBE.getActivity(), _) >> [];
@@ -275,7 +275,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
         };
         1 * compositeGroupService.getEntity(_, _, _) >> portletDefEntity;
 
-        1 * portletDefEntity.getAllContainingGroups() >> [].iterator();
+        1 * portletDefEntity.getAncestorGroups() >> [].iterator();
 
         1 * authorizationService.newUpdatingPermissionManager(_) >> updatingPermissionManager;
         1 * updatingPermissionManager.getPermissions(ExternalPermissionDefinition.SUBSCRIBE.getActivity(), _) >> [];
@@ -331,7 +331,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
         };
         1 * compositeGroupService.getEntity(_, _, _) >> portletDefEntity;
 
-        1 * portletDefEntity.getAllContainingGroups() >> [].iterator();
+        1 * portletDefEntity.getAncestorGroups() >> [].iterator();
 
         1 * authorizationService.newUpdatingPermissionManager(_) >> updatingPermissionManager;
         1 * updatingPermissionManager.getPermissions(ExternalPermissionDefinition.SUBSCRIBE.getActivity(), _) >> [];
@@ -409,7 +409,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
 
             1 * oldGroupStudent.removeMember(portletDefEntity);
             1 * oldGroupStaff.removeMember(portletDefEntity);
-            1 * portletDefEntity.getAllContainingGroups() >> {
+            1 * portletDefEntity.getAncestorGroups() >> {
                 return [
                     oldGroupStudent,
                     oldGroupStaff
@@ -502,7 +502,7 @@ public class PortletDefinitionImporterExporterTest extends Specification {
 
             1 * oldGroupStudent.removeMember(portletDefEntity);
             1 * oldGroupStaff.removeMember(portletDefEntity);
-            1 * portletDefEntity.getAllContainingGroups() >> {
+            1 * portletDefEntity.getAncestorGroups() >> {
                 return [
                     oldGroupStudent,
                     oldGroupStaff

--- a/uportal-war/src/test/java/org/jasig/portal/groups/GroupsTester.java
+++ b/uportal-war/src/test/java/org/jasig/portal/groups/GroupsTester.java
@@ -108,7 +108,7 @@ public class GroupsTester extends TestCase {
                 { numMembers++; }
             for (itr = group.getEntities(); itr.hasNext(); itr.next() )
                 { numEntities++; }
-            for (itr = group.getContainingGroups(); itr.hasNext(); itr.next() )
+            for (itr = group.getParentGroups(); itr.hasNext(); itr.next() )
                 { numContainingGroups++; }
 //          print (printID + " members: " + numMembers + " entities: " + numEntities + " containing groups: " + numContainingGroups);
         }
@@ -741,7 +741,7 @@ public void testDeleteChildGroup() throws Exception
     msg = "Retrieving containing groups from child.";
     print(msg);
     list = new ArrayList();
-    for( itr=child.getContainingGroups(); itr.hasNext(); )
+    for( itr=child.getParentGroups(); itr.hasNext(); )
         { list.add(itr.next()); }
     assertEquals(msg, (totNumGroups - 1), list.size());
 
@@ -1065,7 +1065,7 @@ public void testRetrieveParentGroups() throws Exception
     msg = "Getting containing groups for " + testEntity;
     print(msg);
     list = new ArrayList();
-    for (it = testEntity.getContainingGroups(); it.hasNext();)
+    for (it = testEntity.getParentGroups(); it.hasNext();)
         { list.add(it.next()); }
     assertEquals(msg, numContainingGroups, list.size());
 
@@ -1084,7 +1084,7 @@ public void testRetrieveParentGroups() throws Exception
     msg = "Getting ALL containing groups for " + testEntity;
     print(msg);
     list = new ArrayList();
-    for (it = testEntity.getAllContainingGroups(); it.hasNext();)
+    for (it = testEntity.getAncestorGroups(); it.hasNext();)
         { list.add(it.next()); }
     assertEquals(msg, numAllGroups, list.size());
     
@@ -1093,7 +1093,7 @@ public void testRetrieveParentGroups() throws Exception
     msg = "Getting ALL containing groups for DUPLICATE entity:" + testEntity;
     print(msg);
     list = new ArrayList();
-    for (it = duplicateTestEntity.getAllContainingGroups(); it.hasNext();)
+    for (it = duplicateTestEntity.getAncestorGroups(); it.hasNext();)
         { list.add(it.next()); }
     assertEquals(msg, numAllGroups, list.size());
       
@@ -1360,7 +1360,7 @@ public void testUpdateMembersVisibility() throws Exception
     list = new ArrayList();
     for(idx=1; idx<totNumGroups; idx++)
     { 
-        for (itr = groups[idx].getContainingGroups(); itr.hasNext();)
+        for (itr = groups[idx].getParentGroups(); itr.hasNext();)
             { list.add(itr.next()); }
         assertEquals(msg, 0, list.size());
     }
@@ -1407,7 +1407,7 @@ public void testUpdateMembersVisibility() throws Exception
     msg = "Checking child entity for ALL containing groups.";
     print(msg);
     list = new ArrayList();
-    for (itr = ent.getAllContainingGroups(); itr.hasNext();)
+    for (itr = ent.getAncestorGroups(); itr.hasNext();)
             { list.add(itr.next()); }
     assertEquals(msg, 2, list.size());
     

--- a/uportal-war/src/test/java/org/jasig/portal/groups/GroupsTester.java
+++ b/uportal-war/src/test/java/org/jasig/portal/groups/GroupsTester.java
@@ -258,13 +258,6 @@ private String getRandomString(java.util.Random r, int length) {
     return new String(chars);
 }
 /**
- * @return org.jasig.portal.services.GroupService
- */
-private GroupService getService() throws GroupsException
-{
-    return GroupService.instance();
-}
-/**
  * Starts the application.
  * @param args an array of command-line arguments
  */


### PR DESCRIPTION
…pl.getContainingGroups()

https://issues.jasig.org/browse/UP-4656

## Microbenchmarking

**WARNING:  These numbers reflect an early point in this PR and are not representative of the change.**

I'm using a server DEV deployment with MySQL and a lot of data (portlets & groups).

### Sample Requests to /Login Before (this patch)
```
TRACE [ajp-nio-127.0.0.1-8009-exec-8-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-06 18:22:16,241 - FINISHED PortalPreAuthenticatedProcessingFilter.doFilter() for ec7498d3-bfdb-44fb-a3c4-967b73530c59 in 5604ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-5-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-06 18:23:47,951 - FINISHED PortalPreAuthenticatedProcessingFilter.doFilter() for bb85c2bc-0792-486f-930b-53e03f9be1db in 3897ms #milestone
```

### Sample Requests to /Login After (this patch)
```
TRACE [ajp-nio-127.0.0.1-8009-exec-4-guest] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:29:10,365 - FINISHED [8aa27d74-72fa-48ee-b69e-223058cb66c4] for URI=/uPortal/Login in 2677ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-2-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:30:09,705 - FINISHED [9d1b3b51-94cf-4574-be24-14af81c33e2b] for URI=/uPortal/Login in 3648ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-8-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:30:52,665 - FINISHED [66322f27-b62b-4480-a740-ccd7b5a90106] for URI=/uPortal/Login in 1919ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-5-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:31:29,558 - FINISHED [d8ee2d3d-4f78-47d1-a3be-50383a33c96f] for URI=/uPortal/Login in 2355ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-9-idda@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:33:18,148 - FINISHED [53691b1c-a6ba-475e-87f8-a886cfeee056] for URI=/uPortal/Login in 2354ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-8-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:35:19,512 - FINISHED [7db5278e-44fd-4e2e-b332-ad686ff68af0] for URI=/uPortal/Login in 8498ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-2-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:35:40,193 - FINISHED [59add746-4d6d-4d9b-bdd5-7c5187b152b4] for URI=/uPortal/Login in 3724ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-6-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:36:32,918 - FINISHED [cad6f345-2eec-42ff-bc07-33ab1e5e590b] for URI=/uPortal/Login in 7ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-5-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:36:43,617 - FINISHED [ba8769c0-6fa6-4533-9f26-e013a0c4641a] for URI=/uPortal/Login in 3000ms #milestone
TRACE [ajp-nio-127.0.0.1-8009-exec-10-andrewwills@district87.illinicloud.org] o.j.p.s.s.p.PortalPreAuthenticatedProcessingFilter 2016-04-08 17:37:08,668 - FINISHED [4d965de3-152d-4069-b5f0-207f29ac3f24] for URI=/uPortal/Login in 2976ms #milestone
```