### PR TITLE
UP-4702:  Add support for encrypted values to the property files with…

### DIFF
--- a/uportal-war/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
+++ b/uportal-war/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
@@ -48,7 +48,7 @@ import org.springframework.util.CollectionUtils;
  *   <li>Force configuration setting ignoreResourceNotFound=true and (safely)
  *   ignore noisy WARNings in the log concerning missing properties files that
  *   are optional</li>
- *   <li>...</li>
+ *   <li>Provide support for encrypted property values based on Jasypt</li>
  * </ul>
  *
  * @author Josh Helmer, jhelmer@unicon.net

--- a/uportal-war/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
+++ b/uportal-war/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
@@ -21,7 +21,10 @@ package org.springframework.context.support;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.properties.EncryptableProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -33,23 +36,27 @@ import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySourcesPropertyResolver;
 import org.springframework.core.io.Resource;
+import org.springframework.util.CollectionUtils;
 
 
 /**
  * Custom extension of {@link PropertySourcesPlaceholderConfigurer} that serves
- * two purposes:
+ * three purposes:
  * <ul>
  *   <li>Override postProcessing to provide access to "local" properties before
  *   bean post-processing has completed</li>
  *   <li>Force configuration setting ignoreResourceNotFound=true and (safely)
  *   ignore noisy WARNings in the log concerning missing properties files that
  *   are optional</li>
+ *   <li>...</li>
  * </ul>
  *
  * @author Josh Helmer, jhelmer@unicon.net
  */
 public class PortalPropertySourcesPlaceholderConfigurer extends PropertySourcesPlaceholderConfigurer {
+
     public static final String EXTENDED_PROPERTIES_SOURCE = "extendedPropertiesSource";
+    public static final String JAYSYPT_ENCRYPTION_KEY_VARIABLE = "UP_JASYPT_KEY";
 
     private PropertyResolver propertyResolver;
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -136,4 +143,71 @@ public class PortalPropertySourcesPlaceholderConfigurer extends PropertySourcesP
     public PropertyResolver getPropertyResolver() {
         return propertyResolver;
     }
+
+    /**
+     * Override PropertiesLoaderSupport.mergeProprties in order to slip in a
+     * properly-configured EncryptableProperties instance, allowing us to
+     * encrypt property values at rest.
+     */
+    @Override
+    protected Properties mergeProperties() throws IOException {
+
+        Properties rslt = null;
+
+        /*
+         * If properties file encryption is used in this deployment, the
+         * encryption key will be made available to the application as an
+         * environment variable called UP_JASYPT_KEY.
+         */
+        final String encryptionKey = System.getenv(JAYSYPT_ENCRYPTION_KEY_VARIABLE);
+        if (encryptionKey != null) {
+
+            logger.info("Jasypt support for encrypted property values ENABLED");
+
+            StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
+            encryptor.setPassword(encryptionKey);
+            rslt = new EncryptableProperties(encryptor);
+
+            /*
+             * BEGIN copied from PropertiesLoaderSupport.mergeProperties()
+             */
+
+            if (this.localOverride) {
+                // Load properties from file upfront, to let local properties override.
+                loadProperties(rslt);
+            }
+
+            if (this.localProperties != null) {
+                for (int i = 0; i < this.localProperties.length; i++) {
+                    CollectionUtils.mergePropertiesIntoMap(this.localProperties[i], rslt);
+                }
+            }
+
+            if (!this.localOverride) {
+                // Load properties from file afterwards, to let those properties override.
+                loadProperties(rslt);
+            }
+
+            /*
+             * END copied from PropertiesLoaderSupport.mergeProperties()
+             */
+
+        } else {
+
+            logger.info("Jasypt support for encrypted property values DISABLED;  "
+                    + "specify environment variable {} to use this feature",
+                    JAYSYPT_ENCRYPTION_KEY_VARIABLE);
+
+            /*
+             * The feature is not in use;  defer to the Spring-provided
+             * implementation of this method.
+             */
+            return super.mergeProperties();
+
+        }
+
+        return rslt;
+
+    }
+
 }


### PR DESCRIPTION
…in primaryPropertyPlaceholderConfigurer

https://issues.jasig.org/browse/UP-4702

This solution leverages [Jasypt](http://www.jasypt.org/).

The feature is optional and non-invasive.  Use it if you want to;  if you don't, carry on the way you were.

### Setting the Encryption Key

This solution expects the key as an environment variable named `UP_JASYPT_KEY`.  Use a command like...

`export UP_JASYPT_KEY=CHANGEME`

To set the key in the shell before starting the portal.  (Or set the variable another way.)

### Encrypting a Property Value

Use the [Jasypt Command Line Interface (CLI) Tools](http://www.jasypt.org/cli.html) to encrypt a string...

`./encrypt.sh input=sa password=CHANGEME`

Then copy & paste the output into one of the supported properties files (any of them within `primaryPropertyPlaceholderConfigurer`) _and place ENC() around it_.

#### Example

`environment.build.hibernate.connection.username=ENC(6EX9JW+LZDR2ErQgRh0pEA==)`

### ToDo:

- [ ] Update the Manual