### PR TITLE
UP-4691 Adds method to reset user's layouts on all profiles

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/UserLayoutHelperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/UserLayoutHelperImpl.java
@@ -30,7 +30,6 @@ import org.jasig.portal.IUserProfile;
 import org.jasig.portal.PortalException;
 import org.jasig.portal.security.PersonFactory;
 import org.jasig.portal.security.provider.RestrictedPerson;
-import org.jasig.portal.spring.locator.UserLayoutStoreLocator;
 import org.jasig.services.persondir.IPersonAttributes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
@@ -50,6 +49,13 @@ public class UserLayoutHelperImpl extends JdbcDaoSupport implements IUserLayoutH
 	
 	protected final Log logger = LogFactory.getLog(this.getClass());
 	private IUserIdentityStore userIdentityStore;
+	
+    private IUserLayoutStore userLayoutStore;
+    
+    @Autowired(required = true)
+    public void setUserLayoutStore(IUserLayoutStore userLayoutStore) {
+        this.userLayoutStore = userLayoutStore;
+    }
 
 	/**
 	 * @param userIdentityStore the userIdentityStore to set
@@ -74,7 +80,6 @@ public class UserLayoutHelperImpl extends JdbcDaoSupport implements IUserLayoutH
 		int uid = userIdentityStore.getPortalUID( person, false );
 		person.setID(uid);
 
-		IUserLayoutStore userLayoutStore = UserLayoutStoreLocator.getUserLayoutStore();
 		try {
 			// determine user profile            
 			IUserProfile userProfile = userLayoutStore.getUserProfileByFname(person, DEFAULT_LAYOUT_FNAME);

--- a/uportal-war/src/main/java/org/jasig/portal/layout/UserLayoutHelperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/UserLayoutHelperImpl.java
@@ -21,6 +21,9 @@
  */
 package org.jasig.portal.layout;
 
+import java.util.Hashtable;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
@@ -28,6 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jasig.portal.IUserIdentityStore;
 import org.jasig.portal.IUserProfile;
 import org.jasig.portal.PortalException;
+import org.jasig.portal.UserProfile;
 import org.jasig.portal.security.PersonFactory;
 import org.jasig.portal.security.provider.RestrictedPerson;
 import org.jasig.services.persondir.IPersonAttributes;
@@ -64,6 +68,35 @@ public class UserLayoutHelperImpl extends JdbcDaoSupport implements IUserLayoutH
 	public void setUserIdentityStore(IUserIdentityStore userIdentityStore) {
 		this.userIdentityStore = userIdentityStore;
 	}
+	
+    
+    /**
+     * Resets a users layout for all the users profiles
+     * @param personAttributes
+     */
+    public void resetUserLayoutAllProfiles(final IPersonAttributes personAttributes){
+
+        RestrictedPerson person = PersonFactory.createRestrictedPerson();       
+        person.setAttributes(personAttributes.getAttributes());
+        // get the integer uid into the person object without creating any new person data       
+        int uid = userIdentityStore.getPortalUID( person, false );
+        person.setID(uid);
+
+        try {
+            Hashtable<Integer, UserProfile> userProfileList = userLayoutStore.getUserProfileList(person);
+            for(Integer key: userProfileList.keySet()){
+                UserProfile userProfile = userProfileList.get(key);
+                userProfile.setLayoutId(0);
+                userLayoutStore.updateUserProfile(person, userProfile);
+                logger.info("resetUserLayout complete for " + person + "for profile "+userProfile);
+            }
+        } catch (Exception e) {
+            final String msg = "Exception caught during resetUserLayout for " + person;
+            logger.error(msg, e);
+            throw new PortalException(msg, e);
+        }
+        return;
+    }
 
 	/**
 	 * @param personAttributes

--- a/uportal-war/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-user-layout.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-user-layout.xml
@@ -27,6 +27,8 @@
     
     <view-state id="reset-confirm">
         <transition on="confirm" to="reset-result">
+            <!-- Choose resetUserLayoutAllProfiles if on layout reset, you need
+            to reset all layouts on user's profiles, not just the default profile -->
             <evaluate expression="userLayoutHelper.resetUserLayout(person)"/>
         </transition>
         <transition on="cancel" to="reset-complete"/>


### PR DESCRIPTION
Currently, we have two profiles at Wisconsin.  We have "default" (universality/muniversality) and our new profile "bucky".

When a user clicks reset-my-layout, their "default" resets, but not their "bucky" layout.  So, this adds a method so that if you click that button, all your layouts get reset.  This is off by default, but has a comment on how to turn it on.

I'm guessing this was also a case when we had both respondr and univerality/muniversality.

I'll also mention, that yes, we will be moving away from universality/muniversality soon, so no judging on that.