### PR TITLE
UP-4759: Ensure ids are unique in fragment audit portlet - master

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/fragment-audit/fragment-audit.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/fragment-audit/fragment-audit.jsp
@@ -21,7 +21,7 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-        
+
 <!-- Portlet -->
 <div class="fl-widget portlet" role="section">
     <!-- Portlet Body -->
@@ -81,6 +81,9 @@
                 var templateDiv = $("#${n}template");
                 $(data.fragments).each(function(index, frag) {
                     var copy = templateDiv.clone();
+                    // create unique id for each copy
+                    copy.attr("id", copy.attr("id") + index);
+
                     copy.find(".name").text(frag.name);
                     copy.find(".owner").text(frag.ownerId);
                     copy.find(".precedence").text(frag.precedence);


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4759

#### Issue

Duplicate id attribute value found on the web page.:

`#Pluto_11_ctf6_14_template`

Code Snippet

``` html
<div id="Pluto_11_ctf6_14_template" class="fl-widget panel panel-default" style="">
```

#### Resolution

Add add index as id suffix