### PR TITLE
allow security.properties to use the environment.build.cas.context variable

### DIFF
--- a/uportal-war/src/main/resources/properties/security.properties
+++ b/uportal-war/src/main/resources/properties/security.properties
@@ -48,17 +48,17 @@ credentialToken.root.cas=ticket
 ## (See comments in the LogoutController class)
 ## It would be better to escape the value of the url parameter, but since there are no parameters on the
 ## unescaped URL and since there are no further parameters on the logout URL, this does work.
-logoutRedirect.root=${environment.build.cas.protocol}://${environment.build.cas.server}/cas/logout?url=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
+logoutRedirect.root=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/logout?url=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
 
 ## This is the factory that supplies the concrete authorization class
 authorizationProvider=org.jasig.portal.security.provider.AuthorizationServiceFactoryImpl
 
 ## Login URL, if specified the CLogin channel will display a Login link with
 ## this URL instead of the standard userName/password form.
-org.jasig.portal.channels.CLogin.CasLoginUrl=${environment.build.cas.protocol}://${environment.build.cas.server}/cas/login?service=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
+org.jasig.portal.channels.CLogin.CasLoginUrl=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/login?service=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
 
 ## URL of the CAS clearPass password service
-org.jasig.portal.security.provider.cas.clearpass.PasswordCachingCasAssertionSecurityContextFactory.clearPassCasUrl=${environment.build.cas.protocol}://${environment.build.cas.server}/cas/clearPass
+org.jasig.portal.security.provider.cas.clearpass.PasswordCachingCasAssertionSecurityContextFactory.clearPassCasUrl=${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}/clearPass
 
 ## Flag to determine if the portal should convert CAS assertion attributes to user attributes - defaults to false
 #org.jasig.portal.security.cas.assertion.copyAttributesToUserAttributes=true


### PR DESCRIPTION
Update security.properties to use the environment.build.cas.context property that is set in the filters file.  This allows for adjusting for implementations of CAS that might not be deployed in the standard context configuration without having to further modify the security.properties file.