### PR TITLE
[NOJIRA] fix duplicate portlet name

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/portlet.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/portlet.xml
@@ -163,7 +163,7 @@
 
     <portlet>
         <portlet-name>FragmentAdministration</portlet-name>
-        <display-name xml:lang="en">Exit Fragment Administration</display-name>
+        <display-name xml:lang="en">Fragment Administration</display-name>
         <portlet-class>org.springframework.web.portlet.DispatcherPortlet</portlet-class>
         <init-param>
             <name>contextConfigLocation</name>


### PR DESCRIPTION
…inistration.   I think the second one was a copy-paste error.  This avoids having 2 drop down items in the Add Portlet flow that have the exact same name, but do different things.