### PR TITLE
UP-4733:  For non-production deployments, configure setting logAbando…

### DIFF
--- a/filters/data-test.properties
+++ b/filters/data-test.properties
@@ -46,6 +46,9 @@ environment.build.hibernate.connection.password=
 environment.build.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION_SCHEMA.SYSTEM_USERS
 
+## Print a stack trace for abandoned connections to the log?  (false for PROD, otherwise true)
+environment.build.tomcat.jdbc.pool.logAbandoned=true
+
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
 environment.build.uportal.protocol=http

--- a/filters/live-nightly.properties
+++ b/filters/live-nightly.properties
@@ -46,6 +46,9 @@ environment.build.hibernate.connection.password=
 environment.build.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION_SCHEMA.SYSTEM_USERS
 
+## Print a stack trace for abandoned connections to the log?  (false for PROD, otherwise true)
+environment.build.tomcat.jdbc.pool.logAbandoned=true
+
 # uPortal server configuration properties
 environment.build.uportal.server=up41-nightly.jasig.org
 environment.build.uportal.protocol=https

--- a/filters/local.properties
+++ b/filters/local.properties
@@ -45,6 +45,9 @@ environment.build.hibernate.connection.password=
 environment.build.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION_SCHEMA.SYSTEM_USERS
 
+## Print a stack trace for abandoned connections to the log?  (false for PROD, otherwise true)
+environment.build.tomcat.jdbc.pool.logAbandoned=true
+
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
 environment.build.uportal.protocol=http

--- a/filters/prod.properties
+++ b/filters/prod.properties
@@ -45,6 +45,9 @@ environment.build.hibernate.connection.password=
 environment.build.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 environment.build.hibernate.connection.validationQuery=select 1 from INFORMATION_SCHEMA.SYSTEM_USERS
 
+## Print a stack trace for abandoned connections to the log?  (false for PROD, otherwise true)
+environment.build.tomcat.jdbc.pool.logAbandoned=false
+
 # uPortal server configuration properties
 environment.build.uportal.server=localhost:8080
 environment.build.uportal.protocol=http

--- a/uportal-war/src/main/resources/properties/contexts/datasourceContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/datasourceContext.xml
@@ -45,7 +45,7 @@
         <property name="abandonWhenPercentageFull" value="70" />
         <property name="removeAbandoned" value="true" />
         <property name="removeAbandonedTimeout" value="300" />
-        <property name="logAbandoned" value="${tomcat.jdbc.pool.logAbandoned}"/>
+        <property name="logAbandoned" value="${tomcat.jdbc.pool.logAbandoned:false}"/>
         
         <property name="jdbcInterceptors" value="ConnectionState(useEquals=true);ResetAbandonedTimer"/>
         

--- a/uportal-war/src/main/resources/properties/contexts/datasourceContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/datasourceContext.xml
@@ -45,6 +45,7 @@
         <property name="abandonWhenPercentageFull" value="70" />
         <property name="removeAbandoned" value="true" />
         <property name="removeAbandonedTimeout" value="300" />
+        <property name="logAbandoned" value="${tomcat.jdbc.pool.logAbandoned}"/>
         
         <property name="jdbcInterceptors" value="ConnectionState(useEquals=true);ResetAbandonedTimer"/>
         

--- a/uportal-war/src/main/resources/properties/rdbm.properties
+++ b/uportal-war/src/main/resources/properties/rdbm.properties
@@ -30,6 +30,7 @@ hibernate.connection.username=${environment.build.hibernate.connection.username}
 hibernate.connection.password=${environment.build.hibernate.connection.password}
 hibernate.connection.validationQuery=${environment.build.hibernate.connection.validationQuery}
 hibernate.dialect=${environment.build.hibernate.dialect}
+tomcat.jdbc.pool.logAbandoned=${environment.build.tomcat.jdbc.pool.logAbandoned}
 
 ##### uPortal Raw Events DB
 RawEventsJdbcDriver=${environment.build.hibernate.connection.driver_class}


### PR DESCRIPTION
…ned=true in the Tomcat dbcp

https://issues.jasig.org/browse/UP-4733

If abandoned connections are happening in uPortal, I think we want visibility into that.