### PR TITLE
Update session.json on backend to return timeout data.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rest/SessionRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/SessionRESTController.java
@@ -76,7 +76,7 @@ public class SessionRESTController {
         final ModelAndView mv = new ModelAndView();
         
         HttpSession session = request.getSession(false);
-        
+
         if (session == null) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         }
@@ -100,11 +100,6 @@ public class SessionRESTController {
             // Timing information for smarter frontends
             long timeoutMS = 1000l * (long)session.getMaxInactiveInterval();
             attributes.put("timeoutMS", timeoutMS);
-
-            long inactiveMS = new Date().getTime() - session.getLastAccessedTime();
-            long remainingMS = timeoutMS - inactiveMS;
-
-            attributes.put("remainingMS", remainingMS);
 
             try {
                 attributes.put("serverName", InetAddress.getLocalHost().getHostName());

--- a/uportal-war/src/main/java/org/jasig/portal/rest/SessionRESTController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/SessionRESTController.java
@@ -20,7 +20,6 @@ package org.jasig.portal.rest;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
This patch will add timeout information to the `session.json` API endpoint, so that smarter front-ends, which may not be interacting with the server whilst the user is still active on the page, can decide what the deadline is, and if/how to inform the user.