### PR TITLE
UP-4685 Adds ServerProfileMapper

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/ServerProfileMapperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/ServerProfileMapperImpl.java
@@ -1,0 +1,90 @@
+package org.jasig.portal.layout.profile;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.Validate;
+import org.jasig.portal.security.IPerson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+/**
+ * Returns the specified profile FName for a given server specified in the
+ * server regular expression or returns null if server doesn't match
+ *
+ * This mapper is intended to be used within the profile mapping chain within
+ * ChaniningProfileMapperImpl
+ *
+ */
+public class ServerProfileMapperImpl implements IProfileMapper{
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private String profile = "default";
+
+    private String serverRegex;
+
+    private Pattern pattern;
+
+    /**
+     * Sets the regular expression for the servers you want to select a profile
+     * for
+     * @param serverRegex
+     */
+    @Required
+    public void setServerRegex(String serverRegex){
+        Validate.notBlank(serverRegex);
+        this.serverRegex = serverRegex;
+        this.pattern = Pattern.compile(this.serverRegex);
+    }
+
+    /**
+     * Sets the profile users will be sent to
+     * @param defaultProfile
+     */
+    public void setProfile(String profile){
+        Validate.notBlank(profile);
+        this.profile = profile;
+    }
+
+    /**
+     * Returns the profile name specified by
+     * {@link #setDefaultProfile(String defaultProfile) setDefaultProfile} or
+     * "default" if
+     * {@link #setDefaultProfile(String defaultProfile) setDefaultProfile} is
+     * not called if the user is using a server in the server regular expression
+     * specified by {@link #setServerRegex(String serverRegex) setServerRegex}
+     * returns null otherwise
+     *
+     * @param person cannot be null
+     * @param request cannot be null
+     */
+    @Override
+    public String getProfileFname(IPerson person, HttpServletRequest request) {
+        Validate.notNull(person,
+          "Cannot get profile fname for a null person.");
+        Validate.notNull(request,
+          "Cannot get profile fname for a null request.");
+
+        String userName = person.getUserName();
+
+        final String userServerName = request.getServerName();
+
+        Matcher matcher = this.pattern.matcher(userServerName);
+
+        if(matcher.matches()){
+            logger.debug("User {} will be given {} profile because server {} matches regular expression {}",
+              userName, this.profile, userServerName, this.serverRegex);
+            return this.profile;
+        }else{
+            logger.debug("User {} will not be given {} profile because server {} does not match regular expression {}",
+              userName, this.profile, userServerName, this.serverRegex);
+            return null;
+        }
+    }
+
+
+}

--- a/uportal-war/src/main/resources/properties/contexts/userContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/userContext.xml
@@ -59,6 +59,9 @@
         <property name="subMappers">
             <util:list>
                 <ref bean="sessionAttributeProfileMapper" />
+                
+                <!-- If the user's server dictates to use a profile, apply it -->
+                <!-- <ref bean="serverProfileMapper" />  -->
 
                 <!--
                  | uPortal 4.1 promotes a responsive design theme Respondr.  The older uPortal 3.x, 4.0x
@@ -92,6 +95,14 @@
             </util:list>
         </property>
     </bean>
+    
+    <!-- Example of how to use serverProfileMapper.  This puts users on profile=default
+    for any server that matches the regex (everything not *.wisconsin.edu* for example -->
+    <!-- 
+    <bean id="serverProfileMapper" class="org.jasig.portal.layout.profile.ServerProfileMapperImpl"
+        p:serverRegex="^((?!.\\.wisconsin\\.edu).)*$"
+        p:profile="default" />
+    -->
 
     <bean id="sessionAttributeProfileMapper" class="org.jasig.portal.layout.profile.SessionAttributeProfileMapperImpl"
         p:mappings-ref="profileKeyMappings"/>

--- a/uportal-war/src/test/java/org/jasig/portal/layout/profile/ServerProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/profile/ServerProfileMapperImplTest.java
@@ -1,0 +1,115 @@
+package org.jasig.portal.layout.profile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.security.IPerson;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ServerProfileMapperImplTest{
+
+    @Mock HttpServletRequest request;
+
+    @Mock IPerson person;
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+
+    private String serverRegex;
+
+    private Pattern pattern;
+
+    private String nonMatchingHost1;
+    private String nonMatchingHost2;
+    private String matchingHost1;
+    private String matchingHost2;
+    private String matchingHost3;
+
+
+    ServerProfileMapperImpl serverProfileMapper = new ServerProfileMapperImpl();
+
+    @Before
+    public void setUp(){
+
+        MockitoAnnotations.initMocks(this);
+
+        //regex matches everything that isn't *.wisconsin.edu*
+        serverRegex = "^((?!.\\.wisconsin\\.edu).)*$";
+        pattern = Pattern.compile(serverRegex);
+        serverProfileMapper.setServerRegex(serverRegex);
+        nonMatchingHost1 = "my.wisconsin.edu";
+        nonMatchingHost2 = "predev.wisconsin.edu/profile";
+        matchingHost1 = "my.wisc.edu";
+        matchingHost2 = "my.university-of-wisconsin.edu/money";
+        matchingHost3 = "my.uwrf.edu";
+
+        //Make sure that matching hosts match
+        assertTrue(pattern.matcher(matchingHost1).matches());
+        assertTrue(pattern.matcher(matchingHost2).matches());
+        assertTrue(pattern.matcher(matchingHost3).matches());
+
+        //Make sure that unmatching hosts don't match
+        assertFalse(pattern.matcher(nonMatchingHost1).matches());
+        assertFalse(pattern.matcher(nonMatchingHost2).matches());
+    }
+
+    @Test
+    public void testNullorEmptyRegex(){
+        thrown.expect(NullPointerException.class);
+        serverProfileMapper.setServerRegex(null);
+        thrown.expect(IllegalArgumentException.class);
+        serverProfileMapper.setServerRegex("");
+    }
+
+    @Test
+    public void testNullorEmptyProfile(){
+        thrown.expect(NullPointerException.class);
+        serverProfileMapper.setProfile(null);
+        thrown.expect(IllegalArgumentException.class);
+        serverProfileMapper.setProfile("");
+    }
+
+    @Test
+    public void testNullParametersToGetProfileName(){
+        thrown.expect(NullPointerException.class);
+        serverProfileMapper.getProfileFname(null, request);
+        serverProfileMapper.getProfileFname(person, null);
+        when(person.getUserName()).thenReturn(null);
+        serverProfileMapper.getProfileFname(person, request);
+    }
+
+    @Test
+    public void testDefaultProfileExistsForServerMatch(){
+        when(request.getServerName()).thenReturn(matchingHost1);
+        assertNotNull(serverProfileMapper.getProfileFname(person, request));
+    }
+
+    @Test
+    public void testGetProfileFnameWithSpecifiedProfile(){
+        String buckyProfile = "bucky";
+        serverProfileMapper.setProfile(buckyProfile);
+        when(request.getServerName()).thenReturn(matchingHost1);
+        assertEquals(serverProfileMapper.getProfileFname(person, request),
+          buckyProfile);
+    }
+
+    @Test
+    public void testGetProfileNoServerMatch(){
+      when(request.getServerName()).thenReturn(nonMatchingHost1);
+      assertNull(serverProfileMapper.getProfileFname(person, request));
+    }
+
+}


### PR DESCRIPTION
Allows the profile of a user to be dictated by what server the user is coming from, so that the user can test different profiles based on server.

Came up for us when one of our system schools (UW-River Falls) wanted to test our new profile via a specific url (my.uwrf.edu) but still retain the current profile at the old host (my.wisconsin.edu).

Adds the ability to select servers based on regular expression.

This is turned off by default, but does include commented examples of how to use.