### PR TITLE
UP-4768: Add label and type to search portlet input - master

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Search/search.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Search/search.jsp
@@ -36,7 +36,7 @@
 
     <!-- Portlet Body -->
     <div class="fl-widget-content portlet-body" role="main">
-  
+
         <!-- Portlet Section -->
         <div id="${n}search" class="portlet-section" role="region">
 
@@ -44,7 +44,7 @@
 
                 <form id="${n}searchForm" action="${ formUrl }" class="form-inline" style="margin-bottom:10px;" method="POST">
                     <div class="form-group">
-                        <input id="${n}searchInput" class="searchInput form-control" name="query" value="${ fn:escapeXml(query )}"/>
+                        <input id="${n}searchInput" type="search" class="searchInput form-control" name="query" value="${ fn:escapeXml(query )}" aria-label="<spring:message code="search"/>"/>
                         <input id="${n}searchButton" type="submit" class="btn btn-default" value="<spring:message code="search.submit"/>"/>
                     </div>
                 </form>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4768

#### Issue

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.


When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.


Code Snippet

``` html
<input id="Pluto_31_ctf1_14_searchInput" class="searchInput form-control ui-autocomplete-input" name="query" value="" autocomplete="off">
```

This text input element does not have a name available to an accessibility API. Valid names are: label element, title attribute.


Code Snippet

``` html
<input id="Pluto_31_ctf1_14_searchInput" class="searchInput form-control ui-autocomplete-input" name="query" value="" autocomplete="off">
```

#### Resolution

Add `aria-label` and `type="search"`