### PR TITLE
UP-4761: Label inputs in password manager portlet - master

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
@@ -32,7 +32,7 @@
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="edit.my.account"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
 
@@ -44,14 +44,14 @@
                     <form:errors path="*" element="div"/>
                 </div> <!-- end: portlet-msg -->
             </spring:hasBindErrors>
-        
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
                     <h3 class="title" role="heading"><spring:message code="my.account.details"/></h3>
                 </div>
                 <div id="${n}userAttributes" class="content">
-                
+
                     <table class="portlet-table table table-hover">
                         <tbody>
 
@@ -59,16 +59,23 @@
                             <c:forEach items="${ editAttributes }" var="attribute">
                                 <tr>
                                     <td class="attribute-name">
-                                        <strong><spring:message code="${ attribute.label }"/></strong>
+                                        <label for="${ n }${ attribute.name }">
+                                            <strong>
+                                                <spring:message code="${ attribute.label }"/>
+                                            </strong>
+                                        </label>
                                     </td>
                                     <td>
-                                          <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
-                                          <editPortlet:preferenceInput input="${ attribute.preferenceInput.value }" 
-                                            path="${ paramPath }" values="${ accountForm.attributes[attribute.name].value }"/>
+                                        <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
+                                        <editPortlet:preferenceInput
+                                            id="${ n }${ attribute.name }"
+                                            input="${ attribute.preferenceInput.value }"
+                                            path="${ paramPath }"
+                                            values="${ accountForm.attributes[attribute.name].value }" />
                                     </td>
                                 </tr>
                             </c:forEach>
-                            
+
                         </tbody>
                     </table>
 
@@ -84,31 +91,51 @@
                     <table class="portlet-table table table-hover">
                         <thead>
                             <tr>
-                                <th><spring:message code="attribute.name"/></th>
-                                <th><spring:message code="attribute.value"/></th>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th>
+                                    <spring:message code="attribute.value"/>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
 
                             <!--  Password and confirm password -->
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="password"/></strong></td>
-                                <td><form:password id="${n}password" path="password"/></td>
+                                <td class="attribute-name">
+                                  <label for="${n}password">
+                                      <strong>
+                                          <spring:message code="password"/>
+                                      </strong>
+                                  </label>
+                                </td>
+                                <td>
+                                    <form:password autocomplete="new-password" id="${n}password" path="password"/>
+                                </td>
                             </tr>
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="confirm.password"/></strong></td>
-                                <td><form:password id="${n}confirmPassword" path="confirmPassword"/></td>
+                                <td class="attribute-name">
+                                    <label for="${n}confirmPassword">
+                                        <strong>
+                                            <spring:message code="confirm.password"/>
+                                        </strong>
+                                    </label>
+                                </td>
+                                <td>
+                                    <form:password autcomplete="new-password" id="${n}confirmPassword" path="confirmPassword"/>
+                                </td>
                             </tr>
 
                         </tbody>
                     </table>
                 </div>
-            </div>    
-            
+            </div>
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-            
+
                     <div class="buttons">
                         <input class="button btn primary" type="submit" value="<spring:message code="save"/>" name="_eventId_save"/>
                         <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
@@ -117,7 +144,7 @@
             </div>
 
         </form:form>
-        
+
     </div>
 
     <div id="${n}parameterForm" style="display:none">
@@ -125,8 +152,8 @@
             <spring:message code="attribute.name"/>: <input name="name"/>
             <input type="submit" value="<spring:message code="add"/>"/>
         </form>
-    </div>    
-    
+    </div>
+
 </div>
 
 <script type="text/javascript">
@@ -134,7 +161,7 @@
         var $ = up.jQuery;
         $(document).ready(function(){
             up.ParameterEditor(
-                $("#${n}userAttributes"), 
+                $("#${n}userAttributes"),
                 {
                     parameterBindName: 'attributes',
                     multivalued: true,

--- a/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
+++ b/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
@@ -25,6 +25,7 @@
 <%@ attribute name="path"    required="true" %>
 <%@ attribute name="name"    required="false" %>
 <%@ attribute name="values"  required="false" type="java.util.Collection" %>
+<%@ attribute name="id"    required="false" %>
 
 <c:choose>
 
@@ -51,10 +52,10 @@
       <!-- Textarea -->
         <c:choose>
             <c:when test="${ values != null }">
-                <textarea class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
+                <textarea id="${ id }" class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
             </c:when>
             <c:otherwise>
-                <form:textarea path="${path}"/>
+                <form:textarea id="${ id }" path="${path}"/>
             </c:otherwise>
         </c:choose>
       </c:when>
@@ -62,16 +63,16 @@
       <!-- Text input -->
         <c:choose>
             <c:when test="${ values != null }">
-                <input name="${fn:escapeXml(path)}" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
+                <input name="${fn:escapeXml(path)}" id="${ id }" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
             </c:when>
             <c:otherwise>
-                <form:input path="${path}"/>
+                <form:input id="${ id }" path="${ path }"/>
             </c:otherwise>
         </c:choose>
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.apereo.portal.portletpublishing.xml.SingleChoicePreferenceInput') }">
   <!-- Single-value choice input types -->
     <c:choose>
@@ -90,7 +91,7 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.apereo.portal.portletpublishing.xml.MultiChoicePreferenceInput') }">
   <!-- Multi-value choice input types -->
     <c:choose>
@@ -109,5 +110,5 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
 </c:choose>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4761

#### Issue

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.


When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.


This text input element does not have a name available to an accessibility API. Valid names are: label element, title attribute.


Code Snippet

``` html
<input name="attributes['title'].value" value="Portal Administrator" class="form-control">
```

... all instances of text inputs.

#### Resolution

Update `preferenceInput.tag` to support ids and add `<label>`s.