### PR TITLE
UP-4613 (updated for uPortal5): Fixed issue where exiting Fragment Admin logs out user when …

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/security/IdentitySwapperManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/IdentitySwapperManager.java
@@ -22,6 +22,8 @@ import javax.portlet.PortletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.springframework.security.core.Authentication;
+
 /**
  * Manages workflow around use of the identity swapper features.
  * 
@@ -62,20 +64,36 @@ public interface IdentitySwapperManager {
      * @param profile The profile of which you want to login under
      */
     void impersonateUser(PortletRequest portletRequest, String currentUserName, String targetUsername, String profile);
-    
+
     /**
-     * During impersonation of targetUsername sets the original user to currentUserName for later
-     * retrieval by {@link #getOriginalUsername(HttpSession)}
+     * During impersonation of targetUsername sets the original user to currentUserName for later retrieval by 
+     * {@link #getOriginalUsername(HttpSession)}.  If the original authentication will also be needed for later 
+     * retrieval, use {@link #setOriginalUser(HttpSession, String, String, Authentication)} instead.
      * 
      * @throws RuntimeAuthorizationException if the current user cannot impersonate the target user
      */
     void setOriginalUser(HttpSession session, String currentUserName, String targetUsername);
-    
+
+    /**
+     * During impersonation of targetUsername sets the original user to currentUserName for later retrieval by 
+     * {@link #getOriginalUsername(HttpSession)} and the set the original authentication for later retrieval by 
+     * {@link #getOriginalAuthentication(HttpSession).
+     * 
+     * @throws RuntimeAuthorizationException if the current user cannot impersonate the target user
+     */
+    void setOriginalUser(
+            HttpSession session, String currentUserName, String targetUsername, Authentication originalAuth);
+
     /**
      * @return The original user if the current user is an impersonation, null if no impersonation is happening
      */
     String getOriginalUsername(HttpSession session);
-    
+
+    /**
+     * @return the authentication for the original user
+     */
+    Authentication getOriginalAuthentication(HttpSession session);
+
     /**
      * @return The target of impersonation, null if there is no impersonation target
      */

--- a/uportal-war/src/main/java/org/apereo/portal/security/IdentitySwapperManagerImpl.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/IdentitySwapperManagerImpl.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apereo.portal.EntityIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service("identitySwapperManager")
@@ -34,7 +35,7 @@ public class IdentitySwapperManagerImpl implements IdentitySwapperManager {
     private static final String SWAP_TARGET_UID = IdentitySwapperManagerImpl.class.getName() + ".SWAP_TARGET_UID";
     private static final String SWAP_TARGET_PROFILE = IdentitySwapperManagerImpl.class.getName() + ".SWAP_TARGET_PROFILE";
     private static final String SWAP_ORIGINAL_UID = IdentitySwapperManagerImpl.class.getName() + ".SWAP_ORIGINAL_UID";
-    
+    private static final String SWAP_ORIGINAL_AUTH = IdentitySwapperManagerImpl.class.getName() + ".SWAP_ORIGINAL_AUTH";
 
     private IAuthorizationService authorizationService;
     
@@ -84,18 +85,29 @@ public class IdentitySwapperManagerImpl implements IdentitySwapperManager {
 
     @Override
     public void setOriginalUser(HttpSession session, String currentUserName, String targetUsername) {
+        this.setOriginalUser(session, currentUserName, targetUsername, null);
+    }
+
+    @Override
+    public void setOriginalUser(
+            HttpSession session, String currentUserName, String targetUsername, Authentication originalAuth) {
         if (!canImpersonateUser(currentUserName, targetUsername)) {
             throw new RuntimeAuthorizationException(currentUserName, IPermission.IMPERSONATE_USER_ACTIVITY, targetUsername);
         }
-        
         session.setAttribute(SWAP_ORIGINAL_UID, currentUserName);
+        session.setAttribute(SWAP_ORIGINAL_AUTH, originalAuth);
     }
-    
+
     @Override
     public String getOriginalUsername(HttpSession session) {
         return (String) session.getAttribute(SWAP_ORIGINAL_UID);
     }
-    
+
+    @Override
+    public Authentication getOriginalAuthentication(HttpSession session) {
+        return (Authentication) session.getAttribute(SWAP_ORIGINAL_AUTH);
+    }
+
     @Override
     public String getTargetUsername(HttpSession session) {
         return (String) session.getAttribute(SWAP_TARGET_UID);

--- a/uportal-war/src/main/resources/properties/contexts/securityContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/securityContext.xml
@@ -40,6 +40,7 @@
     <bean id="portalPreAuthenticationFilter"
         class="org.apereo.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter">
         <property name="authenticationManager" ref="authenticationManager" />
+        <property name="clearSecurityContextPriorToPortalAuthentication" value="false" />
     </bean>
   
     <bean id="preAuthProvider"

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.jasig.portal.layout.profile.ProfileSelectionEvent;
+import org.junit.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class PortalPreAuthenticatedProcessingFilterIdentitySwapTest
+        extends PortalPreAuthenticatedProcessingFilterTestBase {
+
+    private String targetProfileKey;
+    private String targetUsername;
+
+    public void additionalSetup() {
+        this.targetProfileKey = "targetProfileKey";
+        this.targetUsername = "targetUsername";
+        SecurityContextHolder.createEmptyContext();
+        SecurityContextHolder.getContext().setAuthentication(this.auth);
+    }
+
+    @Test
+    public void testThatOriginalUserIsSetWhenSecurityContextIsStillAvailable() throws Exception {
+        // given
+        this.filter.setClearSecurityContextPriorToPortalAuthentication(false);
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.identitySwapperManager).setOriginalUser(this.session, this.username, this.targetUsername, this.auth);
+    }
+
+    @Test
+    public void testThatOriginalUserIsSetWhenSecurityContextIsNoLongerAvailable() throws Exception {
+        // given
+        this.filter.setClearSecurityContextPriorToPortalAuthentication(true);
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.identitySwapperManager).setOriginalUser(this.session, this.username, this.targetUsername, this.auth);
+    }
+
+    @Test
+    public void testThatTargetUsernameIsSetAsPersonName() throws Exception {
+        // given
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.person).setUserName(this.targetUsername);
+    }
+
+    /**
+     * Test that when swapping to another identity while specifying a target profile, fires event for that profile.
+     */
+    @Test
+    public void testThatProfileSelectedEventIsSent() throws IOException, ServletException {
+        // given
+        this.requestIsForIdentitySwapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        final ProfileSelectionEvent expectedEvent =
+                new ProfileSelectionEvent(this.filter, this.targetProfileKey, this.person, this.request);
+        verify(this.eventPublisher).publishEvent(expectedEvent);
+    }
+
+    private void requestIsForIdentitySwapLogin() {
+        when(this.identitySwapperManager.getTargetProfile(this.session)).thenReturn(this.targetProfileKey);
+        when(this.identitySwapperManager.getOriginalUsername(this.session)).thenReturn(null);
+        when(this.identitySwapperManager.getTargetUsername(this.session)).thenReturn(this.targetUsername);
+        when(this.request.getServletPath()).thenReturn("/Login");
+    }
+
+    private void requestedSessionIdIsValid() {
+        when(this.request.isRequestedSessionIdValid()).thenReturn(true);
+    }
+
+}

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentitySwapTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jasig.portal.spring.security.preauth;
+package org.apereo.portal.spring.security.preauth;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
-import org.jasig.portal.layout.profile.ProfileSelectionEvent;
+import org.apereo.portal.layout.profile.ProfileSelectionEvent;
 import org.junit.Test;
 import org.springframework.security.core.context.SecurityContextHolder;
 

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class PortalPreAuthenticatedProcessingFilterIdentityUnswapTest
+        extends PortalPreAuthenticatedProcessingFilterTestBase {
+
+    private String originalUsername;
+    private String targetUsername;
+    @Mock Authentication originalAuthentication;
+
+    public void additionalSetup() {
+        this.originalUsername = "originalUsername";
+        this.targetUsername = "targetUsername";
+        SecurityContextHolder.createEmptyContext();
+        SecurityContextHolder.getContext().setAuthentication(this.auth);
+        given(this.identitySwapperManager.getOriginalAuthentication(this.session)).willReturn(this.originalAuthentication);
+    }
+
+    @Test
+    public void testThatOriginalUsernameIsSetAsPersonUserName() throws Exception {
+        // given
+        this.requestIsForIdentityUnswapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        verify(this.person).setUserName(this.originalUsername);
+    }
+
+    @Test
+    public void testThatOriginalAuthenticationIsSetInSecurityContext() throws IOException, ServletException {
+        // given
+        this.requestIsForIdentityUnswapLogin();
+        this.requestedSessionIdIsValid();
+        // when
+        this.filter.doFilter(this.request, this.response, this.filterChain);
+        // then
+        final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertEquals(this.originalAuthentication, auth);
+    }
+
+    private void requestIsForIdentityUnswapLogin() {
+        when(this.identitySwapperManager.getTargetProfile(this.session)).thenReturn(null);
+        when(this.identitySwapperManager.getOriginalUsername(this.session)).thenReturn(this.originalUsername);
+        when(this.identitySwapperManager.getTargetUsername(this.session)).thenReturn(this.targetUsername);
+        when(this.request.getServletPath()).thenReturn("/Login");
+    }
+
+    private void requestedSessionIdIsValid() {
+        when(this.request.isRequestedSessionIdValid()).thenReturn(true);
+    }
+
+}

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterIdentityUnswapTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jasig.portal.spring.security.preauth;
+package org.apereo.portal.spring.security.preauth;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTest.java
@@ -19,76 +19,48 @@
 package org.apereo.portal.spring.security.preauth;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
-import org.hibernate.PropertyAccessException;
 import org.apereo.portal.layout.profile.ProfileSelectionEvent;
-import org.apereo.portal.security.IPerson;
-import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.ISecurityContext;
-import org.apereo.portal.security.IdentitySwapperManager;
 import org.apereo.portal.security.mvc.LoginController;
 import org.apereo.portal.spring.security.PortalPersonUserDetails;
-import org.junit.Before;
+import org.hibernate.PropertyAccessException;
 import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-public class PortalPreAuthenticatedProcessingFilterTest {
-    @InjectMocks PortalPreAuthenticatedProcessingFilter filter;
+public class PortalPreAuthenticatedProcessingFilterTest extends PortalPreAuthenticatedProcessingFilterTestBase {
 
-    @Mock FilterChain filterChain;
-    @Mock HttpServletRequest request;
-    @Mock HttpServletResponse response;
-    @Mock HttpSession session;
-    @Mock IPersonManager personManager;
-    @Mock IPerson person;
-    @Mock ISecurityContext context;
-    @Mock Authentication auth;
-    @Mock SecurityContext initialContext;
-    @Mock AuthenticationManager authenticationManager;
-    @Mock ApplicationEventPublisher eventPublisher;
-    @Mock IdentitySwapperManager identitySwapperManager;
-    
-    @Before
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-        filter.setAuthenticationService(new org.apereo.portal.services.Authentication());
-        filter.setApplicationEventPublisher(eventPublisher);
-        filter.setIdentitySwapperManager(identitySwapperManager);
-        filter.afterPropertiesSet();
-       
-        when(request.getSession(false)).thenReturn(session);
-        when(request.getSession(true)).thenReturn(session);
-        when(personManager.getPerson(request)).thenReturn(person);
-        when(person.getName()).thenReturn("testuser");
-        when(person.isGuest()).thenReturn(false);
-        when(person.getSecurityContext()).thenReturn(context);
+    public void additionalSetup() {
     }
-    
+
     @Test
-    public void testLogin() throws IOException, ServletException {
+    public void testLoginWithClearingOfContext() throws IOException, ServletException {
         SecurityContextHolder.createEmptyContext();
         SecurityContextHolder.getContext().setAuthentication(auth);
         when(request.getServletPath()).thenReturn("/Login");
+        filter.setClearSecurityContextPriorToPortalAuthentication(true);
         filter.doFilter(request, response, filterChain);
-        
         assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testLoginWithNoClearingOfContext() throws IOException, ServletException {
+        SecurityContextHolder.createEmptyContext();
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        when(request.getServletPath()).thenReturn("/Login");
+        filter.setClearSecurityContextPriorToPortalAuthentication(false);
+        filter.doFilter(request, response, filterChain);
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(auth, SecurityContextHolder.getContext().getAuthentication());
     }
 
     @Test
@@ -111,7 +83,7 @@ public class PortalPreAuthenticatedProcessingFilterTest {
     public void testAuth() throws IOException, ServletException {
         PortalPersonUserDetails details = (PortalPersonUserDetails) filter.getPreAuthenticatedPrincipal(request);
         
-        assertEquals("testuser", details.getUsername());
+        assertEquals(this.username, details.getUsername());
     }
 
     @Test

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.spring.security.preauth;
+
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.jasig.portal.security.IPerson;
+import org.jasig.portal.security.IPersonManager;
+import org.jasig.portal.security.ISecurityContext;
+import org.jasig.portal.security.IdentitySwapperManager;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+
+public abstract class PortalPreAuthenticatedProcessingFilterTestBase {
+
+    @InjectMocks PortalPreAuthenticatedProcessingFilter filter;
+
+    @Mock FilterChain filterChain;
+    @Mock HttpServletRequest request;
+    @Mock HttpServletResponse response;
+    @Mock HttpSession session;
+    @Mock IPersonManager personManager;
+    @Mock IPerson person;
+    @Mock ISecurityContext context;
+    @Mock Authentication auth;
+    @Mock SecurityContext initialContext;
+    @Mock AuthenticationManager authenticationManager;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock IdentitySwapperManager identitySwapperManager;
+
+    String username;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        this.username = "testuser";
+        filter.setAuthenticationService(new org.jasig.portal.services.Authentication());
+        filter.setApplicationEventPublisher(eventPublisher);
+        filter.setIdentitySwapperManager(identitySwapperManager);
+        filter.afterPropertiesSet();
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getSession(true)).thenReturn(session);
+        when(personManager.getPerson(request)).thenReturn(person);
+        when(person.getName()).thenReturn(this.username);
+        when(person.isGuest()).thenReturn(false);
+        when(person.getSecurityContext()).thenReturn(context);
+
+        this.additionalSetup();
+    }
+
+    public abstract void additionalSetup();
+
+}

--- a/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
+++ b/uportal-war/src/test/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilterTestBase.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jasig.portal.spring.security.preauth;
+package org.apereo.portal.spring.security.preauth;
 
 import static org.mockito.Mockito.when;
 
@@ -25,10 +25,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.jasig.portal.security.IPerson;
-import org.jasig.portal.security.IPersonManager;
-import org.jasig.portal.security.ISecurityContext;
-import org.jasig.portal.security.IdentitySwapperManager;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.IPersonManager;
+import org.apereo.portal.security.ISecurityContext;
+import org.apereo.portal.security.IdentitySwapperManager;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -40,7 +40,8 @@ import org.springframework.security.core.context.SecurityContext;
 
 public abstract class PortalPreAuthenticatedProcessingFilterTestBase {
 
-    @InjectMocks PortalPreAuthenticatedProcessingFilter filter;
+    @InjectMocks
+    org.apereo.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter filter;
 
     @Mock FilterChain filterChain;
     @Mock HttpServletRequest request;
@@ -61,7 +62,7 @@ public abstract class PortalPreAuthenticatedProcessingFilterTestBase {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         this.username = "testuser";
-        filter.setAuthenticationService(new org.jasig.portal.services.Authentication());
+        filter.setAuthenticationService(new org.apereo.portal.services.Authentication());
         filter.setApplicationEventPublisher(eventPublisher);
         filter.setIdentitySwapperManager(identitySwapperManager);
         filter.afterPropertiesSet();


### PR DESCRIPTION
…using a two step login process, where the first step sets up the SecurityContext Authentication and the second step is the normal /uPortal/Login process.

There are really three sets of changes here:

refactor identity swap code in "PortalPreAuthenticatedProcessingFilter" to use an inner class ("IdentitySwapHelper"), in order to make the code easier to understand and to clean up the main authentication logic

addition of "clearSecurityContextPriorToPortalAuthentication" flag in order to disable the clearing of the security context prior to authentication

updates so that during an identity swap the current Authentication object gets save and later restored during the unswap

Numbers 2. and 3. are changes that may or may not need to be included, based on whether the problem they solve is thought to be general enough. What they do is enable the use of a two step log in process where the first step establishes the SecurityContext Authentication, and the second step is the normal uPortal login logic. In the scenario for which these were added, we are using Shibboleth. For login, the IDP redirects to uPortal at "/uPortal/saml/SSO" which is maps to "org.springframework.security.saml.SAMLProcessingFilter". On success, the redirect handler redirects to "/uPortal/Login" which uses the updated code in this pull request. Because it is a two step login process, for identity swaps we need to save the Authentication object and restore it during the unswap. The two step login also requires that we do not clear the security context in step 2 since it has been set up in step 1.

(description copied from https://github.com/Jasig/uPortal/pull/714)

https://issues.jasig.org/browse/UP-4613
