### PR TITLE
UP-4729 : Activating flyout menu option from portal.properties - rel-4-3-patches

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -54,7 +54,7 @@
 <xsl:param name="TAB_CONTEXT" select="'header'"/><!-- Sets the location of the navigation. Values are 'header' or 'sidebar'. -->
 <xsl:param name="CONTEXT" select="'header'"/>
 <xsl:param name="subscriptionsSupported">true</xsl:param>
-<xsl:param name="USE_FLYOUT_MENUS" select="'false'" /> <!-- Sets the use of flyout menus.  Values are 'true' or 'false'. TODO:  Move to parameter in renderingPipelineContext.xml with configuration in portal.properties. -->
+<xsl:param name="USE_FLYOUT_MENUS">false</xsl:param> <!-- Moved to parameter in renderingPipelineContext.xml with configuration in portal.properties. -->
 <xsl:param name="useTabGroups">false</xsl:param>
 <xsl:param name="PORTAL_VIEW">
   <xsl:choose>

--- a/uportal-war/src/main/resources/properties/contexts/renderingPipelineContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/renderingPipelineContext.xml
@@ -181,6 +181,7 @@
                                     <entry key="EXTERNAL_LOGIN_URL" value="${org.jasig.portal.channels.CLogin.CasLoginUrl}" />
                                     <entry key="useTabGroups" value="${org.jasig.portal.layout.useTabGroups}"/>
                                     <entry key="UP_VERSION" value="${org.jasig.portal.version}"/>
+                                    <entry key="USE_FLYOUT_MENUS" value="${org.jasig.portal.layout.useFlyoutMenus}" />
                                 </map>
                             </property>
                             <property name="parameterExpressions">

--- a/uportal-war/src/main/resources/properties/portal.properties
+++ b/uportal-war/src/main/resources/properties/portal.properties
@@ -460,6 +460,14 @@ org.jasig.portal.portlets.statistics.maxIntervals=4000
 org.jasig.portal.layout.useTabGroups=false
 
 ##
+## Whether or not to use sub navigation level (a.k.a. Flyout Menu in old releases).
+## This feature allows a sub-navigation level, like a dropdown menu on each tabs
+## that will show all channels that the tab contains. And a click on a channel title will
+## render it on a maximized window state.
+##
+org.jasig.portal.layout.useFlyoutMenus=false
+
+##
 ## Set the serverName to use to identify this server within a cluster, if not set but
 ## networkInterfaceName is set then the first hostname on the NetworkInterface with the
 ## specified name will be used. If neither are set InetAddress.getLocalHost() will be


### PR DESCRIPTION
Useful to avoid to modify the option in the XSL.

Adapted from #717 

@jgribonvald 's patch rebased on top of current rel-4-3-patches.