### PR TITLE
UP-4758: Label select input in most popular apps portlet - rel-4-3-patches

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/PopularPortlets/listPortlets.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/PopularPortlets/listPortlets.jsp
@@ -87,19 +87,21 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 | and more, refer to:
 | http://www.ja-sig.org/wiki/x/cQ
 -->
-    
+
 <!-- Portlet -->
 <div id="${n}portletBrowser" class="fl-widget portlet" role="section">
 <form id="${n}form">
-  
+
   <!-- Portlet Title -->
   <div class="fl-widget-titlebar portlet-title" role="sectionhead">
     <h2 role="heading"><spring:message code="most.frequently.added"/></h2>
   </div> <!-- end: portlet-title -->
-  
+
   <!-- Portlet Toolbar -->
   <div class="portlet-toolbar" role="toolbar">
-    <spring:message code="previous"/>
+    <label for="${n}days">
+      <spring:message code="previous"/>
+    </label>
     <select id="${n}days" name="days">
       <option value="1">1</option>
       <option value="7">7</option>
@@ -108,12 +110,12 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
       <option value="365">365</option>
     </select>
   </div> <!-- end: portlet-toolbar -->
-        
+
     <!-- Portlet Body -->
   <div class="fl-widget-content portlet-body" role="main">
 
     <!-- Portlet Section -->
-    <div id="${n}popularPortlets" class="portlet-section fl-pager" role="region">      
+    <div id="${n}popularPortlets" class="portlet-section fl-pager" role="region">
 
       <div class="portlet-section-body">
         <table id="${n}portletsTable" style="width:100%;">
@@ -136,7 +138,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
         </div>
       </c:if>
     </div> <!-- end: portlet-section -->
-    
+
   </div> <!-- end: portlet-body -->
 
 </form>
@@ -191,7 +193,7 @@ up.jQuery(function() {
             },
             aoColumns: [
                 { mData: 'portletFName', sType: 'string', sWidth: '50%' },  // Name
-                { mData: 'count', sType: 'string', sWidth: '50%' }  // Times 
+                { mData: 'count', sType: 'string', sWidth: '50%' }  // Times
             ],
             fnInitComplete: function (oSettings) {
                 portletList_configuration.main.table.fnDraw();


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4758
#### issue

This select element does not have a name available to an accessibility API. Valid names are: label element, title attribute.

``` html
<select id="Pluto_23_ctf6_14_days" name="days"> <option value="1">1</opt...</select>

<select disabled="disabled"><option value="">Title</option></select>

<select disabled="disabled"><option value=""># Times</optio...</select>
```
#### resolution

add `<label>` for `<select>`
#### note

two select boxes are generated and under the control of [datatables](https://datatables.net/).
datatable's sDom does not give any straight forward way to add labels for elements.
