### PR TITLE
UP-4765: register portlet flow labels - master

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
@@ -213,8 +213,13 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                             <label for="portletTimeout">
                                                 <spring:message code="portlet.timeout"/>
                                             </label>
-                                            <span class="glyphicon glyphicon-info-sign" title="<spring:message code='portlet.timeout.tooltip'/>"
-                                                  data-toggle="tooltip" data-placement="top"></span>
+                                            <span
+                                                aria-label="<spring:message code='portlet.timeout.tooltip'/>"
+                                                class="glyphicon glyphicon-info-sign"
+                                                data-placement="top"
+                                                data-toggle="tooltip"
+                                                title="<spring:message code='portlet.timeout.tooltip'/>">
+                                            </span>
                                         </span>
                                         <div class="col-sm-4">
                                             <form:input path="timeout" type="text" class="form-control" id="portletTimeout"/>

--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
@@ -210,7 +210,9 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                 <div class="portlet-section" role="region">
                                     <div class="form-group">
                                         <span class="col-sm-2 control-label">
-                                            <label for="portletTimeout"><spring:message code="portlet.timeout"/></label>
+                                            <label for="portletTimeout">
+                                                <spring:message code="portlet.timeout"/>
+                                            </label>
                                             <span class="glyphicon glyphicon-info-sign" title="<spring:message code='portlet.timeout.tooltip'/>"
                                                   data-toggle="tooltip" data-placement="top"></span>
                                         </span>
@@ -243,15 +245,15 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                     <tr class="${ up:containsKey(portlet.portletPreferences, pref.name) ? 'override-preference' : '' }">
                                                         <td class="preference-name">
                                                             <div class="control-label">
-                                                                ${ fn:escapeXml(pref.name )}
+                                                                ${ fn:escapeXml(pref.name) }
                                                             </div>
                                                         </td>
                                                         <td>
                                                             <c:forEach var="value" items="${ pref.values }">
-                                                                <div>${ fn:escapeXml(value )}</div>
+                                                                <div>${ fn:escapeXml(value) }</div>
                                                             </c:forEach>
                                                         </td>
-                                                        <td>${ fn:escapeXml(pref.readOnly )}</td>
+                                                        <td>${ fn:escapeXml(pref.readOnly) }</td>
                                                     </tr>
                                                 </c:forEach>
                                             </tbody>
@@ -282,7 +284,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <c:forEach items="${ step.parameters }" var="parameter">
+                                                        <c:forEach items="${ step.parameters }" var="parameter" varStatus="status">
                                                             <c:set var="paramPath" value="parameters['${ parameter.name }'].value"/>
                                                             <c:choose>
                                                                 <c:when test="${ parameter.parameterInput.value.display == 'HIDDEN' }">
@@ -292,7 +294,9 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                                     <tr>
                                                                         <td class="text-right">
                                                                             <div class="control-label">
-                                                                                <spring:message code="${parameter.label}"/>
+                                                                                <label for="step-parameter-${ status.index }">
+                                                                                    <spring:message code="${parameter.label}"/>
+                                                                                </label>
                                                                                 <c:if test="${not empty parameter.description}">
                                                                                     <span class="glyphicon glyphicon-info-sign"
                                                                                           title="${fn:escapeXml(parameter.description)}"
@@ -302,7 +306,9 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                                                 </c:if>
                                                                             </div>
                                                                         </td>
-                                                                        <td><editPortlet:parameterInput input="${ parameter.parameterInput.value }" path="${ paramPath }" cssClass="form-control"/></td>
+                                                                        <td>
+                                                                            <editPortlet:parameterInput id="step-parameter-${ status.index }" input="${ parameter.parameterInput.value }" path="${ paramPath }" cssClass="form-control"/>
+                                                                        </td>
                                                                     </tr>
                                                                 </c:otherwise>
                                                             </c:choose>
@@ -324,7 +330,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                             </tr>
                                                         </thead>
                                                         <tbody>
-                                                            <c:forEach items="${ step.preferences }" var="preference">
+                                                            <c:forEach items="${ step.preferences }" var="preference" varStatus="status">
                                                                 <c:set var="paramPath" value="portletPreferences['${ preference.name }'].value"/>
                                                                 <c:set var="overrideParamPath" value="portletPreferenceReadOnly['${ preference.name }'].value"/>
                                                                 <c:choose>
@@ -332,28 +338,30 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                                         <c:set var="values" value="${ portlet.portletPreferences[preference.name].value }"/>
                                                                         <input type="hidden" name="${ fn:escapeXml(paramPath )}"  value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}"/>
                                                                     </c:when>
-                                                                <c:otherwise>
-                                                                    <tr>
-                                                                        <td class="preference-name">
-                                                                            <div class="control-label">
-                                                                                <spring:message code="${ preference.label }" text="${ preference.label }"/>
-                                                                                <c:if test="${not empty preference.description}">
-                                                                                    <span class="glyphicon glyphicon-info-sign"
-                                                                                          title="${fn:escapeXml(preference.description)}"
-                                                                                          data-toggle="tooltip"
-                                                                                          data-placement="top">
-                                                                                    </span>
-                                                                                </c:if>
-                                                                            </div>
-                                                                        </td>
-                                                                        <td>
-                                                                            <editPortlet:preferenceInput input="${ preference.preferenceInput.value }" path="${ paramPath }" name="${ preference.name }" values="${ portlet.portletPreferences[preference.name].value }"/>
-                                                                        </td>
-                                                                        <td>
-                                                                            <form:checkbox path="${overrideParamPath}" value="true"/>
-                                                                        </td>
-                                                                    </tr>
-                                                                </c:otherwise>
+                                                                    <c:otherwise>
+                                                                        <tr>
+                                                                            <td class="preference-name">
+                                                                                <div class="control-label">
+                                                                                    <label for="preference-input-${ status.index }">
+                                                                                        <spring:message code="${ preference.label }" text="${ preference.label }"/>
+                                                                                    </label>
+                                                                                    <c:if test="${not empty preference.description}">
+                                                                                        <span class="glyphicon glyphicon-info-sign"
+                                                                                              title="${fn:escapeXml(preference.description)}"
+                                                                                              data-toggle="tooltip"
+                                                                                              data-placement="top">
+                                                                                        </span>
+                                                                                    </c:if>
+                                                                                </div>
+                                                                            </td>
+                                                                            <td>
+                                                                                <editPortlet:preferenceInput id="preference-input-${ status.index }" input="${ preference.preferenceInput.value }" path="${ paramPath }" name="${ preference.name }" values="${ portlet.portletPreferences[preference.name].value }"/>
+                                                                            </td>
+                                                                            <td>
+                                                                                <form:checkbox path="${overrideParamPath}" value="true"/>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </c:otherwise>
                                                                 </c:choose>
                                                             </c:forEach>
                                                         </tbody>
@@ -404,7 +412,11 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                                             </c:forEach>
                                                         </tbody>
                                                     </table>
-                                                    <p><a class="add-parameter-link btn btn-primary" href="javascript:;"><spring:message code="add.preference"/>&nbsp;&nbsp;<i class="fa fa-plus-circle"></i></a></p>
+                                                    <p>
+                                                        <a class="add-parameter-link btn btn-primary" href="javascript:;">
+                                                            <spring:message code="add.preference"/>&nbsp;&nbsp;<i class="fa fa-plus-circle"></i>
+                                                        </a>
+                                                    </p>
                                                 </div>
                                             </c:if>
                                         </c:if> <!-- end: (portlet step test) -->
@@ -507,7 +519,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                                 <ul class="config-list">
                                     <c:forEach items="${ portlet.categories }" var="category">
                                         <li>
-                                            <i class="fa fa-folder-open"></i> ${fn:escapeXml(category.name )}
+                                            <i class="fa fa-folder-open"></i> ${ fn:escapeXml(category.name) }
                                         </li>
                                     </c:forEach>
                                 </ul>
@@ -526,16 +538,24 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
-                    <h3 class="title" role="heading"><spring:message code="lifecycle.management"/></h3>
+                    <h3 class="title" role="heading">
+                        <spring:message code="lifecycle.management"/>
+                    </h3>
                 </div>
                 <div class="content">
                     <div class="preference-options-section">
                         <table class="portlet-table table table-hover" summary="">
                             <thead>
                                 <tr>
-                                    <th><spring:message code="option"/></th>
-                                    <th><spring:message code="state"/></th>
-                                    <th><spring:message code="description"/></th>
+                                    <th>
+                                        <spring:message code="option"/>
+                                    </th>
+                                    <th>
+                                        <spring:message code="state"/>
+                                    </th>
+                                    <th>
+                                        <spring:message code="description"/>
+                                    </th>
                                 </tr>
                             </thead>
                             <tfoot></tfoot>
@@ -543,11 +563,20 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                             <c:forEach items="${ lifecycleStates }" var="lifecycleState">
                                 <tr>
                                     <td align="center">
-                                        <form:radiobutton path="lifecycleState" value="${ lifecycleState }"
-                                                          cssClass="portlet-form-input-field lifecycle-state"/>
+                                        <form:radiobutton
+                                            id="lifecycle-${lifecycleState}"
+                                            path="lifecycleState"
+                                            value="${ lifecycleState }"
+                                            cssClass="portlet-form-input-field lifecycle-state"/>
                                     </td>
-                                    <td><spring:message code="lifecycle.name.${ lifecycleState }"/></td>
-                                    <td><spring:message code="lifecycle.description.${ lifecycleState }"/></td>
+                                    <td>
+                                        <label for="lifecycle-${lifecycleState}">
+                                            <spring:message code="lifecycle.name.${ lifecycleState }"/>
+                                        </label>
+                                    </td>
+                                    <td>
+                                        <spring:message code="lifecycle.description.${ lifecycleState }"/>
+                                    </td>
                                 </tr>
                             </c:forEach>
                             </tbody>
@@ -574,26 +603,32 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                         </thead>
                         <tbody>
                         <tr>
-                            <td class="fl-text-align-right"><spring:message code="auto.publish.date.time"/></td>
+                            <td class="fl-text-align-right">
+                                <label for="expirationDate">
+                                    <spring:message code="auto.publish.date.time"/>
+                                </label>
+                            </td>
                             <td>
-                                <form:input path="publishDateString" size="10" cssClass="cal-datepicker"/>
-                                    <span style="${ portlet.publishDate == null ? 'display:none' : '' }">
-                                         <form:select path="publishHour">
-                                             <c:forEach begin="1" end="12" var="hour">
-                                                 <form:option value="${ hour }"/>
-                                             </c:forEach>
-                                         </form:select>:<form:select path="publishMinute">
-                                       <c:forEach begin="0" end="59" var="min">
-                                           <fmt:formatNumber var="m" value="${ min }" minIntegerDigits="2"/>
-                                           <form:option value="${ m }"/>
+                                <form:input id="expirationDate" type="datetime" path="publishDateString" size="10" cssClass="cal-datepicker"/>
+                                <span style="${ portlet.publishDate == null ? 'display:none' : '' }">
+                                    <form:select path="publishHour">
+                                       <c:forEach begin="1" end="12" var="hour">
+                                           <form:option value="${ hour }"/>
                                        </c:forEach>
                                     </form:select>
-                                     <form:select path="publishAmPm">
-                                         <form:option value="0" label="${ amLabel }"/>
-                                         <form:option value="1" label="${ pmLabel }"/>
-                                     </form:select>
-                             (<a class="clear-date" href="javascript:;"><spring:message code="reset"/></a>)
-                         </span>
+                                    :
+                                    <form:select path="publishMinute">
+                                        <c:forEach begin="0" end="59" var="min">
+                                           <fmt:formatNumber var="m" value="${ min }" minIntegerDigits="2"/>
+                                           <form:option value="${ m }"/>
+                                        </c:forEach>
+                                    </form:select>
+                                    <form:select path="publishAmPm">
+                                        <form:option value="0" label="${ amLabel }"/>
+                                        <form:option value="1" label="${ pmLabel }"/>
+                                    </form:select>
+                                    (<a class="clear-date" href="javascript:;"><spring:message code="reset"/></a>)
+                                </span>
                             </td>
                         </tr>
                         </tbody>

--- a/uportal-war/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
@@ -96,7 +96,7 @@
                                 </div>
                                 <div id="${n}portletSearch" class="portlet-search">
                                     <form id="${n}searchForm" class="form-inline" role="form">
-                                        <input type="text" class="form-control" name="searchterm" value="<spring:message code="enter.name"/>"/>
+                                        <input type="search" class="form-control" name="searchterm" value="<spring:message code="enter.name"/>" aria-label="<spring:message code="enter.name"/>"/>
                                         <input type="submit" class="button btn" value="<spring:message code="go"/>" />
                                     </form>
                                     <div id="${n}searchDropDown" class="search-dropdown">

--- a/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
@@ -32,7 +32,7 @@
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="edit.my.account"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
 
@@ -44,14 +44,14 @@
                     <form:errors path="*" element="div"/>
                 </div> <!-- end: portlet-msg -->
             </spring:hasBindErrors>
-        
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
                     <h3 class="title" role="heading"><spring:message code="my.account.details"/></h3>
                 </div>
                 <div id="${n}userAttributes" class="content">
-                
+
                     <table class="portlet-table table table-hover">
                         <tbody>
 
@@ -59,16 +59,23 @@
                             <c:forEach items="${ editAttributes }" var="attribute">
                                 <tr>
                                     <td class="attribute-name">
-                                        <strong><spring:message code="${ attribute.label }"/></strong>
+                                        <label for="${ n }${ attribute.name }">
+                                            <strong>
+                                                <spring:message code="${ attribute.label }"/>
+                                            </strong>
+                                        </label>
                                     </td>
                                     <td>
-                                          <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
-                                          <editPortlet:preferenceInput input="${ attribute.preferenceInput.value }" 
-                                            path="${ paramPath }" values="${ accountForm.attributes[attribute.name].value }"/>
+                                        <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
+                                        <editPortlet:preferenceInput
+                                            id="${ n }${ attribute.name }"
+                                            input="${ attribute.preferenceInput.value }"
+                                            path="${ paramPath }"
+                                            values="${ accountForm.attributes[attribute.name].value }" />
                                     </td>
                                 </tr>
                             </c:forEach>
-                            
+
                         </tbody>
                     </table>
 
@@ -84,31 +91,51 @@
                     <table class="portlet-table table table-hover">
                         <thead>
                             <tr>
-                                <th><spring:message code="attribute.name"/></th>
-                                <th><spring:message code="attribute.value"/></th>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th>
+                                    <spring:message code="attribute.value"/>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
 
                             <!--  Password and confirm password -->
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="password"/></strong></td>
-                                <td><form:password id="${n}password" path="password"/></td>
+                                <td class="attribute-name">
+                                  <label for="${n}password">
+                                      <strong>
+                                          <spring:message code="password"/>
+                                      </strong>
+                                  </label>
+                                </td>
+                                <td>
+                                    <form:password autocomplete="new-password" id="${n}password" path="password"/>
+                                </td>
                             </tr>
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="confirm.password"/></strong></td>
-                                <td><form:password id="${n}confirmPassword" path="confirmPassword"/></td>
+                                <td class="attribute-name">
+                                    <label for="${n}confirmPassword">
+                                        <strong>
+                                            <spring:message code="confirm.password"/>
+                                        </strong>
+                                    </label>
+                                </td>
+                                <td>
+                                    <form:password autcomplete="new-password" id="${n}confirmPassword" path="confirmPassword"/>
+                                </td>
                             </tr>
 
                         </tbody>
                     </table>
                 </div>
-            </div>    
-            
+            </div>
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-            
+
                     <div class="buttons">
                         <input class="button btn primary" type="submit" value="<spring:message code="save"/>" name="_eventId_save"/>
                         <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
@@ -117,7 +144,7 @@
             </div>
 
         </form:form>
-        
+
     </div>
 
     <div id="${n}parameterForm" style="display:none">
@@ -125,8 +152,8 @@
             <spring:message code="attribute.name"/>: <input name="name"/>
             <input type="submit" value="<spring:message code="add"/>"/>
         </form>
-    </div>    
-    
+    </div>
+
 </div>
 
 <script type="text/javascript">
@@ -134,7 +161,7 @@
         var $ = up.jQuery;
         $(document).ready(function(){
             up.ParameterEditor(
-                $("#${n}userAttributes"), 
+                $("#${n}userAttributes"),
                 {
                     parameterBindName: 'attributes',
                     multivalued: true,

--- a/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
+++ b/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
@@ -25,6 +25,7 @@
 <%@ attribute name="path"    required="true" %>
 <%@ attribute name="name"    required="false" %>
 <%@ attribute name="values"  required="false" type="java.util.Collection" %>
+<%@ attribute name="id"    required="false" %>
 
 <c:choose>
 
@@ -51,10 +52,10 @@
       <!-- Textarea -->
         <c:choose>
             <c:when test="${ values != null }">
-                <textarea class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
+                <textarea id="${ id }" class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
             </c:when>
             <c:otherwise>
-                <form:textarea path="${path}"/>
+                <form:textarea id="${ id }" path="${path}"/>
             </c:otherwise>
         </c:choose>
       </c:when>
@@ -62,16 +63,16 @@
       <!-- Text input -->
         <c:choose>
             <c:when test="${ values != null }">
-                <input name="${fn:escapeXml(path)}" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
+                <input name="${fn:escapeXml(path)}" id="${ id }" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
             </c:when>
             <c:otherwise>
-                <form:input path="${path}"/>
+                <form:input id="${ id }" path="${ path }"/>
             </c:otherwise>
         </c:choose>
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.apereo.portal.portletpublishing.xml.SingleChoicePreferenceInput') }">
   <!-- Single-value choice input types -->
     <c:choose>
@@ -90,7 +91,7 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.apereo.portal.portletpublishing.xml.MultiChoicePreferenceInput') }">
   <!-- Multi-value choice input types -->
     <c:choose>
@@ -109,5 +110,5 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
 </c:choose>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4765

#### Issue

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.
When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.
This select element does not have a name available to an accessibility API. Valid names are: label element, title attribute.

#### Resolution

Add labels, update input types to more specific html 5 types where possible.


#### Note

This code depends on the `preferenceInput` changes made in #753