### PR TITLE
UP-4706:  Possible memory leak in DLM causing hundreds of millions of…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/NodeInfoTracker.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/NodeInfoTracker.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.layout.dlm;
+
+import java.util.List;
+
+import org.jasig.portal.xml.XmlUtilitiesImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+
+/**
+  * Helps {@link PLFIntegrator} track the number of {@link NodeInfo} objects
+  * created for a single layout.  There is some evidence in the community
+  * that there is a bug within the <code>mergePLFintoILF</code> process that
+  * can occur with certain data.  When triggered, it pulls the process into
+  * an infinite(?) loop, causing it to instantiate {@link NodeInfo} objects
+  * until the JVM runs out of memory.  This class tracks the number these
+  * objects created and fails noisily when the specific threshold is
+  * crossed.
+  */
+ /* package-private */ final class NodeInfoTracker {
+
+     private final Logger logger = LoggerFactory.getLogger(getClass());
+
+     /**
+      * The maximum number of {@link NodeInfo} objects that may be created
+      * in processing a single layout.
+      */
+     private static final int MAX_NUMBER = 1000;
+
+     private int count;
+
+     public void track(NodeInfo ni, List<NodeInfo> order, Element compViewParent, Element positionSet) {
+         ++count;
+         if (count > MAX_NUMBER) {
+             final String msg = "Maximum number of NodeInfo objects for this layout exceeded";
+             logger.error(msg);
+             logger.error("count="+count);
+             logger.error("order="+order);
+             logger.error("compViewParent="+XmlUtilitiesImpl.toString(compViewParent));
+             logger.error("positionSet="+XmlUtilitiesImpl.toString(positionSet));
+             throw new RuntimeException(msg);
+         }
+     }
+ }

--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PLFIntegrator.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PLFIntegrator.java
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jasig.portal.layout.dlm;
 
-import java.util.List;
+package org.jasig.portal.layout.dlm;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portal.PortalException;
-import org.jasig.portal.xml.XmlUtilitiesImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -272,42 +270,5 @@ public class PLFIntegrator {
         }
         return copy;
     }
-
-     /*
-      * Nested Types
-      */
-
-     /**
-      * Helps {@link PLFIntegrator} track the number of {@link NodeInfo} objects
-      * created for a single layout.  There is some evidence in the community
-      * that there is a bug within the <code>mergePLFintoILF</code> process that
-      * can occur with certain data.  When triggered, it pulls the process into
-      * an infinite(?) loop, causing it to instantiate {@link NodeInfo} objects
-      * until the JVM runs out of memory.  This class tracks the number these
-      * objects created and fails noisily when the specific threshold is
-      * crossed.
-      */
-     /* package-private */ static final class NodeInfoTracker {
-         /**
-          * The maximum number of {@link NodeInfo} objects that may be created
-          * in processing a single layout.
-          */
-         private static final int MAX_NUMBER = 1000;
-
-         private int count;
-
-         public void track(NodeInfo ni, List<NodeInfo> order, Element compViewParent, Element positionSet) {
-             ++count;
-             if (count > MAX_NUMBER) {
-                 final String msg = "Maximum number of NodeInfo objects for this layout exceeded";
-                 LOG.error(msg);
-                 LOG.error("count="+count);
-                 LOG.error("order="+order);
-                 LOG.error("compViewParent="+XmlUtilitiesImpl.toString(compViewParent));
-                 LOG.error("positionSet="+XmlUtilitiesImpl.toString(positionSet));
-                 throw new RuntimeException(msg);
-             }
-         }
-     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PositionManager.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PositionManager.java
@@ -128,18 +128,17 @@ public class PositionManager {
        the final ordering is specified then it is applied to the children of
        the compViewParent and returned.
      */
-    static void applyPositions( Element compViewParent,
-                                Element positionSet,
-                                IntegrationResult result )
-        throws PortalException
-    {
+    static void applyPositions(Element compViewParent, Element positionSet,
+            IntegrationResult result, PLFIntegrator.NodeInfoTracker tracker)
+            throws PortalException {
+
         if ( positionSet == null ||
              positionSet.getFirstChild() == null )
             return;
 
         List<NodeInfo> order = new ArrayList<NodeInfo>();
 
-        applyOrdering        ( order, compViewParent, positionSet );
+        applyOrdering        ( order, compViewParent, positionSet, tracker);
         applyNoReparenting   ( order, compViewParent, positionSet );
         applyNoHopping       ( order, compViewParent, positionSet );
         applyLowerPrecedence ( order, compViewParent, positionSet );
@@ -543,9 +542,8 @@ public class PositionManager {
        nodes still exist in the composite view and then by any remaining
        children in the compViewParent.
      */
-    static void applyOrdering( List<NodeInfo> order,
-                               Element compViewParent,
-                               Element positionSet ) {
+    static void applyOrdering(List<NodeInfo> order, Element compViewParent,
+            Element positionSet, PLFIntegrator.NodeInfoTracker tracker) {
 
         // first pull out all visible channel or visible folder children and
         // put their id's in a list of available children and record their
@@ -564,8 +562,9 @@ public class PositionManager {
             if ( child.getAttribute( "hidden" ).equals( "false" ) &&
                  ( ! child.getAttribute( "chanID" ).equals( "" ) ||
                    child.getAttribute( "type" ).equals( "regular" ) ) ) {
-                final NodeInfo nodeInfo = new NodeInfo( child,
-                                             indexInCVP++ );
+                final NodeInfo nodeInfo = new NodeInfo(child, indexInCVP++);
+
+                tracker.track(nodeInfo, order, compViewParent, positionSet);
 
                 final NodeInfo prevNode = available.put( nodeInfo.getId(), nodeInfo );
                 if (prevNode != null) {
@@ -603,6 +602,7 @@ public class PositionManager {
                 NodeInfo ni = available.remove(childId);
                 if (ni == null) {
                     ni = new NodeInfo( child );
+                    tracker.track(ni, order, compViewParent, positionSet);
                 }
 
                 ni.setPositionDirective(directive);

--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PositionManager.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/PositionManager.java
@@ -129,7 +129,7 @@ public class PositionManager {
        the compViewParent and returned.
      */
     static void applyPositions(Element compViewParent, Element positionSet,
-            IntegrationResult result, PLFIntegrator.NodeInfoTracker tracker)
+            IntegrationResult result, NodeInfoTracker tracker)
             throws PortalException {
 
         if ( positionSet == null ||
@@ -543,7 +543,7 @@ public class PositionManager {
        children in the compViewParent.
      */
     static void applyOrdering(List<NodeInfo> order, Element compViewParent,
-            Element positionSet, PLFIntegrator.NodeInfoTracker tracker) {
+            Element positionSet, NodeInfoTracker tracker) {
 
         // first pull out all visible channel or visible folder children and
         // put their id's in a list of available children and record their


### PR DESCRIPTION
… NodiInfo objects

https://issues.jasig.org/browse/UP-4706

There is some evidence in the community of a bug within the <code>mergePLFintoILF</code> process that can occur with certain data.  When triggered, it pulls the process into an infinite(?) loop, causing it to instantiate {@link NodeInfo} objects until the JVM runs out of memory.

I am currently unable to see how this issue could occur.

I can, however, offer a patch that tracks the number these objects created and fails noisily -- with detailed info -- when the specific threshold is crossed.  This patch should...

* Prevent the bug from bringing down servers;  and
* Provide better info (from the logs) that will allow us to fix the issue properly