### PR TITLE
UP4712: Fix logic error with GroupMemberImpl.primGetAncestorGroups()

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/GroupMemberImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/GroupMemberImpl.java
@@ -188,8 +188,7 @@ protected boolean isKnownEntityType(Class anEntityType) throws GroupsException
  * @return Set
  */
 protected Set<IEntityGroup> primGetAncestorGroups(IGroupMember member, Set<IEntityGroup> rslt) throws GroupsException {
-    for (IEntityGroup group : getParentGroups())
-    {
+    for (IEntityGroup group : member.getParentGroups()) {
         // avoid stack overflow in case of circular group dependencies
         if (!rslt.contains(group)) {
             rslt.add(group);


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4712

## Next Steps

- [x] Apply to rel-4-3-patches
- [x] Apply to master, but after the Gradle refactor