### PR TITLE
UP-4740:  Report on caches in poor condition

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/utils/cache/CacheHealthReporterService.java
+++ b/uportal-war/src/main/java/org/apereo/portal/utils/cache/CacheHealthReporterService.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.utils.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * This service supports custom {@link net.sf.ehcache.event.CacheEventListener}
+ * objects that recognize when "something bad" is happening with a uPortal
+ * cache.  Those listeners quickly contact this service with the details.
+ * Periodically this service produces a report on bad things that are occurring,
+ * if any, and writes it to the log.
+ *
+ * @author drewwills
+ */
+@Service("cacheHealthReporterService")
+public class CacheHealthReporterService {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private enum Reports {
+        CACHE_SIZE_NOT_LARGE_ENOUGH {
+            @Override
+            protected void doReportInternal(Logger logger, List<ReportTuple> list) {
+                if (list.size() != 0) {
+                    final StringBuilder report = new StringBuilder();
+                    final Map<String,Integer> counts = new HashMap<>();
+                    for (ReportTuple tuple : list) {
+                        final String cacheName = tuple.getCache().getName();
+                        Integer newCount = 1;  // default
+                        Integer oldCount = counts.get(cacheName);
+                        if (oldCount != null) {
+                            newCount = ++oldCount;
+                        }
+                        counts.put(cacheName, newCount);
+                    }
+                    report.append("The following cache(s) have insufficient maxElementsInMemory;  " +
+                            "there must be room in the cache to hold every object of " +
+                            "the corresponding type in the portal:");
+                    for (Map.Entry<String,Integer> y : counts.entrySet()) {
+                        report.append("\n\t- ").append(y.getKey()).append(" (")
+                                .append(y.getValue())
+                                .append(" elements evicted due to insufficient size since last report)");
+                    }
+                    logger.warn(report.toString());
+                }
+            }
+        };
+
+        private final List<ReportTuple> entries = Collections.synchronizedList(new ArrayList<ReportTuple>());
+
+        public final void add(ReportTuple tuple) {
+            entries.add(tuple);
+        }
+
+        public final void writeReport(Logger logger) {
+
+            // Copy & Reset the entries list
+            final List<ReportTuple> list = new ArrayList<>(entries);
+            entries.clear();
+            doReportInternal(logger, list);
+
+        }
+
+        protected abstract void doReportInternal(Logger logger, List<ReportTuple> list);
+
+    }
+
+    public void generateReports() {
+        for (Reports report : Reports.values()) {
+            report.writeReport(logger);
+        }
+    }
+
+    @Async
+    public void reportCacheSizeNotLargeEnough(Ehcache cache, Element element) {
+        final ReportTuple tuple = new ReportTuple(cache, element);
+        Reports.CACHE_SIZE_NOT_LARGE_ENOUGH.add(tuple);
+    }
+
+    /*
+     * Nested Types
+     */
+
+    private static final class ReportTuple {
+        private final Ehcache cache;
+        private final Element element;
+        public ReportTuple(Ehcache cache, Element element) {
+            this.cache = cache;
+            this.element = element;
+        }
+        public Ehcache getCache() {
+            return cache;
+        }
+        public Element getElement() {
+            return element;
+        }
+    }
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/utils/cache/InsufficientSizeCacheEventListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/utils/cache/InsufficientSizeCacheEventListener.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.utils.cache;
+
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.event.CacheEventListenerAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used with caches that will degrade performance when the maxElementsInMemory
+ * is smaller than the number of objects of that type in the portal.
+ *
+ * @author drewwills
+ */
+@Service("insufficientSizeCacheEventListener")
+public class InsufficientSizeCacheEventListener extends CacheEventListenerAdapter {
+
+    @Autowired
+    private CacheHealthReporterService cacheHealthReporterService;
+
+    @Override
+    public void notifyElementEvicted(Ehcache cache, Element element) {
+        if (!element.isExpired()) {
+            /*
+             * We've added this listener to the configuration of this cache in
+             * ehcache.xml because we believe it's worrisome for elements to
+             * leave the cache EXCEPT when they exceed their timeToLiveSeconds
+             * or timeToIdleSeconds.
+             */
+            cacheHealthReporterService.reportCacheSizeNotLargeEnough(cache, element);
+        }
+    }
+
+}

--- a/uportal-war/src/main/resources/properties/contexts/schedulerContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/schedulerContext.xml
@@ -63,6 +63,7 @@
         <task:scheduled ref="portalEventDaoQueuingEventHandler" method="flush" fixed-delay="997"/> <!-- ~1 second period -->
         <task:scheduled ref="cacheManagerExpiredElementEvictor" method="evictExpiredElements" fixed-delay="61900"/> <!-- ~1 minute period -->
         <task:scheduled ref="portletPermissionsCachePrimer" method="primeCache" fixed-delay="299993"/> <!-- just under 5 minute period;  should be shorter than the TTL for the cache named 'org.apereo.portal.security.provider.AnyUnblockedGrantPermissionPolicy.HAS_UNBLOCKED_GRANT' -->
+        <task:scheduled ref="cacheHealthReporterService" method="generateReports" fixed-delay="60013"/> <!-- ~1 minute period -->
 
         <!-- clustered tasks -->
         <task:scheduled ref="portletCookieService" method="purgeExpiredCookies" fixed-delay="${org.apereo.portal.portlet.container.services.PortletCookieServiceImpl.purgeExpiredCookiesPeriod}"/>

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -208,6 +208,7 @@
     <cache name="org.apereo.portal.layout.dlm.FragmentActivator.userViews"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -233,7 +234,9 @@
      +-->
     <cache name="org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore.fragmentNodeInfoCache"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
-        timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+        timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true">
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
+    </cache>
 
     <!--
      | Caches layout DOM
@@ -296,6 +299,7 @@
     <cache name="org.apereo.portal.EntityTypes.CLASS_BY_ID"
         eternal="false" maxElementsInMemory="50" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="28800" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -306,6 +310,7 @@
     <cache name="org.apereo.portal.EntityTypes.ID_BY_CLASS"
         eternal="false" maxElementsInMemory="50" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="28800" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -362,6 +367,7 @@
     <cache name="org.apereo.portal.groups.IEntityGroup"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -417,6 +423,7 @@
     <cache name="org.apereo.portal.groups.EntityGroupImpl.children"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -433,6 +440,7 @@
     <cache name="org.apereo.portal.security.IPermissionSet"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -858,6 +866,7 @@
     <cache name="org.apereo.portal.layout.dlm.Evaluator"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -974,6 +983,7 @@
     <cache name="org.apereo.portal.permission.dao.jpa.PermissionOwnerImpl"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -1151,6 +1161,7 @@
     <cache name="org.apereo.portal.portlet.dao.jpa.PortletDefinitionImpl"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LFU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -1294,12 +1305,13 @@
 
     <!--
      | Caches PortletType objects
-     | - 1 x channel type
+     | - 1 x portlet type
      | - replicated by invalidation
      +-->
     <cache name="org.apereo.portal.portlet.dao.jpa.PortletTypeImpl"
         eternal="false" maxElementsInMemory="250" overflowToDisk="false" diskPersistent="false"
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
         <cacheEventListenerFactory
             class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
             properties="replicateAsynchronously=true,
@@ -1947,7 +1959,9 @@
      +-->
     <cache name="org.apereo.portal.groups.pags.dao.EntityPersonAttributesGroupStore.entityGroup"
            eternal="false" overflowToDisk="false" diskPersistent="false"
-           maxElementsInMemory="625" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+           maxElementsInMemory="625" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true">
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
+    </cache>
 
     <!--
      | Stores objects of type PagsGroup, which are used to test users' attributes for
@@ -1958,7 +1972,9 @@
      +-->
     <cache name="org.apereo.portal.groups.pags.dao.EntityPersonAttributesGroupStore.pagsGroup"
            eternal="false" overflowToDisk="false" diskPersistent="false"
-           maxElementsInMemory="625" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+           maxElementsInMemory="625" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true">
+        <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=insufficientSizeCacheEventListener" listenFor="local" />
+    </cache>
 
     <!--
      | Remembers membership decisions calculated by EntityPersonAttributesGroupStore


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4740

This PR writes warnings to the logs when a cache that should be big enough (for all objects of the corresponding type) starts evicting cache elements due to the configured maxElementsInMemory.

Examples of such caches are those that hold:
- Groups
- Portlets
- Fragments

NOTE:  I'm not sure if a solution like this is a good idea, or if we're better off simply lifting the maxElementsInMemory... allowing the caches to grow to whatever size is needed.
