### PR TITLE
UP-4744:  Provide better handling for 'bad data' in category memberships

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/portlet/dao/jpa/JpaPortletDefinitionDao.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlet/dao/jpa/JpaPortletDefinitionDao.java
@@ -160,12 +160,18 @@ public class JpaPortletDefinitionDao extends BasePortalJpaDao implements IPortle
     @PortalTransactionalReadOnly
     @OpenEntityManager(unitName = PERSISTENCE_UNIT_NAME)
     public IPortletDefinition getPortletDefinition(String portletDefinitionIdString) {
+
         Validate.notNull(portletDefinitionIdString, "portletDefinitionIdString can not be null");
-        
-        final long internalPortletDefinitionId = getNativePortletDefinitionId(portletDefinitionIdString);
-        final PortletDefinitionImpl portletDefinition = this.getEntityManager().find(PortletDefinitionImpl.class, internalPortletDefinitionId);
-        
-        return portletDefinition;
+
+        PortletDefinitionImpl rslt = null;  // default
+
+        final Long internalPortletDefinitionId = getNativePortletDefinitionId(portletDefinitionIdString);
+        if (internalPortletDefinitionId != null) {
+            rslt = this.getEntityManager().find(PortletDefinitionImpl.class, internalPortletDefinitionId);
+        }
+
+        return rslt;
+
     }
 
 	@Override
@@ -268,7 +274,15 @@ public class JpaPortletDefinitionDao extends BasePortalJpaDao implements IPortle
     protected long getNativePortletDefinitionId(IPortletDefinitionId portletDefinitionId) {
         return Long.parseLong(portletDefinitionId.getStringId());
     }
-    protected long getNativePortletDefinitionId(String portletDefinitionId) {
-        return Long.parseLong(portletDefinitionId);
+
+    protected Long getNativePortletDefinitionId(String portletDefinitionId) {
+        Long rslt = null;  // default
+        try {
+            rslt = Long.parseLong(portletDefinitionId);
+        } catch (NumberFormatException nfe) {
+            logger.warn("The portletDefinitionId '{}' is not parsable to a valid portletId (long);  null will be returned", portletDefinitionId);
+        }
+        return rslt;
     }
+
 }


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4744

With this change, instead of an unusable portal you get...

```
WARN  [http-nio-8080-exec-1-admin] o.a.p.p.d.j.JpaPortletDefinitionDao 2016-10-13 15:37:57,655 - The portletDefinitionId 'admin' is not parsable to a valid portletId (long);  null will be returned
WARN  [http-nio-8080-exec-1-admin] o.a.p.p.r.PortletCategoryRegistryImpl 2016-10-13 15:37:57,675 - Failed to obtain a portletDefinition for groupMember 'EntityIdentifier[type=interface org.apereo.portal.portlet.om.IPortletDefinition,key=admin]';  this circumstance probably means a portlet was deleted in a way that didn't clean up details like categpry memberships and permissions;  all interfaces that delete portlets should go through IPortletPublishingService.removePortletDefinition();  memberships for this missing portlet will be removed.
```

In the logs once.