### PR TITLE
UP-4762: Label search box on "Portlet Administration" portlet - rel-4-3-patches

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/portlet-manager/listChannels.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/portlet-manager/listChannels.jsp
@@ -129,8 +129,10 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
       </div>
       <div class="fl-col fl-text-align-right datatable-search-view">
         <form class="portlet-search-form form-inline" style="display:inline">
-          <label><spring:message code="search"/></label>
-          <input type="text" class="portlet-search-input form-control"/>
+          <label for="${n}search">
+            <spring:message code="search"/>
+          </label>
+          <input id="${n}search" type="search" class="portlet-search-input form-control"/>
         </form>
       </div>
     </div>
@@ -187,7 +189,7 @@ up.jQuery(function() {
         return '<a href="' + url + '"><spring:message code="delete" htmlEscape="false" javaScriptEscape="true"/> <span class="pull-right"><i class="fa fa-trash-o"></i></span></a>';
     };
 
-    // Created as its own 
+    // Created as its own
     var initializeTable = function() {
         portletList_configuration.main.table = $("#${n}portletsList").dataTable({
             iDisplayLength: portletList_configuration.main.pageSize,
@@ -197,7 +199,7 @@ up.jQuery(function() {
             sAjaxDataProp: "portlets",
             bDeferRender: false,
             bProcessing: true,
-            bAutoWidth:false,
+            bAutoWidth: false,
             sPaginationType: 'full_numbers',
             oLanguage: {
                 sLengthMenu: '<spring:message code="datatables.length-menu.message" htmlEscape="false" javaScriptEscape="true"/>',
@@ -208,7 +210,7 @@ up.jQuery(function() {
             },
             aoColumns: [
                 { mData: 'name', sType: 'html', sWidth: '30%' },  // Name
-                { mData: 'type', sType: 'html', sWidth: '30%' },  // Type 
+                { mData: 'type', sType: 'html', sWidth: '30%' },  // Type
                 { mData: 'lifecycleState', sType: 'html', sWidth: '20%' },  // Lifecycle State
                 { mData: 'id', sType: 'html', bSearchable: false, sWidth: '10%' },  // Edit Link
                 { mData: 'id', sType: 'html', bSearchable: false, sWidth: '10%' },  // Delete Link
@@ -227,7 +229,7 @@ up.jQuery(function() {
                     bSearchable: true,
                     bVisible: false,
                     asSorting: [ "desc", "asc" ]
-                }  // Categories - hidden 
+                }  // Categories - hidden
             ],
             fnInitComplete: function (oSettings) {
                 //portletList_configuration.main.table.fnDraw();


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4762

#### Issue

When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.

Code Snippet:
``` html
<input type="text" class="portlet-search-input form-control">
```

#### Resolution

Add `id`, link label to input with `id`.
Also updated input type to `search`.