### PR TITLE
Upgrade to Web Proxy Portlet v2.2.2 from v2.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <sakai-connector-portlet.version>1.5.2</sakai-connector-portlet.version>
         <SimpleContentPortlet.version>2.0.2</SimpleContentPortlet.version>
         <WeatherPortlet.version>1.1.5</WeatherPortlet.version>
-        <WebProxyPortlet.version>2.1.1</WebProxyPortlet.version>
+        <WebProxyPortlet.version>2.2.2</WebProxyPortlet.version>
 
         <!-- Project Dependency Version Properties -->
         <aopalliance.version>1.0</aopalliance.version>


### PR DESCRIPTION
Upgrades:

Excludes bugged Commons Collections dependency. Also,

[2.1.2](https://github.com/Jasig/WebproxyPortlet/releases/tag/WebProxyPortlet-2.1.2):
* portlet-preference-driven `BASIC` authentication
* Fix double-encoding of `link` elements

[2.2.0](https://github.com/Jasig/WebproxyPortlet/releases/tag/WebProxyPortlet-2.2.0):
* adds `PreInterceptor` for conveying user attributes as headers on the proxy request.

2.2.1: no-op.

[2.2.2](https://github.com/Jasig/WebproxyPortlet/releases/tag/WebProxyPortlet-2.2.2): 
* Removes overzealous naive caching