### PR TITLE
NOJIRA: Solve I18N problems on xsl translated messages for javascript properties

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/security/xslt/IXalanMessageHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/xslt/IXalanMessageHelper.java
@@ -38,4 +38,12 @@ public interface IXalanMessageHelper {
     public String getMessage(String code, String language, String arg1, String arg2);
     
     public String getMessage(String code, String language, String arg1, String arg2, String arg3);
+
+    public String getMessageForEmacsScript(String code, String language);
+
+    public String getMessageForEmacsScript(String code, String language, String arg1);
+
+    public String getMessageForEmacsScript(String code, String language, String arg1, String arg2);
+
+    public String getMessageForEmacsScript(String code, String language, String arg1, String arg2, String arg3);
 }

--- a/uportal-war/src/main/java/org/jasig/portal/security/xslt/XalanMessageHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/xslt/XalanMessageHelper.java
@@ -49,4 +49,20 @@ public final class XalanMessageHelper {
     public static String getMessage(String code, String language, String arg1, String arg2, String arg3) {
         return messageHelper.getMessage(code, language, arg1, arg2, arg3);
     }
+
+    public static String getMessageForEmacsScript(String code, String language) {
+        return messageHelper.getMessageForEmacsScript(code, language);
+    }
+
+    public static String getMessageForEmacsScript(String code, String language, String arg1) {
+        return messageHelper.getMessageForEmacsScript(code, language, arg1);
+    }
+
+    public static String getMessageForEmacsScript(String code, String language, String arg1, String arg2) {
+        return messageHelper.getMessageForEmacsScript(code, language, arg1, arg2);
+    }
+
+    public static String getMessageForEmacsScript(String code, String language, String arg1, String arg2, String arg3) {
+        return messageHelper.getMessageForEmacsScript(code, language, arg1, arg2, arg3);
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/security/xslt/XalanMessageHelperBean.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/xslt/XalanMessageHelperBean.java
@@ -20,6 +20,7 @@ package org.jasig.portal.security.xslt;
 
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.jasig.portal.i18n.LocaleManager;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
@@ -57,5 +58,25 @@ public class XalanMessageHelperBean implements IXalanMessageHelper, MessageSourc
     public String getMessage(String code, String language, String arg1, String arg2, String arg3) {
         final Locale locale = LocaleManager.parseLocale(language);
         return messageSource.getMessage(code, new Object[] { arg1, arg2, arg3 }, locale);
+    }
+
+    @Override
+    public String getMessageForEmacsScript(String code, String language) {
+        return StringEscapeUtils.escapeEcmaScript(this.getMessage(code, language));
+    }
+
+    @Override
+    public String getMessageForEmacsScript(String code, String language, String arg1) {
+        return StringEscapeUtils.escapeEcmaScript(this.getMessage(code, language, arg1));
+    }
+
+    @Override
+    public String getMessageForEmacsScript(String code, String language, String arg1, String arg2) {
+        return StringEscapeUtils.escapeEcmaScript(this.getMessage(code, language, arg1, arg2));
+    }
+
+    @Override
+    public String getMessageForEmacsScript(String code, String language, String arg1, String arg2, String arg3) {
+        return StringEscapeUtils.escapeEcmaScript(this.getMessage(code, language, arg1, arg2, arg3));
     }
 }

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -549,14 +549,14 @@
         up.jQuery(document).ready(function() {
         
             if(window.location.search.indexOf('redirectToDefault=true') > 0) {
-              up.jQuery('#up-notification').noty({text: '<xsl:value-of select="upMsg:getMessage('error.redirectinfo', $USER_LANG)"/>', type: 'information'});
+              up.jQuery('#up-notification').noty({text: '<xsl:value-of select="upMsg:getMessageForEmacsScript('error.redirectinfo', $USER_LANG)"/>', type: 'information'});
             }
 
             <xsl:if test="$IS_FRAGMENT_ADMIN_MODE='true'">
             up.FragmentPermissionsManager("body", {
                 savePermissionsUrl: '<xsl:value-of select="$CONTEXT_PATH"/>/api/layout',
                 messages: {
-                    columnX: '<xsl:value-of select="upMsg:getMessage('column.x', $USER_LANG)"/>',
+                    columnX: '<xsl:value-of select="upMsg:getMessageForEmacsScript('column.x', $USER_LANG)"/>',
                 }
             });
             </xsl:if>
@@ -576,20 +576,20 @@
                     return 'col-md-' + Math.round(column / 8.3333);
                 },
                 messages: {
-                    confirmRemoveTab: '<xsl:value-of select="upMsg:getMessage('are.you.sure.remove.tab', $USER_LANG)"/>',
-                    confirmRemovePortlet: '<xsl:value-of select="upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)"/>',
-                    movePortletError: '<xsl:value-of select="upMsg:getMessage('move.this.portlet.error', $USER_LANG)"/>',
-                    addTabLabel: '<xsl:value-of select="upMsg:getMessage('my.tab', $USER_LANG)"/>',
-                    column: '<xsl:value-of select="upMsg:getMessage('column', $USER_LANG)"/>',
-                    columns: '<xsl:value-of select="upMsg:getMessage('columns', $USER_LANG)"/>',
-                    fullWidth: '<xsl:value-of select="upMsg:getMessage('full.width', $USER_LANG)"/>',
-                    narrowWide: '<xsl:value-of select="upMsg:getMessage('narrow.wide', $USER_LANG)"/>',
-                    even: '<xsl:value-of select="upMsg:getMessage('even', $USER_LANG)"/>',
-                    wideNarrow: '<xsl:value-of select="upMsg:getMessage('wide.narrow', $USER_LANG)"/>',
-                    narrowWideNarrow: '<xsl:value-of select="upMsg:getMessage('narrow.wide.narrow', $USER_LANG)"/>',
-                    searchForStuff: '<xsl:value-of select="upMsg:getMessage('search.for.stuff', $USER_LANG)"/>',
-                    allCategories: '<xsl:value-of select="upMsg:getMessage('all(categories)', $USER_LANG)"/>',
-                    persistenceError: '<xsl:value-of select="upMsg:getMessage('error.persisting.layout.change', $USER_LANG)"/>'
+                    confirmRemoveTab: '<xsl:value-of select="upMsg:getMessageForEmacsScript('are.you.sure.remove.tab', $USER_LANG)"/>',
+                    confirmRemovePortlet: '<xsl:value-of select="upMsg:getMessageForEmacsScript('are.you.sure.remove.portlet', $USER_LANG)"/>',
+                    movePortletError: '<xsl:value-of select="upMsg:getMessageForEmacsScript('move.this.portlet.error', $USER_LANG)"/>',
+                    addTabLabel: '<xsl:value-of select="upMsg:getMessageForEmacsScript('my.tab', $USER_LANG)"/>',
+                    column: '<xsl:value-of select="upMsg:getMessageForEmacsScript('column', $USER_LANG)"/>',
+                    columns: '<xsl:value-of select="upMsg:getMessageForEmacsScript('columns', $USER_LANG)"/>',
+                    fullWidth: '<xsl:value-of select="upMsg:getMessageForEmacsScript('full.width', $USER_LANG)"/>',
+                    narrowWide: '<xsl:value-of select="upMsg:getMessageForEmacsScript('narrow.wide', $USER_LANG)"/>',
+                    even: '<xsl:value-of select="upMsg:getMessageForEmacsScript('even', $USER_LANG)"/>',
+                    wideNarrow: '<xsl:value-of select="upMsg:getMessageForEmacsScript('wide.narrow', $USER_LANG)"/>',
+                    narrowWideNarrow: '<xsl:value-of select="upMsg:getMessageForEmacsScript('narrow.wide.narrow', $USER_LANG)"/>',
+                    searchForStuff: '<xsl:value-of select="upMsg:getMessageForEmacsScript('search.for.stuff', $USER_LANG)"/>',
+                    allCategories: '<xsl:value-of select="upMsg:getMessageForEmacsScript('all(categories)', $USER_LANG)"/>',
+                    persistenceError: '<xsl:value-of select="upMsg:getMessageForEmacsScript('error.persisting.layout.change', $USER_LANG)"/>'
                 }
             };
             var layoutPreferences = up.LayoutPreferences("body", options);
@@ -653,7 +653,7 @@
                 portalContext: '<xsl:value-of select="$CONTEXT_PATH"/>',
                 layoutPersistenceUrl: '<xsl:value-of select="$CONTEXT_PATH"/>/api/layout',
                 messages: {
-                    persistenceError: '<xsl:value-of select="upMsg:getMessage('error.persisting.layout.change', $USER_LANG)"/>'
+                    persistenceError: '<xsl:value-of select="upMsg:getMessageForEmacsScript('error.persisting.layout.change', $USER_LANG)"/>'
                 }
             });
         });


### PR DESCRIPTION
When injecting translated messages into javascript (ECM) code from xsl you need to escape special ECM characters as xsl inject unescaped text.

As problem example set messages with simple quote (double simple quote in messages.properties to escape it) and watch on js property (options.messages.movePortletError as example, value generated in respondr.xsl from move.this.portlet.error message property). For this property the gallery isn't working anymore

To solve that, use a java specific function for xsl processors : upMsg:getMessageForEmacsScript, this function use commons.lang3 escaping function from EmacsScript (the library can provide also escaping for Json, HTML, etc...).