### PR TITLE
UP-4613: Fixed issue where exiting Fragment Admin logs out user when …

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/security/IdentitySwapperManager.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/IdentitySwapperManager.java
@@ -22,6 +22,8 @@ import javax.portlet.PortletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.springframework.security.core.Authentication;
+
 /**
  * Manages workflow around use of the identity swapper features.
  * 
@@ -62,20 +64,36 @@ public interface IdentitySwapperManager {
      * @param profile The profile of which you want to login under
      */
     void impersonateUser(PortletRequest portletRequest, String currentUserName, String targetUsername, String profile);
-    
+
     /**
-     * During impersonation of targetUsername sets the original user to currentUserName for later
-     * retrieval by {@link #getOriginalUsername(HttpSession)}
+     * During impersonation of targetUsername sets the original user to currentUserName for later retrieval by 
+     * {@link #getOriginalUsername(HttpSession)}.  If the original authentication will also be needed for later 
+     * retrieval, use {@link #setOriginalUser(HttpSession, String, String, Authentication)} instead.
      * 
      * @throws RuntimeAuthorizationException if the current user cannot impersonate the target user
      */
     void setOriginalUser(HttpSession session, String currentUserName, String targetUsername);
-    
+
+    /**
+     * During impersonation of targetUsername sets the original user to currentUserName for later retrieval by 
+     * {@link #getOriginalUsername(HttpSession)} and the set the original authentication for later retrieval by 
+     * {@link #getOriginalAuthentication(HttpSession).
+     * 
+     * @throws RuntimeAuthorizationException if the current user cannot impersonate the target user
+     */
+    void setOriginalUser(
+            HttpSession session, String currentUserName, String targetUsername, Authentication originalAuth);
+
     /**
      * @return The original user if the current user is an impersonation, null if no impersonation is happening
      */
     String getOriginalUsername(HttpSession session);
-    
+
+    /**
+     * @return the authentication for the original user
+     */
+    Authentication getOriginalAuthentication(HttpSession session);
+
     /**
      * @return The target of impersonation, null if there is no impersonation target
      */

--- a/uportal-war/src/main/java/org/jasig/portal/security/IdentitySwapperManagerImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/IdentitySwapperManagerImpl.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpSession;
 
 import org.jasig.portal.EntityIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service("identitySwapperManager")
@@ -34,7 +35,7 @@ public class IdentitySwapperManagerImpl implements IdentitySwapperManager {
     private static final String SWAP_TARGET_UID = IdentitySwapperManagerImpl.class.getName() + ".SWAP_TARGET_UID";
     private static final String SWAP_TARGET_PROFILE = IdentitySwapperManagerImpl.class.getName() + ".SWAP_TARGET_PROFILE";
     private static final String SWAP_ORIGINAL_UID = IdentitySwapperManagerImpl.class.getName() + ".SWAP_ORIGINAL_UID";
-    
+    private static final String SWAP_ORIGINAL_AUTH = IdentitySwapperManagerImpl.class.getName() + ".SWAP_ORIGINAL_AUTH";
 
     private IAuthorizationService authorizationService;
     
@@ -84,18 +85,29 @@ public class IdentitySwapperManagerImpl implements IdentitySwapperManager {
 
     @Override
     public void setOriginalUser(HttpSession session, String currentUserName, String targetUsername) {
+        this.setOriginalUser(session, currentUserName, targetUsername, null);
+    }
+
+    @Override
+    public void setOriginalUser(
+            HttpSession session, String currentUserName, String targetUsername, Authentication originalAuth) {
         if (!canImpersonateUser(currentUserName, targetUsername)) {
             throw new RuntimeAuthorizationException(currentUserName, IPermission.IMPERSONATE_USER_ACTIVITY, targetUsername);
         }
-        
         session.setAttribute(SWAP_ORIGINAL_UID, currentUserName);
+        session.setAttribute(SWAP_ORIGINAL_AUTH, originalAuth);
     }
-    
+
     @Override
     public String getOriginalUsername(HttpSession session) {
         return (String) session.getAttribute(SWAP_ORIGINAL_UID);
     }
-    
+
+    @Override
+    public Authentication getOriginalAuthentication(HttpSession session) {
+        return (Authentication) session.getAttribute(SWAP_ORIGINAL_AUTH);
+    }
+
     @Override
     public String getTargetUsername(HttpSession session) {
         return (String) session.getAttribute(SWAP_TARGET_UID);

--- a/uportal-war/src/main/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
@@ -61,8 +61,8 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
  * 
  * @author Jen Bourey, jennifer.bourey@gmail.com
  */
-public class PortalPreAuthenticatedProcessingFilter
-        extends AbstractPreAuthenticatedProcessingFilter {
+public class PortalPreAuthenticatedProcessingFilter extends AbstractPreAuthenticatedProcessingFilter {
+
     protected final Log swapperLog = LogFactory.getLog("org.jasig.portal.portlets.swapper");
 
     private String loginPath = "/Login";
@@ -71,10 +71,12 @@ public class PortalPreAuthenticatedProcessingFilter
     protected HashMap<String, String> credentialTokens;
     protected HashMap<String, String> principalTokens;
     protected Authentication authenticationService = null;
+
     private IPersonManager personManager;
     private IdentitySwapperManager identitySwapperManager;
-
     private ApplicationEventPublisher eventPublisher;
+
+    private boolean clearSecurityContextPriorToPortalAuthentication = true; //default
 
     @Autowired
     public void setIdentitySwapperManager(IdentitySwapperManager identitySwapperManager) {
@@ -91,38 +93,16 @@ public class PortalPreAuthenticatedProcessingFilter
         this.authenticationService = authenticationService;
     }
 
+    public void setClearSecurityContextPriorToPortalAuthentication(boolean b) {
+        this.clearSecurityContextPriorToPortalAuthentication = b;
+    }
+
     @Override
     public void afterPropertiesSet() {
         super.afterPropertiesSet();
-
         this.credentialTokens = new HashMap<String,String>(1);
         this.principalTokens = new HashMap<String,String>(1);
-
-        try {
-            String key;
-            // We retrieve the tokens representing the credential and principal
-            // parameters from the security properties file.
-            Properties props = ResourceLoader.getResourceAsProperties(getClass(), "/properties/security.properties");
-            Enumeration<?> propNames = props.propertyNames();
-            while (propNames.hasMoreElements()) {
-                String propName = (String) propNames.nextElement();
-                String propValue = props.getProperty(propName);
-                if (propName.startsWith("credentialToken.")) {
-                    key = propName.substring(16);
-                    this.credentialTokens.put(key, propValue);
-                }
-                if (propName.startsWith("principalToken.")) {
-                    key = propName.substring(15);
-                    this.principalTokens.put(key, propValue);
-                }
-            }
-        }
-        catch (PortalException pe) {
-            logger.error("LoginServlet::static ", pe);
-        }
-        catch (IOException ioe) {
-            logger.error("LoginServlet::static ", ioe);
-        }
+        this.retrieveCredentialAndPrincipalTokensFromPropertiesFile();
     }
 
     /**
@@ -166,38 +146,23 @@ public class PortalPreAuthenticatedProcessingFilter
          * is useful.
          */
         if (loginPath.equals(currentPath)) {
-
-            SecurityContextHolder.clearContext();
-
-            if (logger.isDebugEnabled()) {
-                logger.debug("Path [" + currentPath + "] is loginPath, so cleared security context" +
-                " so we can re-establish it once the new session is established.");
+            final org.springframework.security.core.Authentication originalAuthentication =
+                    SecurityContextHolder.getContext().getAuthentication();
+            if (this.clearSecurityContextPriorToPortalAuthentication) {
+                SecurityContextHolder.clearContext();
             }
-
-            this.doPortalAuthentication((HttpServletRequest)request);
+            this.logForLoginPath(currentPath);
+            this.doPortalAuthentication((HttpServletRequest)request, originalAuthentication);
             chain.doFilter(request, response);
         }
-
         else if (logoutPath.equals(currentPath)) {
-
             SecurityContextHolder.clearContext();
-
-            if (logger.isDebugEnabled()) {
-                logger.debug("Path [" + currentPath + "] is logoutPath, so cleared security context" +
-                        " so can re-establish it once the new session is established.");
-            }
-
-
+            this.logForLogoutPath(currentPath);
             chain.doFilter(request, response);
         }
-
         // otherwise, call the base class logic
         else {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Path [" + currentPath  + "] is neither a login nor a logout path," +
-                        " so no uPortal-custom filtering.");
-            }
-
+            this.logForNonLoginOrLogoutPath(currentPath);
             super.doFilter(request, response, chain);
         }
 
@@ -205,140 +170,60 @@ public class PortalPreAuthenticatedProcessingFilter
             final HttpServletRequest httpr = (HttpServletRequest) request;
             logger.debug("FINISHED [" + uuid.toString() + "] for URI=" + httpr.getRequestURI() + " in " + Long.toString(System.currentTimeMillis() - timestamp) + "ms #milestone");
         }
-
     }
 
     @Override
     protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
-        // if there's no session, the user hasn't yet visited the login 
-        // servlet and we should just give up
+        // if there's no session, the user hasn't yet visited the login servlet and we should just give up
         HttpSession session = request.getSession(false);
         if (session == null) {
             return null;
         }
-
-        // otherwise, use the person's current SecurityContext as the 
-        // credentials
+        // otherwise, use the person's current SecurityContext as the credentials
         final IPerson person = personManager.getPerson(request);
         return person.getSecurityContext();
     }
 
     @Override
     protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
-        // if there's no session, the user hasn't yet visited the login 
-        // servlet and we should just give up
+        // if there's no session, the user hasn't yet visited the login servlet and we should just give up
         HttpSession session = request.getSession(false);
         if (session == null) {
             return null;
         }
-
         // otherwise, use the current IPerson as the UserDetails
-        final IPerson person = personManager.getPerson(request);       
+        final IPerson person = personManager.getPerson(request);
         final UserDetails details = new PortalPersonUserDetails(person);
         return details;
     }
 
-    private void doPortalAuthentication(HttpServletRequest request) {
-        // Clear out the existing session for the user if they have one
-        String targetUid = null;
-        String originalUid = null;
-        boolean swap = false;
-        String swapperProfile = null;
+    private void doPortalAuthentication(
+            final HttpServletRequest request,
+            final org.springframework.security.core.Authentication originalAuthentication) {
 
+        IdentitySwapHelper identitySwapHelper = null;
         final String requestedSessionId = request.getRequestedSessionId();
-
         if (request.isRequestedSessionIdValid()) {
             if (logger.isDebugEnabled()) {
                 logger.debug("doPortalAuthentication for valid requested session id " + requestedSessionId);
             }
-
-            try {
-                HttpSession s = request.getSession(false);
-
-                if (s != null) {
-                    //Check if this is a swapped user hitting the Login servlet
-                    originalUid = this.identitySwapperManager.getOriginalUsername(s);
-                }
-
-                //No original person in session so check for swap request
-                if (originalUid == null) {
-                    targetUid = this.identitySwapperManager.getTargetUsername(s);
-                    if (targetUid != null) {
-                        final IPerson person = personManager.getPerson(request);
-                        originalUid = person.getName();
-                        swap = true;
-                        swapperProfile = identitySwapperManager.getTargetProfile(s);
-                    }
-                }
-                //Original person in session so this must be an un-swap request
-                else {
-                    if (logger.isDebugEnabled()) {
-                        logger.trace("This is an un-swap request swapping back from impersonated " + targetUid
-                                + " to original user " + originalUid + ".");
-                    }
-
-                    final IPerson person = personManager.getPerson(request);
-                    targetUid = person.getName();
-                }
-
-                if (s != null) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Invalidating the impersonated session in un-swapping.");
-                    }
-
-                    s.invalidate();
-                }
-            }
-            catch (IllegalStateException ise) {
-                // ISE indicates session was already invalidated.
-                // This is fine.  This servlet trying to guarantee that the session has been invalidated;
-                // it doesn't have to insist that it is the one that invalidated it.
-                if (logger.isTraceEnabled()) {
-                    logger.trace("LoginServlet attempted to invalidate an already invalid session.", ise);
-                }
-            }
+            identitySwapHelper = getIdentitySwapDataAndInvalidateSession(request, originalAuthentication);
         } else {
             if (logger.isTraceEnabled()) {
                 logger.trace("Requested session id " + requestedSessionId + " was not valid " +
                         "so no attempt to apply swapping rules.");
             }
-
         }
 
-        //  Create the user's session
         HttpSession s = request.getSession(true);
-
         IPerson person = null;
         try {
             final HashMap<String, String> principals;
             final HashMap<String, String> credentials;
-
-            // Get the person object associated with the request
             person = personManager.getPerson(request);
 
-            //If doing an identity swap
-            if (targetUid != null && originalUid != null) {
-                if (swap) {
-                    swapperLog.warn("Swapping identity for '" + originalUid + "' to '" + targetUid + "'");
-
-                    //Track the originating user
-                    this.identitySwapperManager.setOriginalUser(s, originalUid, targetUid);
-
-                    //Setup the swapped person
-                    person.setUserName(targetUid);
-                }
-                else {
-                    swapperLog.warn("Reverting swapped identity from '" + targetUid + "' to '" + originalUid + "'");
-
-                    person.setUserName(originalUid);
-                }
-
-                //Setup the custom security context
-                final IdentitySwapperPrincipal identitySwapperPrincipal = new IdentitySwapperPrincipal(person);
-                final IdentitySwapperSecurityContext identitySwapperSecurityContext = new IdentitySwapperSecurityContext(
-                        identitySwapperPrincipal);
-                person.setSecurityContext(identitySwapperSecurityContext);
-
+            if (identitySwapHelper != null && identitySwapHelper.isSwapOrUnswapRequest()) {
+                this.handleIdentitySwap(person, s, identitySwapHelper);
                 principals = new HashMap<String, String>();
                 credentials = new HashMap<String, String>();
             }
@@ -362,40 +247,201 @@ public class PortalPreAuthenticatedProcessingFilter
             request.getSession(true).setAttribute(LoginController.AUTH_ERROR_KEY, Boolean.TRUE);
         }
 
+        this.publishProfileSelectionEvent(person, request, identitySwapHelper);
+    }
+
+    /**
+     * Helper inner class for encapsulating logic for determining whether or not the request is for an identity "swap" 
+     * or "unswap", and determining the "swap from" and "swap to" values.
+     */
+    class IdentitySwapHelper {
+        private String originalUsername;
+        private String personName;
+        private String targetProfile;
+        private String targetUsername;
+        private org.springframework.security.core.Authentication originalAuthenticationForSwap;
+        private org.springframework.security.core.Authentication originalAuthenticationForUnswap;
+
+        IdentitySwapHelper(
+                final HttpSession s,
+                final String personName) {
+            // must pull out session data during creation because session may later be invalidated
+            this.originalAuthenticationForUnswap = identitySwapperManager.getOriginalAuthentication(s);
+            this.originalUsername = identitySwapperManager.getOriginalUsername(s);
+            this.personName = personName;
+            this.targetUsername = identitySwapperManager.getTargetUsername(s);
+            this.targetProfile = identitySwapperManager.getTargetProfile(s);
+        }
+        public boolean isSwapRequest() {
+            return this.originalUsername == null && this.targetUsername != null;
+        }
+        public boolean isUnswapRequest() {
+            return this.originalUsername != null;
+        }
+        public boolean isSwapOrUnswapRequest() {
+            return this.isSwapRequest() || this.isUnswapRequest();
+        }
+        public org.springframework.security.core.Authentication getOriginalAuthenticationForSwap() {
+            return this.originalAuthenticationForSwap;
+        }
+        public org.springframework.security.core.Authentication getOriginalAuthenticationForUnswap() {
+            return this.originalAuthenticationForUnswap;
+        }
+        public String getSwapFromUid() {
+            if (this.isSwapRequest()) {
+                return this.personName;
+            }
+            if (this.isUnswapRequest()) {
+                return this.targetUsername;
+            }
+            return null;
+        }
+        public String getSwapToUid() {
+            if (this.isSwapRequest()) {
+                return this.targetUsername;
+            }
+            if (this.isUnswapRequest()) {
+                return this.originalUsername;
+            }
+            return null;
+        }
+        public String getTargetProfile() {
+            return this.targetProfile;
+        }
+        public void setOriginalAuthenticationForSwap(final org.springframework.security.core.Authentication auth) {
+            this.originalAuthenticationForSwap = auth;
+        }
+    }
+
+    private IdentitySwapHelper getIdentitySwapDataAndInvalidateSession(
+            final HttpServletRequest request, final org.springframework.security.core.Authentication originalAuth) {
+        IdentitySwapHelper identitySwapHelper = null;
+        try {
+            HttpSession s = request.getSession(false);
+            if (s != null) {
+                final IPerson person = personManager.getPerson(request);
+                identitySwapHelper = new IdentitySwapHelper(s, person.getName());
+                if (identitySwapHelper.isSwapRequest()) {
+                    identitySwapHelper.setOriginalAuthenticationForSwap(originalAuth);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Invalidating the impersonated session in un-swapping.");
+                }
+                s.invalidate();
+            }
+        }
+        catch (IllegalStateException ise) {
+            // ISE indicates session was already invalidated.
+            // This is fine.  This servlet trying to guarantee that the session has been invalidated;
+            // it doesn't have to insist that it is the one that invalidated it.
+            if (logger.isTraceEnabled()) {
+                logger.trace("LoginServlet attempted to invalidate an already invalid session.", ise);
+            }
+        }
+        return identitySwapHelper;
+    }
+
+    private void handleIdentitySwap(
+            final IPerson person, final HttpSession session , final IdentitySwapHelper identitySwapHelper) {
+        String msgFormat;
+        if (identitySwapHelper.isSwapRequest()) {
+            msgFormat = "Swapping identity for '%s' to '%s'";
+            this.identitySwapperManager.setOriginalUser(
+                session,
+                identitySwapHelper.getSwapFromUid(),
+                identitySwapHelper.getSwapToUid(),
+                identitySwapHelper.getOriginalAuthenticationForSwap());
+        }
+        else {
+            msgFormat = "Reverting swapped identity from '%s' to '%s'";
+            if (identitySwapHelper.getOriginalAuthenticationForUnswap() != null) {
+                SecurityContextHolder.getContext().setAuthentication(
+                        identitySwapHelper.getOriginalAuthenticationForUnswap());
+            }
+        }
+        person.setUserName(identitySwapHelper.getSwapToUid());
+        final String msg = String.format(
+                msgFormat, identitySwapHelper.getSwapFromUid(), identitySwapHelper.getSwapToUid());
+        swapperLog.warn(msg);
+
+        //Setup the custom security context
+        final IdentitySwapperPrincipal identitySwapperPrincipal = new IdentitySwapperPrincipal(person);
+        final IdentitySwapperSecurityContext identitySwapperSecurityContext = 
+                new IdentitySwapperSecurityContext(identitySwapperPrincipal);
+        person.setSecurityContext(identitySwapperSecurityContext);
+    }
+
+    private void publishProfileSelectionEvent(
+            final IPerson person, final HttpServletRequest request, final IdentitySwapHelper identitySwapHelper) {
         final String requestedProfile = request.getParameter(LoginController.REQUESTED_PROFILE_KEY);
-
         if (requestedProfile != null) {
-
             final ProfileSelectionEvent event = new ProfileSelectionEvent(this, requestedProfile, person, request);
-
-            try {
-                this.eventPublisher.publishEvent(event);
-            } catch (final Exception exceptionFiringProfileSelection) {
-                // failing to register a profile selection is bad,
-                // but preventing login entirely is worse.  Log the exception and continue.
-                logger.error("Exception on firing profile selection event " + event,
-                    exceptionFiringProfileSelection);
-            }
-
-
-        } else if(swapperProfile != null) {
-
-            final ProfileSelectionEvent event = new ProfileSelectionEvent(this, swapperProfile, person, request);
-
-            try {
-                this.eventPublisher.publishEvent(event);
-            } catch (final Exception exceptionFiringSwappedProfileSelection) {
-                // failing to swap as the desired profile selection is bad,
-                // but preventing login entirely is worse.  Log the exception and continue.
-                logger.error("Exception on firing profile selection event " + event,
-                    exceptionFiringSwappedProfileSelection);
-            }
-
-
+            this.publishProfileSelectionEvent(event);
+        } else if(identitySwapHelper != null && identitySwapHelper.isSwapRequest()) {
+            final ProfileSelectionEvent event =
+                    new ProfileSelectionEvent(this, identitySwapHelper.getTargetProfile(), person, request);
+            this.publishProfileSelectionEvent(event);
         } else {
             if (logger.isTraceEnabled()) {
                 logger.trace("No requested or swapper profile requested so no profile selection event.");
             }
+        }
+    }
+    private void publishProfileSelectionEvent(final ProfileSelectionEvent event) {
+        try {
+            this.eventPublisher.publishEvent(event);
+        } catch (final Exception exceptionFiringProfileSelection) {
+            // failing to swap as the desired profile selection is bad,
+            // but preventing login entirely is worse.  Log the exception and continue.
+            logger.error("Exception on firing profile selection event " + event,
+                exceptionFiringProfileSelection);
+        }
+    }
+
+    private void logForLoginPath(final String currentPath) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Path [" + currentPath + "] is loginPath, so cleared security context" +
+                    " so we can re-establish it once the new session is established.");
+        }
+    }
+    private void logForLogoutPath(final String currentPath) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Path [" + currentPath + "] is logoutPath, so cleared security context" +
+                    " so can re-establish it once the new session is established.");
+        }
+    }
+    private void logForNonLoginOrLogoutPath(final String currentPath) {
+        if (logger.isTraceEnabled()) {
+            logger.trace("Path [" + currentPath  + "] is neither a login nor a logout path," +
+                    " so no uPortal-custom filtering.");
+        }
+    }
+
+    private void retrieveCredentialAndPrincipalTokensFromPropertiesFile() {
+        try {
+            String key;
+            // We retrieve the tokens representing the credential and principal
+            // parameters from the security properties file.
+            Properties props = ResourceLoader.getResourceAsProperties(getClass(), "/properties/security.properties");
+            Enumeration<?> propNames = props.propertyNames();
+            while (propNames.hasMoreElements()) {
+                String propName = (String) propNames.nextElement();
+                String propValue = props.getProperty(propName);
+                if (propName.startsWith("credentialToken.")) {
+                    key = propName.substring(16);
+                    this.credentialTokens.put(key, propValue);
+                }
+                if (propName.startsWith("principalToken.")) {
+                    key = propName.substring(15);
+                    this.principalTokens.put(key, propValue);
+                }
+            }
+        }
+        catch (PortalException pe) {
+            logger.error("LoginServlet::static ", pe);
+        }
+        catch (IOException ioe) {
+            logger.error("LoginServlet::static ", ioe);
         }
     }
 
@@ -469,3 +515,4 @@ public class PortalPreAuthenticatedProcessingFilter
         return this.eventPublisher;
     }
 }
+

--- a/uportal-war/src/main/resources/properties/contexts/securityContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/securityContext.xml
@@ -40,6 +40,7 @@
     <bean id="portalPreAuthenticationFilter"
         class="org.jasig.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter">
         <property name="authenticationManager" ref="authenticationManager" />
+        <property name="clearSecurityContextPriorToPortalAuthentication" value="false" />
     </bean>
   
     <bean id="preAuthProvider"

--- a/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.jasig.portal.layout.profile.ProfileSelectionEvent;
+import org.junit.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class PortalPreAuthenticatedProcessingFilterIdentitySwapTest
+        extends PortalPreAuthenticatedProcessingFilterTestBase {
+
+    private String targetProfileKey;
+    private String targetUsername;
+
+    public void additionalSetup() {
+        this.targetProfileKey = "targetProfileKey";
+        this.targetUsername = "targetUsername";
+        SecurityContextHolder.createEmptyContext();
+        SecurityContextHolder.getContext().setAuthentication(this.auth);
+    }
+
+    @Test
+    public void testThatOriginalUserIsSetWhenSecurityContextIsStillAvailable() throws Exception {
+        // given
+        this.filter.setClearSecurityContextPriorToPortalAuthentication(false);
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.identitySwapperManager).setOriginalUser(this.session, this.username, this.targetUsername, this.auth);
+    }
+
+    @Test
+    public void testThatOriginalUserIsSetWhenSecurityContextIsNoLongerAvailable() throws Exception {
+        // given
+        this.filter.setClearSecurityContextPriorToPortalAuthentication(true);
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.identitySwapperManager).setOriginalUser(this.session, this.username, this.targetUsername, this.auth);
+    }
+
+    @Test
+    public void testThatTargetUsernameIsSetAsPersonName() throws Exception {
+        // given
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.person).setUserName(this.targetUsername);
+    }
+
+    /**
+     * Test that when swapping to another identity while specifying a target profile, fires event for that profile.
+     */
+    @Test
+    public void testThatProfileSelectedEventIsSent() throws IOException, ServletException {
+        // given
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        final ProfileSelectionEvent expectedEvent =
+                new ProfileSelectionEvent(this.filter, this.targetProfileKey, this.person, this.request);
+        verify(this.eventPublisher).publishEvent(expectedEvent);
+    }
+
+    private void requestIsForIdentitySwapLogin() {
+        when(this.identitySwapperManager.getTargetProfile(this.session)).thenReturn(this.targetProfileKey);
+        when(this.identitySwapperManager.getOriginalUsername(this.session)).thenReturn(null);
+        when(this.identitySwapperManager.getTargetUsername(this.session)).thenReturn(this.targetUsername);
+        when(this.request.getServletPath()).thenReturn("/Login");
+    }
+
+    private void requestedSessionIdIsValid() {
+        when(this.request.isRequestedSessionIdValid()).thenReturn(true);
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class PortalPreAuthenticatedProcessingFilterIdentityUnswapTest
+        extends PortalPreAuthenticatedProcessingFilterTestBase {
+
+    private String originalUsername;
+    private String targetUsername;
+    @Mock Authentication originalAuthentication;
+
+    public void additionalSetup() {
+        this.originalUsername = "originalUsername";
+        this.targetUsername = "targetUsername";
+        SecurityContextHolder.createEmptyContext();
+        SecurityContextHolder.getContext().setAuthentication(this.auth);
+        given(this.identitySwapperManager.getOriginalAuthentication(this.session)).willReturn(this.originalAuthentication);
+    }
+
+    @Test
+    public void testThatOriginalUsernameIsSetAsPersonUserName() throws Exception {
+        // given
+        this.requestIsForIdentityUnswapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.person).setUserName(this.originalUsername);
+    }
+
+    @Test
+    public void testThatOriginalAuthenticationIsSetInSecurityContext() throws IOException, ServletException {
+        // given
+        this.requestIsForIdentityUnswapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertEquals(this.originalAuthentication, auth);
+    }
+
+    private void requestIsForIdentityUnswapLogin() {
+        when(this.identitySwapperManager.getTargetProfile(this.session)).thenReturn(null);
+        when(this.identitySwapperManager.getOriginalUsername(this.session)).thenReturn(this.originalUsername);
+        when(this.identitySwapperManager.getTargetUsername(this.session)).thenReturn(this.targetUsername);
+        when(this.request.getServletPath()).thenReturn("/Login");
+    }
+
+    private void requestedSessionIdIsValid() {
+        when(this.request.isRequestedSessionIdValid()).thenReturn(true);
+    }
+
+}

--- a/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
+++ b/uportal-war/src/test/java/org/jasig/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.jasig.portal.security.IPerson;
+import org.jasig.portal.security.IPersonManager;
+import org.jasig.portal.security.ISecurityContext;
+import org.jasig.portal.security.IdentitySwapperManager;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+
+public abstract class PortalPreAuthenticatedProcessingFilterTestBase {
+
+    @InjectMocks PortalPreAuthenticatedProcessingFilter filter;
+
+    @Mock FilterChain filterChain;
+    @Mock HttpServletRequest request;
+    @Mock HttpServletResponse response;
+    @Mock HttpSession session;
+    @Mock IPersonManager personManager;
+    @Mock IPerson person;
+    @Mock ISecurityContext context;
+    @Mock Authentication auth;
+    @Mock SecurityContext initialContext;
+    @Mock AuthenticationManager authenticationManager;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock IdentitySwapperManager identitySwapperManager;
+
+    String username;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        this.username = "testuser";
+        filter.setAuthenticationService(new org.jasig.portal.services.Authentication());
+        filter.setApplicationEventPublisher(eventPublisher);
+        filter.setIdentitySwapperManager(identitySwapperManager);
+        filter.afterPropertiesSet();
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getSession(true)).thenReturn(session);
+        when(personManager.getPerson(request)).thenReturn(person);
+        when(person.getName()).thenReturn(this.username);
+        when(person.isGuest()).thenReturn(false);
+        when(person.getSecurityContext()).thenReturn(context);
+
+        this.additionalSetup();
+    }
+
+    public abstract void additionalSetup();
+
+}


### PR DESCRIPTION
…using a two step login process, where the first step sets up the SecurityContext Authentication and the second step is the normal /uPortal/Login process.

There are really three sets of changes here:

1.   refactor identity swap code in "PortalPreAuthenticatedProcessingFilter" to use an inner class ("IdentitySwapHelper"), in order to make the code easier to understand and to clean up the main authentication logic

2.  addition of "clearSecurityContextPriorToPortalAuthentication" flag in order to disable the clearing of the security context prior to authentication

3.  updates so that during an identity swap the current Authentication object gets save and later restored during the unswap

Numbers 2. and 3. are changes that may or may not need to be included, based on whether the problem they solve is thought to be general enough.  What they do is enable the use of a two step log in process where the first step establishes the SecurityContext Authentication, and the second step is the normal uPortal login logic. In the scenario for which these were added, we are using Shibboleth.  For login, the IDP redirects to uPortal at "/uPortal/saml/SSO" which is maps to  "org.springframework.security.saml.SAMLProcessingFilter".  On success, the redirect handler redirects to "/uPortal/Login" which uses the updated code in this pull request.  Because it is a two step login process, for identity swaps we need to save the Authentication object and restore it during the unswap.  The two step login also requires that we do not clear the security context in step 2 since it has been set up in step 1.