### PR TITLE
Add in predicates for different setups in the rendering pipeline

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rendering/RequestRenderingPipelineUtils.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/RequestRenderingPipelineUtils.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.portlet.om.IPortletDefinition;
+
+public interface RequestRenderingPipelineUtils {
+  /**
+   * Get the PortletDefinition from the Servlet request if they are going after a targeted portlet
+   * @return
+   */
+  public IPortletDefinition getPortletDefinitionFromServletRequest(HttpServletRequest request);
+}

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/RequestRenderingPipelineUtilsImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/RequestRenderingPipelineUtilsImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.portlet.om.IPortletEntity;
+import org.jasig.portal.portlet.om.IPortletWindow;
+import org.jasig.portal.portlet.om.IPortletWindowId;
+import org.jasig.portal.portlet.registry.IPortletWindowRegistry;
+import org.jasig.portal.url.IPortalRequestInfo;
+import org.jasig.portal.url.IUrlSyntaxProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RequestRenderingPipelineUtilsImpl implements RequestRenderingPipelineUtils {
+
+  private IPortletWindowRegistry portletWindowRegistry;
+  private IUrlSyntaxProvider urlSyntaxProvider;
+
+  @Autowired
+  public void setUrlSyntaxProvider(IUrlSyntaxProvider provider) {
+    this.urlSyntaxProvider = provider;
+  }
+
+  @Autowired
+  public void setPortletWindowRegistry(IPortletWindowRegistry portletWindowRegistry) {
+      this.portletWindowRegistry = portletWindowRegistry;
+  }
+
+  @Override
+  public IPortletDefinition getPortletDefinitionFromServletRequest(HttpServletRequest request) {
+    final IPortalRequestInfo portalRequestInfo = this.urlSyntaxProvider.getPortalRequestInfo(request);
+    if(portalRequestInfo != null && portalRequestInfo.getTargetedPortletWindowId() != null) {
+      IPortletWindowId targetedPortletWindowId = portalRequestInfo.getTargetedPortletWindowId();
+      IPortletWindow portletWindow = this.portletWindowRegistry.getPortletWindow(request, targetedPortletWindowId);
+      if(portletWindow != null && portletWindow.getPortletEntity() != null) {
+        final IPortletEntity portletEntity = portletWindow.getPortletEntity();
+        IPortletDefinition portletDefinition = portletEntity.getPortletDefinition();
+        return portletDefinition;
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/GuestUserPredicate.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/GuestUserPredicate.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ package org.jasig.portal.rendering.predicates;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.user.IUserInstance;
+import org.jasig.portal.user.IUserInstanceManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.Assert;
+
+import com.google.common.base.Predicate;
+
+public class GuestUserPredicate implements Predicate<HttpServletRequest> {
+
+  // auto-wired
+  private IUserInstanceManager userInstanceManager;
+
+  @Override
+  public boolean apply(final HttpServletRequest request) {
+
+      final IUserInstance userInstance = this.userInstanceManager.getUserInstance(request);
+      return userInstance.getPerson().isGuest();
+  }
+
+  @Autowired
+  public void setUserInstanceManager(final IUserInstanceManager userInstanceManager) {
+      Assert.notNull(userInstanceManager);
+      this.userInstanceManager = userInstanceManager;
+  }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/NotGuestUserPredicate.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/NotGuestUserPredicate.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering.predicates;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.user.IUserInstance;
+import org.jasig.portal.user.IUserInstanceManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.Assert;
+
+import com.google.common.base.Predicate;
+
+public class NotGuestUserPredicate implements Predicate<HttpServletRequest> {
+
+  // auto-wired
+  private IUserInstanceManager userInstanceManager;
+
+  @Override
+  public boolean apply(final HttpServletRequest request) {
+
+      final IUserInstance userInstance = this.userInstanceManager.getUserInstance(request);
+      return !userInstance.getPerson().isGuest();
+  }
+
+  @Autowired
+  public void setUserInstanceManager(final IUserInstanceManager userInstanceManager) {
+      Assert.notNull(userInstanceManager);
+      this.userInstanceManager = userInstanceManager;
+  }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/RenderOnWebFlagSet.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/RenderOnWebFlagSet.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering.predicates;
+
+import java.util.Iterator;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.portal.portlet.om.IPortletDefinition;
+import org.jasig.portal.portlet.om.IPortletPreference;
+import org.jasig.portal.rendering.RequestRenderingPipelineUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.base.Predicate;
+
+public class RenderOnWebFlagSet implements Predicate<HttpServletRequest> {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private RequestRenderingPipelineUtils utils;
+
+    @Autowired
+    public void setUtils(RequestRenderingPipelineUtils u) {
+      this.utils = u;
+    }
+
+    @Override
+    public boolean apply(final HttpServletRequest request) {
+        try {
+            final IPortletDefinition portletDefinition = utils.getPortletDefinitionFromServletRequest(request);
+            Iterator<IPortletPreference> iterator = portletDefinition.getPortletPreferences().iterator();
+            while(iterator.hasNext()) {
+                IPortletPreference cur = iterator.next();
+                if("renderOnWeb".equalsIgnoreCase(cur.getName())) {
+                    return cur.getValues() != null
+                            && cur.getValues().length == 1
+                            && Boolean.parseBoolean(cur.getValues()[0]);
+                }
+            }
+        } catch(Exception e) {
+            logger.error("Failed to process renderOnWeb check for redirect during pipeline. Failing gracefully by returning false.", e);
+        }
+        return false;
+    }
+
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/URLInSpecificState.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/URLInSpecificState.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rendering.predicates;
+
+import com.google.common.base.Predicate;
+import org.jasig.portal.url.IPortalRequestInfo;
+import org.jasig.portal.url.IUrlSyntaxProvider;
+import org.jasig.portal.url.UrlState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Answers whether a given HttpServletRequest represents one that the rendering pipeline will focus on rendering just
+ * one portlet (e.g., maximized, or exclusive).
+ * @since uPortal 4.2
+ */
+public class URLInSpecificState
+    implements Predicate<HttpServletRequest> {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    // auto-wired.
+    private IUrlSyntaxProvider urlSyntaxProvider;
+    
+    private String state;
+    private boolean isNegated;
+
+    @Override
+    public boolean apply(final HttpServletRequest request) {
+
+        final IPortalRequestInfo portalRequestInfo = this.urlSyntaxProvider.getPortalRequestInfo(request);
+
+        if (null == portalRequestInfo) {
+            logger.warn("Portal request info was not available for this request, " +
+                    "so assuming that it does not represent focus on one portlet.");
+            // False when portalRequestInfo is null because unknown portal state is not
+            // focused-on-one-portlet portal state.
+            return false;
+        }
+
+        final UrlState urlState = portalRequestInfo.getUrlState();
+        boolean stateEqual = urlState.toString().equals(state);
+        
+        return isNegated ? !stateEqual : stateEqual;
+    }
+
+    @Autowired
+    public void setUrlSyntaxProvider(IUrlSyntaxProvider urlSyntaxProvider) {
+        this.urlSyntaxProvider = urlSyntaxProvider;
+    }
+
+    public void setNegated(boolean isNegated) {
+      this.isNegated = isNegated;
+    }
+    
+    public void setState(String state) {
+      this.state = state;
+    }
+
+    public String toString() {
+      return this.getClass().getSimpleName();
+  }
+}


### PR DESCRIPTION
+ `GuestUserPredicate` - Checks if user is the guest user.
+ `NotGuestUserPredicate` - Checks if the user is *NOT* the guest user.
+ `RenderOnWebFlagSet` - Checks if the `renderOnWeb` `portlet-preference` is set to `true`.
+ `URLInSpecificState` - Checks if the URL on the request is in a specific state.