### PR TITLE
UP-4483:  Looks like a cache for PersonAttributesGroupDefinitionImpl.…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupDefinitionImpl.java
@@ -109,6 +109,7 @@ public class PersonAttributesGroupDefinitionImpl implements IPersonAttributesGro
     @JoinTable(name="UP_PAGS_GROUP_MEMBERS", joinColumns = {@JoinColumn(name="PAGS_GROUP_ID")}, inverseJoinColumns={@JoinColumn(name="PAGS_GROUP_MEMBER_ID")})
     @JsonSerialize(using=PagsDefinitionJsonUtils.DefinitionLinkJsonSerializer.class)
     @JsonDeserialize(using=PagsDefinitionJsonUtils.DefinitionLinkJsonDeserializer.class)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<IPersonAttributesGroupDefinition> members = new HashSet<IPersonAttributesGroupDefinition>(0);
 
     @OneToMany(cascade=CascadeType.ALL, mappedBy="group", targetEntity=PersonAttributesGroupTestGroupDefinitionImpl.class, orphanRemoval=true)

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1888,6 +1888,10 @@
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="350" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
 
+    <cache name="org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupDefinitionImpl.members"
+           eternal="false" overflowToDisk="false" diskPersistent="false"
+           maxElementsInMemory="300" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
+
     <cache name="org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupDefinitionImpl.testGroups"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="300" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>


### PR DESCRIPTION
…members may have been overlooked

https://issues.jasig.org/browse/UP-4483

Do we need a cache here as well?

The table that backs this collection is one of the high-usage tables identified in the graphs.  I have a newer graph from Manchester -- including the previous updates for this ticket -- that identifies this table (and only this table).