### PR TITLE
UP-4473: Fixed component-scan exclude-filter regex expressions, addin…

### DIFF
--- a/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
@@ -33,15 +33,19 @@
     <aop:aspectj-autoproxy/>
     
     <context:annotation-config/>
+    <context:component-scan base-package="org.jasig.portal.portlets">
+        <context:include-filter type="regex" expression=".*\.PortletPreferencesJsonDao" />
+        <context:include-filter type="regex" expression=".*\.account\.UserAccountHelper" />
+    </context:component-scan>
     <context:component-scan base-package="org.jasig.portal">
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.portlets\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.security\.mvc\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.json\.rendering\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.layout\.dlm\.remoting\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.security\.remoting\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.rest\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.redirect\."/>
-        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.rendering\."/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.portlets\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.security\.mvc\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.json\.rendering\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.layout\.dlm\.remoting\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.security\.remoting\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.rest\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.redirect\..+"/>
+        <context:exclude-filter type="regex" expression="org\.jasig\.portal\.rendering\..+"/>
     </context:component-scan>
     
     <bean id="primaryPropertyPlaceholderConfigurer" class="org.springframework.context.support.PortalPropertySourcesPlaceholderConfigurer">


### PR DESCRIPTION
…g some new required 'portlets' includes.


I ran into an issue that stemmed from UP-4473, so spent some time addressing this.  The issue I had was that I was updating the Dynamic Skin portlet and had defined some beans in the portlet context file that needed to be autowired into a service class.  However, with the component scan exclude-filter misconfigured, the DynamicSkin @Service beans were being created outside of the portlet context, my new beans were not found since they are only defined at the portlet level, and I was getting a dependency resolution exception. 