### PR TITLE
UP-4725: Region pre-header bug

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -106,7 +106,7 @@
      | This template renders portlets in the top-right greeting area.
     -->
     <xsl:template name="region.pre-header">
-        <xsl:if test="//region[@name='page-top']/channel">
+        <xsl:if test="//region[@name='pre-header']/channel">
             <div id="region-pre-header" class="portal-user">
                 <xsl:for-each select="//region[@name='pre-header']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />


### PR DESCRIPTION
Solve bug in regions.xsl on region.pre-header introduced by offCanvas commit
The bug was introduced in commit a67cacc on regions.xsl file, see here : https://github.com/Jasig/uPortal/commit/a67cacc695104a41328938680463cf1f9fd26d07
JIRA : https://issues.jasig.org/browse/UP-4725