### PR TITLE
UP-4626 Add <portlet> type to permission targets, fix export

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/io/GroupKeyLiteralOrPortletPhrase.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/GroupKeyLiteralOrPortletPhrase.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.io;
+
+import org.danann.cernunnos.Formula;
+import org.danann.cernunnos.Reagent;
+import org.danann.cernunnos.SimpleFormula;
+import org.danann.cernunnos.TaskRequest;
+import org.danann.cernunnos.TaskResponse;
+import org.dom4j.Element;
+import org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl;
+import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.portlet.registry.IPortletDefinitionRegistry;
+import org.jasig.portal.security.IPermission;
+import org.jasig.portal.spring.locator.ApplicationContextLocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class that parses an XML element to determine if it is
+ * <group>groupName</group>
+ * <portlet>fname</portlet>
+ * <literal>usernameSpecialPermissionStringEtc</literal>
+ */
+public class GroupKeyLiteralOrPortletPhrase extends GroupKeyOrLiteralPhrase {
+    // From Cernunnos API
+    public static final String FILE_LOCATION = "Attributes.LOCATION";
+
+    private Logger log = LoggerFactory.getLogger(this.getClass());
+
+    // Dynamically created so Autowired won't work until we implement AspectJ AOP. Using init method to populate.
+    private IPortletDefinitionRegistry portletDefinitionRegistry;
+
+    /*
+     * Public API.
+     */
+
+    public Formula getFormula() {
+        Reagent[] reagents = new Reagent[] {ELEMENT};
+        return new SimpleFormula(GroupKeyLiteralOrPortletPhrase.class, reagents);
+    }
+
+    // Must execute this method at runtime rather than Spring Context initialization since the ApplicationContent
+    // is not available when this class is constructed (cernnunos scripts are parsed and objects initialized
+    // during Spring Context initialization). An alternative is to invoke this code via Groovy rather than
+    // cernnunos.  No need to make syncrhonized or use transient field since multiple threads of execution
+    // would get the same value.
+    private void postInit() {
+        if (portletDefinitionRegistry == null) {
+            portletDefinitionRegistry = (IPortletDefinitionRegistry)
+                    ApplicationContextLocator.getApplicationContext().getBean("portletDefinitionRegistry");
+        }
+    }
+
+    public Object evaluate(TaskRequest req, TaskResponse res) {
+        // Ugly, but must do at runtime and not class initialization time
+        postInit();
+
+        String rslt = null;
+
+        Element e = (Element) element.evaluate(req, res);
+        if (e.getName().equals("group")) {
+            rslt = getValidatedGroupName(e);
+        } else if (e.getName().equals("portlet")) {
+            String fname = e.getText();
+            IPortletDefinition portlet = portletDefinitionRegistry.getPortletDefinitionByFname(fname);
+            if (portlet == null) {
+                throw new RuntimeException("Invalid portlet fname '" + fname + "' in file "
+                        + req.getAttribute(FILE_LOCATION));
+            } else if (portlet instanceof PortletDefinitionImpl) {
+                rslt = IPermission.PORTLET_PREFIX +
+                        ((PortletDefinitionImpl) portlet).getPortletDefinitionId().getLongId();
+            } else {
+                throw new RuntimeException("Unknown portlet type fname '" + fname + "'. Is not a PortletDefinitionImpl");
+            }
+        } else if (e.getName().equals("literal")) {
+            rslt = e.getText();
+            if (rslt != null && rslt.startsWith(IPermission.PORTLET_PREFIX)) {
+                throw new RuntimeException("Invalid literal string " + rslt + " in file "
+                        + req.getAttribute(FILE_LOCATION) + ". This is probably due to export of permission"
+                        + " using an older version of uPortal doing an export that didn't support the new"
+                        + " <portlet> element.  You will need to lookup the portlet with the ID value '"
+                        + rslt.substring(IPermission.PORTLET_PREFIX.length())
+                        + "' in the UP_PORTLET_DEF table and replace the <literal> element in the XML file with"
+                        + " <portlet>portletFname</portlet> then re-import.");
+            }
+        } else {
+            String msg = "Unsupported element type:  " + e.getName();
+            throw new RuntimeException(msg);
+        }
+
+        return rslt;
+
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
@@ -93,7 +93,7 @@ import org.springframework.util.StringUtils;
 @NaturalIdCache(region = "org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-class PortletDefinitionImpl implements IPortletDefinition {
+public class PortletDefinitionImpl implements IPortletDefinition {
     //Properties are final to stop changes in code, hibernate overrides the final via reflection to set their values
     @Id
     @GeneratedValue(generator = "UP_PORTLET_DEF_GEN")

--- a/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/shell/PortalShellBuildHelperImpl.java
@@ -337,7 +337,7 @@ public class PortalShellBuildHelperImpl implements PortalShellBuildHelper {
                     new IPortalDataHandlerService.BatchImportOptions().setLogDirectoryParent(logDir));
         }
         catch (Exception e) {
-            if (pattern != null) {
+            if (patternToUse != null) {
                 throw new RuntimeException(target + " from " + dataDir + " matching " + patternToUse + " failed", e);
             }
             else {

--- a/uportal-war/src/main/resources/org/jasig/portal/io/export-permission_sets.crn
+++ b/uportal-war/src/main/resources/org/jasig/portal/io/export-permission_sets.crn
@@ -135,6 +135,23 @@
                                             </otherwise>
                                         </choose>
                                     </when>
+                                    <when test="${jexl(TARGET.startsWith('PORTLET_ID.'))}">
+                                        <with-attribute key="PORTLET" value="${groovy(org.jasig.portal.spring.locator.ApplicationContextLocator.getApplicationContext().getBean('portletDefinitionRegistry').getPortletDefinition(new org.jasig.portal.portlet.dao.jpa.PortletDefinitionIdImpl(Long.parseLong(TARGET.substring(11)))))}">
+                                            <choose>
+                                                <when test="${jexl(PORTLET != null)}">
+                                                    <append-node>
+                                                        <target permission-type="${PERMISSION_TYPE}">
+                                                            <portlet>${jexl(PORTLET.getFName())}</portlet>
+                                                        </target>
+                                                    </append-node>
+                                                </when>
+                                                <otherwise>
+                                                    <log logger-name="org.jasig.portal.io.export-permissions" level="error">Permission target references a deleted portlet;  removing orphaned reference.</log>
+                                                    <append-node node="${attributeNode(cancel=true)}"/>
+                                                </otherwise>
+                                            </choose>
+                                        </with-attribute>
+                                    </when>
                                     <otherwise>
                                         <append-node>
                                             <target permission-type="${PERMISSION_TYPE}">

--- a/uportal-war/src/main/resources/org/jasig/portal/io/import-permission_set_v3-1.crn
+++ b/uportal-war/src/main/resources/org/jasig/portal/io/import-permission_set_v3-1.crn
@@ -65,7 +65,7 @@
                                 <parameter value="${ENTITY_TYPE_ID}"/>
                                 <parameter value="${PRINCIPAL}"/>
                                 <parameter value="${ACTIVITY}"/>
-                                <parameter value="${org.jasig.portal.io.GroupKeyOrLiteralPhrase(${singleNode(*)})}"/>
+                                <parameter value="${org.jasig.portal.io.GroupKeyLiteralOrPortletPhrase(${singleNode(*)})}"/>
                             </sql-upsert>
                         </node-iterator>
                     </otherwise>


### PR DESCRIPTION
Fix issue in import/export.  Currently an export creates permission-set XML files that list the ID number of the portlet so these files will not import properly.

Old export output:
```
<?xml version="1.0" encoding="UTF-8"?><permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
  <owner>UP_PORTLET_SUBSCRIBE</owner>
  <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
  <principal>
    <group>Tenant Administrators</group>
  </principal>
  <activity>BROWSE</activity>
  <target permission-type="GRANT">
    <literal>PORTLET_ID.1</literal>
  </target>
  <target permission-type="GRANT">
    <literal>PORTLET_ID.10</literal>
  </target>
  <target permission-type="GRANT">
    <literal>PORTLET_ID.15</literal>
  </target>
</permission-set>
```

With fix:
```
<?xml version="1.0" encoding="UTF-8"?><permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
  <owner>UP_PORTLET_SUBSCRIBE</owner>
  <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
  <principal>
     <group>Tenant Administrators</group>
  </principal>
  <activity>BROWSE</activity>
  <target permission-type="GRANT">
    <portlet>fragment-admin</portlet>
  </target>
  <target permission-type="GRANT">
    <portlet>instructions-for-new-tenants</portlet>
  </target>
  <target permission-type="GRANT">
    <portlet>portlet-admin</portlet>
  </target>
</permission-set>
```

Also with new code during import if a literal element is detected that starts with PORTLET_ID., an error is thrown with the message:

	... 79 common frames omitted
Caused by: java.lang.RuntimeException: Invalid literal string PORTLET_ID.39 in file:/home/jwennmacher/projects/uPortal/uPortal/perms2/permission-set/Authenticated_Users__BROWSE__UP_PORTLET_SUBSCRIBE.permission-set.xml. This is probably due to export of permission using an older version of uPortal doing an export that didn't support the new <portlet> element.  You will need to lookup the portlet with the ID value '39' in the UP_PORTLET_DEF table and replace the <literal> element in the XML file with <portlet>portletFname</portlet> then re-import.
	at org.jasig.portal.io.GroupKeyLiteralOrPortletPhrase.evaluate(GroupKeyLiteralOrPortletPhrase.java:101)

With these changes I didn't see a need to bump the permission-set version number as it catches the invalid data and provides instructions on remedy.  There is no way to 'convert' an incorrect xml file to correct data.