### PR TITLE
UP-4752: Darken muted blue to meet contrast requirements for WCAG AA - master

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
@@ -80,7 +80,7 @@
  * 2) The value must be on the same line as the variable name and be terminated with a semicolon due to
  *    regex searches by skin manager.
  */
-@color3: #428BCA;  // light muted blue
+@color3: #317ab9;  // light muted blue
 @color3-light: lighten(@color3, 15%);
 
 /*


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4752

Updated Look (links have inherited the darker colors):

![screencapture-localhost-8080-uportal-f-welcome-normal-render-up-1476474515719](https://cloud.githubusercontent.com/assets/3107513/19400853/035cf762-920d-11e6-84de-a4995d4a85e6.png)