### PR TITLE
UP-4727 :  Managing uPortal deployment on several servername with CAS

### DIFF
--- a/filters/data-test.properties
+++ b/filters/data-test.properties
@@ -57,6 +57,8 @@ environment.build.uportal.email.fromAddress=uportal@localhost
 environment.build.uportal.email.host=localhost
 environment.build.uportal.email.port=25
 environment.build.uportal.email.protocol=smtp
+# For multi server names management, separate server names by a space
+environment.build.uportal.otherServers=
 
 # CAS server configuration properties
 environment.build.cas.server=localhost:8080

--- a/filters/data-test.properties
+++ b/filters/data-test.properties
@@ -48,8 +48,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=uportal@localhost
 environment.build.uportal.email.host=localhost

--- a/filters/live-nightly.properties
+++ b/filters/live-nightly.properties
@@ -48,8 +48,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=up41-nightly.jasig.org
+environment.build.real.uportal.server=up41-nightly.jasig.org
 environment.build.uportal.protocol=https
 environment.build.uportal.context=
+environment.build.real.uportal.context=
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=uportal-dev@lists.ja-sig.org
 environment.build.uportal.email.host=localhost

--- a/filters/live-nightly.properties
+++ b/filters/live-nightly.properties
@@ -57,6 +57,8 @@ environment.build.uportal.email.fromAddress=uportal-dev@lists.ja-sig.org
 environment.build.uportal.email.host=localhost
 environment.build.uportal.email.port=25
 environment.build.uportal.email.protocol=smtp
+# For multi server names management, separate server names by a space
+environment.build.uportal.otherServers=
 
 # CAS server configuration properties
 environment.build.cas.server=up41-nightly.jasig.org

--- a/filters/local.properties
+++ b/filters/local.properties
@@ -47,8 +47,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost

--- a/filters/local.properties
+++ b/filters/local.properties
@@ -56,6 +56,8 @@ environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost
 environment.build.uportal.email.port=25
 environment.build.uportal.email.protocol=smtp
+# For multi server names management, separate server names by a space
+environment.build.uportal.otherServers=
 
 # CAS server configuration properties
 environment.build.cas.server=localhost:8080

--- a/filters/prod.properties
+++ b/filters/prod.properties
@@ -47,8 +47,10 @@ environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION
 
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
+environment.build.real.uportal.server=localhost:8080
 environment.build.uportal.protocol=http
 environment.build.uportal.context=/uPortal
+environment.build.real.uportal.context=/uPortal
 environment.build.uportal.secureSessionCookie=false
 environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost

--- a/filters/prod.properties
+++ b/filters/prod.properties
@@ -56,6 +56,8 @@ environment.build.uportal.email.fromAddress=portal@university.edu
 environment.build.uportal.email.host=localhost
 environment.build.uportal.email.port=25
 environment.build.uportal.email.protocol=smtp
+# For multi server names management, separate server names by a space
+environment.build.uportal.otherServers=
 
 # CAS server configuration properties
 environment.build.cas.server=localhost:8080

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <ant.version>1.8.4</ant.version>
         <aspectjrt.version>1.7.4</aspectjrt.version>
         <aspectjweaver.version>1.7.4</aspectjweaver.version>
-        <casclient.version>3.2.2</casclient.version>
+        <casclient.version>3.4.1</casclient.version>
         <ccpp.version>1.0</ccpp.version>
         <cernunnos.version>1.2.2</cernunnos.version>
         <cobertura-maven-plugin.version>2.6</cobertura-maven-plugin.version>

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/pom.xml
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/pom.xml
@@ -42,6 +42,20 @@
             <version>${cas-proxy-test-portlet.version}</version>
             <type>war</type>
         </dependency>
+        <dependency>
+            <groupId>org.jasig.portlet</groupId>
+            <artifactId>cas-proxy-test-portlet</artifactId>
+            <version>${cas-proxy-test-portlet.version}</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.portlet</groupId>
+            <artifactId>portlet-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/java/org/jasig/portlet/cas/test/mvc/ProxyCasController.java
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/java/org/jasig/portlet/cas/test/mvc/ProxyCasController.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.cas.test.mvc;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.RenderRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.TicketValidationException;
+import org.jasig.cas.client.validation.TicketValidator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.ModelAndView;
+
+/**
+ *
+ *
+ * @author Jen Bourey, jbourey@unicon.net
+ * @version $Revision$
+ */
+@Controller
+@RequestMapping("VIEW")
+public final class ProxyCasController {
+
+	private Log log = LogFactory.getLog(ProxyCasController.class);
+
+	private TicketValidator validator;
+
+	/**
+	 * Set the ticket validator to use for proxy ticket validation.
+	 *
+	 * @param validator
+	 */
+	@Autowired(required = true)
+	public void setTicketValidator(TicketValidator validator) {
+		this.validator = validator;
+	}
+
+	private String serviceUrl = "http://localhost:8080/cas-proxy-test-portlet";
+
+	public void setServiceUrl(String serviceUrl) {
+		this.serviceUrl = serviceUrl;
+	}
+
+	private String proxyTicketKey = "casProxyTicket";
+
+
+	/**
+	 * Attempt to validate the proxy ticket supplied to the UserInfo map and
+	 * display the result in the main view of the portlet.  If the ticket is
+	 * not found or cannot be validated, a short debugging message will be
+	 * displayed in the portlet.
+	 *
+	 * @param request
+	 * @return
+	 */
+	@RequestMapping
+	public ModelAndView validateProxyCas(RenderRequest request) {
+		Map<String,Object> model = new HashMap<String,Object>();
+
+		// get the proxy ticket from the UserInfo map
+		@SuppressWarnings("unchecked")
+		Map<String,String> userInfo = (Map<String,String>) request.getAttribute(PortletRequest.USER_INFO);
+		String proxyTicket = userInfo.get(proxyTicketKey);
+		if (proxyTicket == null){
+			model.put("success", false);
+			model.put("message", "No proxy ticket in UserInfo map");
+			return new ModelAndView("/proxyPortlet", model);
+		}
+
+		// attempt to validate the proxy ticket
+		try {
+			Assertion assertion = validator.validate(proxyTicket, serviceUrl);
+
+			// make sure we can proxy other sites
+			@SuppressWarnings("unused")
+            String proxyTicket2 = assertion.getPrincipal().getProxyTicketFor(serviceUrl);
+			model.put("success", true);
+		} catch (TicketValidationException e) {
+			log.error("Exception attempting to validate proxy ticket", e);
+			model.put("success", false);
+			model.put("message", "Unable to validate proxy ticket");
+		}
+
+		return new ModelAndView("/proxyPortlet", model);
+	}
+
+}

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/resources/configuration.properties
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/resources/configuration.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to Jasig under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Jasig licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a
+# copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#cas.server.base.url=http://localhost:8080/cas
+cas.server.base.url=${environment.build.cas.protocol}://${environment.build.cas.server}/${environment.build.cas.context}
+#portal.server.base=http://localhost:8080
+portal.server.base=${environment.build.uportal.protocol}://${environment.build.uportal.server}
+#portal.real.base=http://localhost:8080
+portal.real.base=${environment.build.uportal.protocol}://${environment.build.real.uportal.server}
+portlet.context=cas-proxy-test-portlet

--- a/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/uportal-portlets-overlay/cas-proxy-test-portlet/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+    <!-- Properties configuration -->
+    <bean id="propertyConfigurer"
+        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+        lazy-init="false">
+        <property name="locations">
+            <list><value>classpath:configuration.properties</value></list>
+        </property>
+    </bean>
+
+    <!--
+        Ticket validation filter for servlet targets
+    -->
+    <bean id="ticketValidationFilter"
+        class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter"
+        p:serverName="${portal.server.base}" p:redirectAfterValidation="false"
+        p:proxyReceptorUrl="/proxy/receptor" p:ticketValidator-ref="ticketValidator"
+        p:proxyGrantingTicketStorage-ref="proxyGrantingTicketStorage"/>
+
+    <!--
+        Validates service and proxy tickets for both the servlet targets and
+        proxy portlet
+    -->
+    <bean id="ticketValidator"
+        class="org.jasig.cas.client.validation.Cas20ProxyTicketValidator"
+        p:proxyCallbackUrl="${portal.real.base}/${portlet.context}/proxy/receptor"
+        p:proxyGrantingTicketStorage-ref="proxyGrantingTicketStorage"
+        p:acceptAnyProxy="true">
+        <constructor-arg index="0" value="${cas.server.base.url}" />
+    </bean>
+
+    <bean id="proxyGrantingTicketStorage"
+        class="org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl"/>
+
+    <!-- JSP view resolver -->
+    <bean id="viewResolver"
+        class="org.springframework.web.servlet.view.InternalResourceViewResolver"
+        p:order="10" p:cache="true" p:viewClass="org.springframework.web.servlet.view.JstlView"
+        p:prefix="/WEB-INF/jsp/" p:suffix=".jsp"/>
+
+    <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />
+
+</beans>

--- a/uportal-war/src/main/java/org/jasig/portal/url/CasLoginRefUrlEncoder.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/CasLoginRefUrlEncoder.java
@@ -18,32 +18,41 @@
  */
 package org.jasig.portal.url;
 
-import org.jasig.portal.security.mvc.LoginController;
-import org.springframework.beans.factory.annotation.Required;
-
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+
+import org.jasig.portal.security.mvc.LoginController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
 
 /**
  * Encode the originally requested URL for use as a RefUrl parameter for the CAS login use case. This handles the
  * additional encoding needed to encode the originally-requested URL since the originally requested URL will be decoded
  * twice (decoded once when the browser sends it to CAS, then again when the browser sends it back to uPortal after
  * coming from CAS).
- * 
+ *
  * @author James Wennmacher, jwennmacher@unicon.net
  */
 public class CasLoginRefUrlEncoder implements LoginRefUrlEncoder {
 
     private String casLoginUrl;
 
+    private UrlAuthCustomizerRegistry urlCustomizer;
+
     @Required
     public void setCasLoginUrl(String casLoginUrl) {
         this.casLoginUrl = casLoginUrl;
     }
 
-    public String getCasLoginUrl() {
-        return casLoginUrl;
+    @Autowired
+    public void setUrlCustomizer(UrlAuthCustomizerRegistry urlCustomizer) {
+        this.urlCustomizer = urlCustomizer;
+    }
+
+    public String getCasLoginUrl(final HttpServletRequest request) {
+        return urlCustomizer.customizeUrl(request, casLoginUrl);
     }
 
     @Override
@@ -63,7 +72,7 @@ public class CasLoginRefUrlEncoder implements LoginRefUrlEncoder {
             loginRedirect.append(URLEncoder.encode(firstEncoding, requestEncoding));
         }
 
-        return loginRedirect.toString();
+        return urlCustomizer.customizeUrl(request, loginRedirect.toString());
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/url/IAuthUrlCustomizer.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/IAuthUrlCustomizer.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.lang.String;
+
+/**
+ * @author  Julien Gribonvald
+ * @version $Revision$
+ */
+public interface IAuthUrlCustomizer {
+
+    /**
+     * Does this customizer supports the current HTTP request.
+     *
+     * @param request
+     * @return
+     */
+    boolean supports(HttpServletRequest request, String url);
+
+    /**
+     * Customize the supplied external login URL.
+     *
+     * @param url
+     * @return
+     */
+    String customizeUrl(HttpServletRequest request, String url);
+}

--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlAuthCustomizerRegistry.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlAuthCustomizerRegistry.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Class to register all login/logout IAuthUrlCustomizer
+ * @author  Julien Gribonvald
+ * @version $Revision$
+ */
+public class UrlAuthCustomizerRegistry {
+
+    /** Logger. */
+    private static final Log LOG = LogFactory.getLog(UrlAuthCustomizerRegistry.class);
+
+    private List<IAuthUrlCustomizer> registry;
+
+    public void setRegistry(List<IAuthUrlCustomizer> registry) {
+        this.registry = registry;
+    }
+
+    public String customizeUrl (final HttpServletRequest request, final String url) {
+        String customizedUrl = url;
+        if (registry != null && !registry.isEmpty()) {
+            for (IAuthUrlCustomizer customizer: this.registry) {
+                if (customizer != null && customizer.supports(request, customizedUrl)) {
+                    customizedUrl = customizer.customizeUrl(request, customizedUrl);
+                }
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The url returned after customization is " + customizedUrl);
+            }
+            return customizedUrl;
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("No IAuthUrlCustomizer was set, the url " + customizedUrl + " wasn't modified");
+        }
+        return customizedUrl;
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlCasParamAppenderCustomizer.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlCasParamAppenderCustomizer.java
@@ -1,0 +1,56 @@
+package org.jasig.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * Customizer to append CAS params to url.
+ * @Author  Julien Gribonvald
+ * @version $Revision$
+ */
+public class UrlCasParamAppenderCustomizer implements IAuthUrlCustomizer, InitializingBean {
+
+    /** Logger. */
+    private static final Log LOG = LogFactory.getLog(UrlCasParamAppenderCustomizer.class);
+
+    /** Regex condition to apply Customization. */
+    private String applyCondition = ".*login\\?service=https?://.*";
+
+    /** Param name with equal and value to append to url. */
+    private String paramToAppend;
+
+    public void setApplyCondition(final String applyCondition) {
+        this.applyCondition = applyCondition;
+    }
+
+    public void setParamToAppend(final String paramToAppend) {
+        this.paramToAppend = paramToAppend;
+    }
+
+
+    public boolean supports(final HttpServletRequest request, final String url) {
+        return url != null && url.matches(applyCondition);
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        if (url != null && !url.isEmpty() && supports(request, url)) {
+            final String updatedUrl = url + "&" + paramToAppend;
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Modifying Url Domain from [%s] to [%s]", url, updatedUrl));
+            }
+            return updatedUrl;
+        }
+        return url;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.hasText(this.applyCondition, "No applyCondition supplied !");
+        Assert.hasText(this.paramToAppend, "No paramToAppend supplied !");
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlMultiServerNameCustomizer.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlMultiServerNameCustomizer.java
@@ -1,0 +1,70 @@
+package org.jasig.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.util.Assert;
+
+/**
+ * Customizer to replace a text by a serverName.
+ * @Author  Julien Gribonvald
+ * @version $Revision$
+ */
+public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
+
+    /** Logger. */
+    private static final Log LOG = LogFactory.getLog(UrlMultiServerNameCustomizer.class);
+
+    private Set<String> allServerNames = new HashSet<>();
+
+    private String serverNameTextReplacement = "_CURRENT_SERVER_NAME_";
+
+    @Required
+    public void setAllServerNames(final Set<String> serverNames) {
+        this.allServerNames = Sets.newHashSet(serverNames);
+        Assert.notEmpty(this.allServerNames);
+    }
+
+    public void setServerNameTextReplacement(final String serverNameTextReplacement) {
+        Assert.hasText(serverNameTextReplacement);
+        this.serverNameTextReplacement = serverNameTextReplacement;
+    }
+
+    public boolean supports(final HttpServletRequest request, final String url) {
+        return url != null && url.contains(serverNameTextReplacement);
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        if (url != null && !url.isEmpty() && supports(request, url)) {
+            final String updateUrl = url.replaceFirst(serverNameTextReplacement, findMatchingServerName(request));
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Modifying Url Domain from [%s] to [%s]", url, updateUrl));
+            }
+            return updateUrl;
+        }
+        return url;
+    }
+
+    protected String findMatchingServerName(final HttpServletRequest request) {
+        if (request != null) {
+            final String comparisonHost = request.getHeader("Host");
+            if (comparisonHost != null && !comparisonHost.isEmpty()) {
+                for (final String server : this.allServerNames) {
+                    if (server.contains(comparisonHost)) {
+                        return server;
+                    }
+                }
+            }
+        }
+
+        return this.allServerNames.iterator().next();
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/utils/StringToSetUtils.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/StringToSetUtils.java
@@ -1,0 +1,15 @@
+package org.jasig.portal.utils;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Created by jgribonvald on 05/07/16.
+ */
+public abstract class StringToSetUtils {
+
+    public static Set<String> delimitedSpaceListToSet(final String entry) {
+        return Sets.newHashSet(entry.split("\\s+"));
+    }
+}

--- a/uportal-war/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
@@ -127,7 +127,6 @@
                                         <key><util:constant static-field="org.jasig.portal.url.xml.XsltPortalUrlProvider.XSLT_PORTAL_URL_PROVIDER" /></key>
                                         <ref bean="xslPortalUrlProvider"/>
                                     </entry>
-                                    <entry key="EXTERNAL_LOGIN_URL" value="${org.jasig.portal.channels.CLogin.CasLoginUrl:}" />
                                     <entry key="useTabGroups" value="${org.jasig.portal.layout.useTabGroups}"/>
                                 </map>
                             </property>
@@ -136,6 +135,7 @@
                                     <entry key="CURRENT_REQUEST" value="request.nativeRequest" />
                                     <entry key="CONTEXT_PATH" value="request.contextPath" />
                                     <entry key="AUTHENTICATED" value="!person.guest" />
+                                    <entry key="EXTERNAL_LOGIN_URL" value="@casRefUrlEncoder.getCasLoginUrl(request.nativeRequest)" />
                                     <entry key="HOST_NAME" value="request.nativeRequest.serverName" />
                                     <entry key="userName" value="person.fullName" />
                                     <entry key="USER_ID" value="person.userName" />

--- a/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
@@ -47,6 +47,20 @@
         <property name="maxUploadSize" value="100000"/>
     </bean>
 
+    <!-- A Helper bean to update Cas login/logout url when the service can be accessed on different serverName -->
+    <bean id="authUrlCustomizer" class="org.jasig.portal.url.UrlAuthCustomizerRegistry">
+        <property name="registry">
+            <list>
+                <bean class="org.jasig.portal.url.UrlMultiServerNameCustomizer">
+                    <property name="allServerNames"><bean class="org.jasig.portal.utils.StringToSetUtils" factory-method="delimitedSpaceListToSet">
+                        <constructor-arg type="java.lang.String" value="${portal.allServerNames}"/>
+                    </bean></property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+
     <!-- The urlCanonicalizingFilter can (will) attempt to deep-link users, 
          through authentication, to the content they are requesting, provided 
          that...
@@ -57,7 +71,7 @@
                  bean) configured
     -->
     <bean id="casRefUrlEncoder" class="org.jasig.portal.url.CasLoginRefUrlEncoder"
-        p:casLoginUrl="${org.jasig.portal.channels.CLogin.CasLoginUrl}" />
+        p:casLoginUrl="${org.jasig.portal.channels.CLogin.CasLoginUrl}" p:urlCustomizer-ref="authUrlCustomizer"/>
 
     <!--
      | Message source for this context, loaded from localized "messages_xx" files

--- a/uportal-war/src/main/resources/properties/contexts/renderingPipelineContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/renderingPipelineContext.xml
@@ -178,7 +178,6 @@
                                         <key><util:constant static-field="org.jasig.portal.url.xml.XsltPortalUrlProvider.XSLT_PORTAL_URL_PROVIDER" /></key>
                                         <ref bean="xslPortalUrlProvider"/>
                                     </entry>
-                                    <entry key="EXTERNAL_LOGIN_URL" value="${org.jasig.portal.channels.CLogin.CasLoginUrl}" />
                                     <entry key="useTabGroups" value="${org.jasig.portal.layout.useTabGroups}"/>
                                     <entry key="UP_VERSION" value="${org.jasig.portal.version}"/>
                                 </map>
@@ -189,6 +188,7 @@
                                     <entry key="CONTEXT_PATH" value="request.contextPath" />
                                     <entry key="HOST_NAME" value="request.nativeRequest.serverName" />
                                     <entry key="AUTHENTICATED" value="!person.guest" />
+                                    <entry key="EXTERNAL_LOGIN_URL" value="@casRefUrlEncoder.getCasLoginUrl(request.nativeRequest)" />
                                     <entry key="userName" value="person.fullName" />
                                     <entry key="USER_ID" value="person.userName" />
                                     <entry key="SERVER_NAME" value="@portalInfoProvider.serverName" />

--- a/uportal-war/src/main/resources/properties/security.properties
+++ b/uportal-war/src/main/resources/properties/security.properties
@@ -48,14 +48,17 @@ credentialToken.root.cas=ticket
 ## (See comments in the LogoutController class)
 ## It would be better to escape the value of the url parameter, but since there are no parameters on the
 ## unescaped URL and since there are no further parameters on the logout URL, this does work.
-logoutRedirect.root=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/logout?url=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
+logoutRedirect.root=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/logout?url=${environment.build.uportal.protocol}://_CURRENT_SERVER_NAME_${environment.build.uportal.context}/Login
 
 ## This is the factory that supplies the concrete authorization class
 authorizationProvider=org.jasig.portal.security.provider.AuthorizationServiceFactoryImpl
 
 ## Login URL, if specified the CLogin channel will display a Login link with
 ## this URL instead of the standard userName/password form.
-org.jasig.portal.channels.CLogin.CasLoginUrl=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/login?service=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
+## For multiple server names, a TEXT_PATTERN = _CURRENT_SERVER_NAME_ is needed for replacement,
+## see in org.jasig.portal.url.CasLoginRefUrlEncoder.java to set a different text replacement value
+## If you have only one serverName the value will be replaced too by portal.allServerNames value
+org.jasig.portal.channels.CLogin.CasLoginUrl=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/login?service=${environment.build.uportal.protocol}://_CURRENT_SERVER_NAME_${environment.build.uportal.context}/Login
 
 ## URL of the CAS clearPass password service.  Note that value must also be listed in the CAS Service Registry as an
 ## allowed URL to access the password.
@@ -63,6 +66,9 @@ org.jasig.portal.security.provider.cas.clearpass.PasswordCachingCasAssertionSecu
 
 ## Flag to determine if the portal should convert CAS assertion attributes to user attributes - defaults to false
 #org.jasig.portal.security.cas.assertion.copyAttributesToUserAttributes=true
+
+# All server names values for multi server name management, separator is a space
+portal.allServerNames=${environment.build.uportal.server} ${environment.build.uportal.otherServers}
 
 
 ##

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Invoker/login.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Invoker/login.jsp
@@ -24,7 +24,8 @@
   <div class="fl-widget-inner">
     <div class="fl-widget-content">
         <div id="portalCASLogin" class="fl-widget-content">
-            <a id="portalCASLoginLink" class="btn" title="<spring:message code="sign.in.via.cas"/>" href="${casRefUrlEncoder.casLoginUrl}"><spring:message code="sign.in"/></a>
+            <c:set var="request" value="${pageContext.request}" />
+            <a id="portalCASLoginLink" class="btn" title="<spring:message code="sign.in.via.cas"/>" href="${casRefUrlEncoder.getCasLoginUrl(request)}"><spring:message code="sign.in"/></a>
             <a id="portalCASLoginNewLink" title="<spring:message code="create.new.portal.account"/>" href="http://www.jasig.org/cas" class="btn"><spring:message code="new.user.question"/></a>
         </div>
     </div>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -98,7 +98,7 @@
         </init-param>
         <init-param>
             <param-name>proxyCallbackUrl</param-name>
-            <param-value>${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/CasProxyServlet</param-value>
+            <param-value>${environment.build.uportal.protocol}://${environment.build.real.uportal.server}${environment.build.real.uportal.context}/CasProxyServlet</param-value>
         </init-param>
         <init-param>
             <param-name>proxyReceptorUrl</param-name>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -94,7 +94,7 @@
         </init-param>
         <init-param>
           <param-name>serverName</param-name>
-          <param-value>${environment.build.uportal.protocol}://${environment.build.uportal.server}</param-value>
+          <param-value>${environment.build.uportal.server} ${environment.build.uportal.otherServers}</param-value>
         </init-param>
         <init-param>
             <param-name>proxyCallbackUrl</param-name>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -104,6 +104,10 @@
             <param-name>proxyReceptorUrl</param-name>
             <param-value>/CasProxyServlet</param-value>
         </init-param>
+        <init-param>
+          <param-name>encodeServiceUrl</param-name>
+          <param-value>false</param-value>
+        </init-param>
         <!--
          | For CAS PGT replication for CAS ClearPass in a clustered uPortal environment.
          | See "Replicating PGT using "proxyGrantingTicketStorageClass" and Distributed Caching" in

--- a/uportal-war/src/test/java/org/jasig/portal/url/CasLoginRefUrlEncoderTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/url/CasLoginRefUrlEncoderTest.java
@@ -18,13 +18,16 @@
  */
 package org.jasig.portal.url;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
-
-import java.io.UnsupportedEncodingException;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @Author James Wennmacher, jwennmacher@unicon.net
@@ -37,32 +40,41 @@ public class CasLoginRefUrlEncoderTest {
     @Before
     public void setUp() throws UnsupportedEncodingException {
         encoder = new CasLoginRefUrlEncoder();
-        encoder.setCasLoginUrl("https://cas:80/cas/login?service=myhost:8080/uPortal/Login");
+        encoder.setCasLoginUrl("https://cas:80/cas/login?service=_CURRENT_SERVER_NAME_/uPortal/Login");
+        UrlMultiServerNameCustomizer urlCustomizer = new UrlMultiServerNameCustomizer();
+        urlCustomizer.setAllServerNames(Sets.newHashSet("myhost:8080", "theirhost:8443"));
+        List<IAuthUrlCustomizer> customizers = new ArrayList<>();
+        customizers.add(urlCustomizer);
+        UrlAuthCustomizerRegistry registry = new UrlAuthCustomizerRegistry();
+        registry.setRegistry(customizers);
+        encoder.setUrlCustomizer(registry);
         request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setCharacterEncoding("UTF-8");
+        request.setServerName("myhost");
+        request.setServerPort(8080);
+        request.addHeader("Host", "myhost:8080");
     }
 
     @Test
     public void testSimpleDestination() throws Exception {
-        assertEquals("https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname",
+        assertEquals(
+                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname",
                 encoder.encodeLoginAndRefUrl(request));
     }
 
     @Test
     public void testWithParam() throws Exception {
-        request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setQueryString("pP_announcementId=1834");
-        request.setCharacterEncoding("UTF-8");
-        assertEquals("https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_announcementId%253D1834",
+        assertEquals(
+                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_announcementId%253D1834",
                 encoder.encodeLoginAndRefUrl(request));
     }
 
     @Test
     public void testWithTwoParams() throws Exception {
-        request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setQueryString("pP_action=displayFullAnnouncement&pP_announcementId=1834");
-        request.setCharacterEncoding("UTF-8");
-        assertEquals("https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_action%253DdisplayFullAnnouncement%2526pP_announcementId%253D1834",
+        assertEquals(
+                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_action%253DdisplayFullAnnouncement%2526pP_announcementId%253D1834",
                 encoder.encodeLoginAndRefUrl(request));
     }
 }


### PR DESCRIPTION
- update CAS client to be able to manage several client server Name (since version 3.3.0 only)
- setting CAS login and logout url using a pattern replacement to use the good url
- provinding tools to manage several server names without security hole - we set all possibles server names and we can use only them else only the first one is used
- change login jsp invoker to adapt the login url change
- provide a new property environment.build.uportal.otherServers to set other server names added to the main setted by environment.build.uportal.server

WARNING: This PR is based on #688 
