### PR TITLE
UP-4726 :  Configuration for proxyCAS url and for load-balancing portals

### DIFF
--- a/filters/data-test.properties
+++ b/filters/data-test.properties
@@ -48,8 +48,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=uportal@localhost
 environment.build.uportal.email.host=localhost

--- a/filters/live-nightly.properties
+++ b/filters/live-nightly.properties
@@ -48,8 +48,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=up41-nightly.jasig.org
+environment.build.real.uportal.server=up41-nightly.jasig.org
 environment.build.uportal.protocol=https
 environment.build.uportal.context=
+environment.build.real.uportal.context=
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=uportal-dev@lists.ja-sig.org
 environment.build.uportal.email.host=localhost

--- a/filters/local.properties
+++ b/filters/local.properties
@@ -47,8 +47,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost

--- a/filters/prod.properties
+++ b/filters/prod.properties
@@ -47,8 +47,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/pom.xml
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/pom.xml
@@ -42,6 +42,20 @@
             <version>${cas-proxy-test-portlet.version}</version>
             <type>war</type>
         </dependency>
+        <dependency>
+            <groupId>org.jasig.portlet</groupId>
+            <artifactId>cas-proxy-test-portlet</artifactId>
+            <version>${cas-proxy-test-portlet.version}</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.portlet</groupId>
+            <artifactId>portlet-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/java/org/jasig/portlet/cas/test/mvc/ProxyCasController.java
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/java/org/jasig/portlet/cas/test/mvc/ProxyCasController.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.cas.test.mvc;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.RenderRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.TicketValidationException;
+import org.jasig.cas.client.validation.TicketValidator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.ModelAndView;
+
+/**
+ *
+ *
+ * @author Jen Bourey, jbourey@unicon.net
+ * @version $Revision$
+ */
+@Controller
+@RequestMapping("VIEW")
+public final class ProxyCasController {
+
+	private Log log = LogFactory.getLog(ProxyCasController.class);
+
+	private TicketValidator validator;
+
+	/**
+	 * Set the ticket validator to use for proxy ticket validation.
+	 *
+	 * @param validator
+	 */
+	@Autowired(required = true)
+	public void setTicketValidator(TicketValidator validator) {
+		this.validator = validator;
+	}
+
+	private String serviceUrl = "http://localhost:8080/cas-proxy-test-portlet";
+
+	public void setServiceUrl(String serviceUrl) {
+		this.serviceUrl = serviceUrl;
+	}
+
+	private String proxyTicketKey = "casProxyTicket";
+
+
+	/**
+	 * Attempt to validate the proxy ticket supplied to the UserInfo map and
+	 * display the result in the main view of the portlet.  If the ticket is
+	 * not found or cannot be validated, a short debugging message will be
+	 * displayed in the portlet.
+	 *
+	 * @param request
+	 * @return
+	 */
+	@RequestMapping
+	public ModelAndView validateProxyCas(RenderRequest request) {
+		Map<String,Object> model = new HashMap<String,Object>();
+
+		// get the proxy ticket from the UserInfo map
+		@SuppressWarnings("unchecked")
+		Map<String,String> userInfo = (Map<String,String>) request.getAttribute(PortletRequest.USER_INFO);
+		String proxyTicket = userInfo.get(proxyTicketKey);
+		if (proxyTicket == null){
+			model.put("success", false);
+			model.put("message", "No proxy ticket in UserInfo map");
+			return new ModelAndView("/proxyPortlet", model);
+		}
+
+		// attempt to validate the proxy ticket
+		try {
+			Assertion assertion = validator.validate(proxyTicket, serviceUrl);
+
+			// make sure we can proxy other sites
+			@SuppressWarnings("unused")
+            String proxyTicket2 = assertion.getPrincipal().getProxyTicketFor(serviceUrl);
+			model.put("success", true);
+		} catch (TicketValidationException e) {
+			log.error("Exception attempting to validate proxy ticket", e);
+			model.put("success", false);
+			model.put("message", "Unable to validate proxy ticket");
+		}
+
+		return new ModelAndView("/proxyPortlet", model);
+	}
+
+}

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/resources/configuration.properties
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/resources/configuration.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to Jasig under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Jasig licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a
+# copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#cas.server.base.url=http://localhost:8080/cas
+cas.server.base.url=${environment.build.cas.protocol}://${environment.build.cas.server}/${environment.build.cas.context}
+#portal.server.base=http://localhost:8080
+portal.server.base=${environment.build.uportal.protocol}://${environment.build.uportal.server}
+#portal.real.base=http://localhost:8080
+portal.real.base=${environment.build.uportal.protocol}://${environment.build.real.uportal.server}
+portlet.context=cas-proxy-test-portlet

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+    <!-- Properties configuration -->
+    <bean id="propertyConfigurer"
+        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+        lazy-init="false">
+        <property name="locations">
+            <list><value>classpath:configuration.properties</value></list>
+        </property>
+    </bean>
+
+    <!--
+        Ticket validation filter for servlet targets
+    -->
+    <bean id="ticketValidationFilter"
+        class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter"
+        p:serverName="${portal.server.base}" p:redirectAfterValidation="false"
+        p:proxyReceptorUrl="/proxy/receptor" p:ticketValidator-ref="ticketValidator"
+        p:proxyGrantingTicketStorage-ref="proxyGrantingTicketStorage"/>
+
+    <!--
+        Validates service and proxy tickets for both the servlet targets and
+        proxy portlet
+    -->
+    <bean id="ticketValidator"
+        class="org.jasig.cas.client.validation.Cas20ProxyTicketValidator"
+        p:proxyCallbackUrl="${portal.real.base}/${portlet.context}/proxy/receptor"
+        p:proxyGrantingTicketStorage-ref="proxyGrantingTicketStorage"
+        p:acceptAnyProxy="true">
+        <constructor-arg index="0" value="${cas.server.base.url}" />
+    </bean>
+
+    <bean id="proxyGrantingTicketStorage"
+        class="org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl"/>
+
+    <!-- JSP view resolver -->
+    <bean id="viewResolver"
+        class="org.springframework.web.servlet.view.InternalResourceViewResolver"
+        p:order="10" p:cache="true" p:viewClass="org.springframework.web.servlet.view.JstlView"
+        p:prefix="/WEB-INF/jsp/" p:suffix=".jsp"/>
+
+    <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />
+
+</beans>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -98,7 +98,7 @@
         </init-param>
         <init-param>
             <param-name>proxyCallbackUrl</param-name>
-            <param-value>${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/CasProxyServlet</param-value>
+            <param-value>${environment.build.uportal.protocol}://${environment.build.real.uportal.server}${environment.build.real.uportal.context}/CasProxyServlet</param-value>
         </init-param>
         <init-param>
             <param-name>proxyReceptorUrl</param-name>


### PR DESCRIPTION
In this way all CAS basic configurations works !

Adding a real (local) domain name and real contextPath to be able to configure directly with an external CAS for a possible load-balanced portal context..
These properties are needed to work correctly in the proxy cas mode with load-balanced portal. Also it configure proxy-cas-test-portlet to be able to work in proxy mod.
(But see PR: https://github.com/Jasig/cas-proxy-test-portlet/pull/1 to remove class provided in the overlay when the new version will be released of the portlet and revert the pom.xml in the overlay)

Also added the cas context path property to be able to set it to empty as in some context the cas is on a specific domain without path.

For documentation :

```
# the public domain, on balanced portal url
environment.build.uportal.server= my.univ.edu
# A public or internal domaine name, used on server's sides only for proxy request (CAS and portal)
environment.build.real.uportal.server=my.portal1.edu
# the public portail context
environment.build.uportal.context=/uPortal
# the internal portail context used in proxy cas
environment.build.real.uportal.context=/uPortal

# no specific protocol is needed as it should be always the same.
```
