### PR TITLE
UP-4506: Fix alt max link to be spelled correctly - rel-4-3_patches

### DIFF
--- a/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
+++ b/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
@@ -271,14 +271,14 @@
                             <xsl:sort select="number(@dlm:precedence)" order="descending"/>
                             <sidebarChannel name="{@name}" title="{@title}" ID="{@ID}" fname="{@fname}" description="{@description}">
                                 <xsl:choose>
-                                    <xsl:when test="parameter[@name='PORTLET.alternativeMaximixedLink']">
-                                        <xsl:attribute name="alternativeMaximixedLink">
-                                            <xsl:value-of select="parameter[@name='PORTLET.alternativeMaximixedLink']/@value"/>
+                                    <xsl:when test="parameter[@name='PORTLET.alternativeMaximizedLink']">
+                                        <xsl:attribute name="alternativeMaximizedLink">
+                                            <xsl:value-of select="parameter[@name='PORTLET.alternativeMaximizedLink']/@value"/>
                                         </xsl:attribute>
                                     </xsl:when>
-                                    <xsl:when test="parameter[@name='alternativeMaximixedLink']">
-                                        <xsl:attribute name="alternativeMaximixedLink">
-                                            <xsl:value-of select="parameter[@name='alternativeMaximixedLink']/@value"/>
+                                    <xsl:when test="parameter[@name='alternativeMaximizedLink']">
+                                        <xsl:attribute name="alternativeMaximizedLink">
+                                            <xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value"/>
                                         </xsl:attribute>
                                     </xsl:when>
                                 </xsl:choose>
@@ -427,14 +427,14 @@
                         </xsl:when>
                     </xsl:choose>
                     <xsl:choose>
-                        <xsl:when test="parameter[@name='PORTLET.alternativeMaximixedLink']">
-                            <xsl:attribute name="alternativeMaximixedLink">
-                                <xsl:value-of select="parameter[@name='PORTLET.alternativeMaximixedLink']/@value"/>
+                        <xsl:when test="parameter[@name='PORTLET.alternativeMaximizedLink']">
+                            <xsl:attribute name="alternativeMaximizedLink">
+                                <xsl:value-of select="parameter[@name='PORTLET.alternativeMaximizedLink']/@value"/>
                             </xsl:attribute>
                         </xsl:when>
-                        <xsl:when test="parameter[@name='alternativeMaximixedLink']">
-                            <xsl:attribute name="alternativeMaximixedLink">
-                                <xsl:value-of select="parameter[@name='alternativeMaximixedLink']/@value"/>
+                        <xsl:when test="parameter[@name='alternativeMaximizedLink']">
+                            <xsl:attribute name="alternativeMaximizedLink">
+                                <xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value"/>
                             </xsl:attribute>
                         </xsl:when>
                     </xsl:choose>

--- a/uportal-war/src/main/resources/layout/theme/muniversality/components.xsl
+++ b/uportal-war/src/main/resources/layout/theme/muniversality/components.xsl
@@ -116,8 +116,8 @@
             <div class="portlet">
               <xsl:variable name="defaultPortletUrl">
                 <xsl:choose>
-                  <xsl:when test="parameter[@name='alternativeMaximixedLink'] and string-length(parameter[@name='alternativeMaximixedLink']/@value) > 0">
-                    <xsl:value-of select="parameter[@name='alternativeMaximixedLink']/@value" />
+                  <xsl:when test="parameter[@name='alternativeMaximizedLink'] and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
+                    <xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value" />
                   </xsl:when>
                   <xsl:otherwise>
                     <xsl:call-template name="portalUrl">
@@ -147,7 +147,7 @@
                 <xsl:attribute name="href"><xsl:value-of select="$portletUrl" /></xsl:attribute>
                 <xsl:attribute name="title"><xsl:value-of select="upMsg:getMessage('to.view', $USER_LANG)" /><xsl:text> </xsl:text><xsl:value-of select="@title" /></xsl:attribute>
                 <xsl:choose>
-                  <xsl:when test="parameter[@name='alternativeMaximixedLink'] and string-length(parameter[@name='alternativeMaximixedLink']/@value) > 0">
+                  <xsl:when test="parameter[@name='alternativeMaximizedLink'] and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
                     <xsl:attribute name="target">_blank</xsl:attribute>
                   </xsl:when>
                   <xsl:otherwise></xsl:otherwise>
@@ -174,9 +174,9 @@
                             <xsl:variable name="defaultPortletUrl">
                               <xsl:choose>
                                 <xsl:when
-                                     test="parameter[@name='alternativeMaximixedLink']
-                                         and string-length(parameter[@name='alternativeMaximixedLink']/@value) > 0">
-                                  <xsl:value-of select="parameter[@name='alternativeMaximixedLink']/@value" />
+                                     test="parameter[@name='alternativeMaximizedLink']
+                                         and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
+                                  <xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value" />
                                 </xsl:when>
                                 <xsl:otherwise>
                                   <xsl:call-template name="portalUrl">
@@ -209,7 +209,7 @@
                                    /><xsl:text> </xsl:text><xsl:value-of select="@title" /></xsl:attribute>
                               <xsl:choose>
                                 <xsl:when
-                                     test="parameter[@name='alternativeMaximixedLink'] and string-length(parameter[@name='alternativeMaximixedLink']/@value) > 0">
+                                     test="parameter[@name='alternativeMaximizedLink'] and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
                                   <xsl:attribute name="target">_blank</xsl:attribute>
                                 </xsl:when>
                                 <xsl:otherwise></xsl:otherwise>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -341,8 +341,8 @@
           <xsl:element name="a"> <!-- Navigation item link. -->
             <xsl:attribute name="title"><xsl:value-of select="@description" /></xsl:attribute>
             <xsl:choose>
-              <xsl:when test="@alternativeMaximixedLink and string-length(@alternativeMaximixedLink) > 0">
-                <xsl:attribute name="href"><xsl:value-of select="@alternativeMaximixedLink" /></xsl:attribute>
+              <xsl:when test="@alternativeMaximizedLink and string-length(@alternativeMaximizedLink) > 0">
+                <xsl:attribute name="href"><xsl:value-of select="@alternativeMaximizedLink" /></xsl:attribute>
                 <xsl:attribute name="target">_blank</xsl:attribute>
                 <xsl:attribute name="class">portal-subnav-link externalLink</xsl:attribute>
               </xsl:when>

--- a/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
+++ b/uportal-war/src/main/resources/org/jasig/portal/portlets/SharedParameters.cpd.xml
@@ -45,7 +45,7 @@
         </parameter>
 
         <parameter>
-            <name>alternativeMaximixedLink</name>
+            <name>alternativeMaximizedLink</name>
             <label>open.alternative.url.in.maximized.view</label>
             <description>Alternate URL to display when the portlet is in MAXIMIZED mode.</description>
             <single-text-parameter-input display="text"/>


### PR DESCRIPTION
Change alternativeMaximixedLink to be alternativeMaximizedLink.

This if for 4.3 branch.
