### PR TITLE
UP-4770: Label user administration inputs - rel-4-3-patches

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
@@ -62,17 +62,7 @@
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-                    <table class="portlet-table table table-hover">
-                        <thead>
-                            <tr>
-                                <th>
-                                    <spring:message code="attribute.name"/>
-                                </th>
-                                <th>
-                                    <spring:message code="attribute.value"/>
-                                </th>
-                            </tr>
-                        </thead>
+                    <table class="portlet-table table table-hover" role="presentation">
                         <tbody>
                             <c:if test="${ accountForm.id < 0 }">
                                 <tr>
@@ -120,17 +110,7 @@
                 </div>
                 <div id="${n}standardAttributes" class="content">
 
-                    <table class="portlet-table table table-hover">
-                        <thead>
-                            <tr>
-                                <th>
-                                    <spring:message code="attribute.name"/>
-                                </th>
-                                <th>
-                                    <spring:message code="attribute.value"/>
-                                </th>
-                            </tr>
-                        </thead>
+                    <table class="portlet-table table table-hover" role="presentation">
                         <tbody>
 
                             <!-- Print out each attribute -->
@@ -169,17 +149,7 @@
                 </div>
                 <div id="${n}customAttributes" class="content">
 
-                    <table class="portlet-table table table-hover">
-                        <thead>
-                            <tr>
-                                <th>
-                                    <spring:message code="attribute.name"/>
-                                </th>
-                                <th colspan="2">
-                                    <spring:message code="attribute.value"/>
-                                </th>
-                            </tr>
-                        </thead>
+                    <table class="portlet-table table table-hover" role="presentation">
                         <tbody>
 
                             <!-- Print out each attribute -->

--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
@@ -46,7 +46,7 @@
             </c:choose>
         </h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
 
@@ -62,44 +62,73 @@
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-
                     <table class="portlet-table table table-hover">
+                        <thead>
+                            <tr>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th>
+                                    <spring:message code="attribute.value"/>
+                                </th>
+                            </tr>
+                        </thead>
                         <tbody>
-
                             <c:if test="${ accountForm.id < 0 }">
                                 <tr>
-                                    <td class="attribute-name"><spring:message code="username"/></td>
-                                    <td><form:input path="username"/></td>
+                                    <td class="attribute-name">
+                                        <label for="${n}userUsername">
+                                            <spring:message code="username" />
+                                        </label>
+                                    </td>
+                                    <td>
+                                        <form:input path="username" id="${n}userUsername" class="form-control"/>
+                                    </td>
                                 </tr>
                             </c:if>
                             <!--  Password and confirm password -->
                             <tr>
-                                <td class="attribute-name"><spring:message code="password"/></td>
-                                <td><form:password path="password"/></td>
+                                <td class="attribute-name">
+                                    <label for="${n}userPassword">
+                                        <spring:message code="password"/>
+                                    </label>
+                                </td>
+                                <td>
+                                    <form:password path="password" id="${n}userPassword" class="form-control"/>
+                                </td>
                             </tr>
                             <tr>
-                                <td class="attribute-name"><spring:message code="confirm.password"/></td>
-                                <td><form:password path="confirmPassword"/></td>
+                                <td class="attribute-name">
+                                    <label for="${n}userConfirmPassword">
+                                        <spring:message code="confirm.password"/>
+                                    </label>
+                                </td>
+                                <td>
+                                    <form:password path="confirmPassword" id="${n}userConfirmPassword" class="form-control"/>
+                                </td>
                             </tr>
-
                         </tbody>
                     </table>
 
                 </div>
             </div>
-        
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
                     <h3 class="title" role="heading"><spring:message code="standard.attributes"/></h3>
                 </div>
                 <div id="${n}standardAttributes" class="content">
-                
+
                     <table class="portlet-table table table-hover">
                         <thead>
                             <tr>
-                                <th><spring:message code="attribute.name"/></th>
-                                <th><spring:message code="attribute.value"/></th>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th>
+                                    <spring:message code="attribute.value"/>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
@@ -108,16 +137,23 @@
                             <c:forEach items="${ editAttributes }" var="attribute">
                                 <tr>
                                     <td class="attribute-name">
-                                        <strong><spring:message code="${ attribute.label }"/></strong>
+                                        <strong>
+                                            <label for="${ n }${ attribute.name }">
+                                                <spring:message code="${ attribute.label }"/>
+                                            </label>
+                                        </strong>
                                     </td>
                                     <td>
                                           <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
-                                          <editPortlet:preferenceInput input="${ attribute.preferenceInput.value }" 
-                                            path="${ paramPath }" values="${ accountForm.attributes[attribute.name].value }"/>
+                                          <editPortlet:preferenceInput
+                                              id="${ n }${ attribute.name }"
+                                              input="${ attribute.preferenceInput.value }"
+                                              path="${ paramPath }"
+                                              values="${ accountForm.attributes[attribute.name].value }"/>
                                     </td>
                                 </tr>
                             </c:forEach>
-                            
+
                         </tbody>
                     </table>
 
@@ -127,16 +163,21 @@
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
-                    <h3 class="title" role="heading"><spring:message code="custom.attributes"/></h3>
+                    <h3 class="title" role="heading">
+                        <spring:message code="custom.attributes"/>
+                    </h3>
                 </div>
                 <div id="${n}customAttributes" class="content">
-                
+
                     <table class="portlet-table table table-hover">
                         <thead>
                             <tr>
-                                <th><spring:message code="attribute.name"/></th>
-                                <th><spring:message code="attribute.value"/></th>
-                                <th></th>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th colspan="2">
+                                    <spring:message code="attribute.value"/>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
@@ -146,9 +187,12 @@
                                 <tr>
 
                                     <td class="attribute-name">
-
                                         <c:set var="attrName" value="${ attribute.key }"/>
-                                        <strong><spring:message code="attribute.displayName.${attrName}" text="${attrName}"/></strong>
+                                        <strong>
+                                            <label for="${ n }${ attrName }">
+                                                <spring:message code="attribute.displayName.${attrName}" text="${attrName}"/>
+                                            </label>
+                                        </strong>
                                         ${ fn:escapeXml(attribute.key)}
                                     </td>
                                     <td>
@@ -156,8 +200,10 @@
                                             <c:when test="${ fn:length(attribute.value.value) > 0 }">
                                                 <c:forEach var="value" items="${ attribute.value.value }">
                                                     <div>
-                                                         <input type="text" name="attributes['${fn:escapeXml(attribute.key)}'].value" value="${ fn:escapeXml(value )}" />
-                                                         <a class="delete-attribute-value-link" href="javascript:;"><spring:message code="remove"/></a>
+                                                         <input type="text" id="${ n }${ attrName }" class="form-control" name="attributes['${fn:escapeXml(attribute.key)}'].value" value="${ fn:escapeXml(value )}" />
+                                                         <a class="delete-attribute-value-link" href="javascript:;">
+                                                            <spring:message code="remove"/>
+                                                         </a>
                                                     </div>
                                                 </c:forEach>
                                                 <a class="add-attribute-value-link" href="javascript:;" paramName="${fn:escapeXml(name)}">
@@ -165,12 +211,16 @@
                                             </c:when>
                                             <c:otherwise>
                                                 <div>
-                                                    <input type="text" name="attributes['${fn:escapeXml(attribute.key)}'].value" value=""/>
+                                                    <input type="text" id="${ n }${ attrName }" class="form-control" name="attributes['${fn:escapeXml(attribute.key)}'].value" value=""/>
                                                 </div>
                                             </c:otherwise>
                                         </c:choose>
                                     </td>
-                                    <td><a class="delete-attribute-link" href="javascript:;"><spring:message code="remove"/></a></td>
+                                    <td>
+                                        <a class="delete-attribute-link" aria-label="<spring:message code="remove"/> <spring:message code="attribute.displayName.${attrName}" text="${attrName}"/>" href="javascript:;">
+                                            <spring:message code="remove"/>
+                                        </a>
+                                    </td>
                                 </tr>
                             </c:forEach>
 
@@ -190,7 +240,7 @@
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-            
+
                     <div class="buttons">
                         <input class="button btn primary" type="submit" value="<spring:message code="save"/>" name="_eventId_save"/>
                         <c:choose>
@@ -207,7 +257,7 @@
             </div>
 
         </form:form>
-        
+
     </div>
 
     <div id="${n}parameterForm" style="display:none">
@@ -215,8 +265,8 @@
             <spring:message code="attribute.name"/>: <input name="name"/>
             <input type="submit" value="<spring:message code="add"/>"/>
         </form>
-    </div>    
-    
+    </div>
+
 </div>
 
 <script type="text/javascript">

--- a/uportal-war/src/main/webapp/WEB-INF/flows/person-lookup/personLookup.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/person-lookup/personLookup.jsp
@@ -91,48 +91,57 @@
 
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-        <h2 class="title" role="heading"><spring:message code="search.for.users" /></h2>
+        <h2 class="title" role="heading">
+            <spring:message code="search.for.users" />
+        </h2>
     </div>
-    
+
     <!-- Portlet Content -->
     <div class="fl-widget-content content portlet-content" role="main">
 
         <div class="portlet-content">
             <form id="${n}searchForm" action="javascript:;">
-                <select id="${n}queryAttribute" name="queryAttribute">
-                        <option value=""><spring:message code="default.directory.attributes"/></option>
-                    <c:forEach var="queryAttribute" items="${queryAttributes}">
-                        <option value="${ queryAttribute }">
-                            <spring:message code="attribute.displayName.${queryAttribute}" text="${queryAttribute}"/>
+                <div class="col-md-6">
+                    <select id="${n}queryAttribute" class="form-control" name="queryAttribute" aria-label="<spring:message code="type"/>">
+                        <option value="">
+                            <spring:message code="default.directory.attributes"/>
                         </option>
-                    </c:forEach>
-                </select>
-                <input id="${n}queryValue" type="text" name="queryValue"/>
-                
-                <!-- Buttons -->
-                <div class="buttons">
-                    <spring:message var="searchButtonText" code="search" />
-                    <input class="button primary btn" type="submit" value="${searchButtonText}" />
-
-                    <a class="button btn" href="${ cancelUrl }">
-                        <spring:message code="cancel" />
-                    </a>
+                        <c:forEach var="queryAttribute" items="${queryAttributes}">
+                            <option value="${ queryAttribute }">
+                                <spring:message code="attribute.displayName.${queryAttribute}" text="${queryAttribute}"/>
+                            </option>
+                        </c:forEach>
+                    </select>
                 </div>
-                
+                <div class="col-md-6">
+                    <input id="${n}queryValue" aria-label="<spring:message code="search.terms"/>" class="form-control" type="search" name="queryValue"/>
+                </div>
+
+                <div class="col-md-6">
+                    <!-- Buttons -->
+                    <div class="buttons">
+                        <spring:message var="searchButtonText" code="search" />
+                        <input class="button primary btn" type="submit" value="${searchButtonText}" />
+
+                        <a class="button btn" href="${ cancelUrl }">
+                            <spring:message code="cancel" />
+                        </a>
+                    </div>
+                </div>
             </form>
-        
+
         <div id="${n}searchResults" class="portlet-section" style="display:none" role="region">
             <div class="titlebar">
                 <h3 role="heading" class="title">Search Results</h3>
             </div>
-                <table id="${n}resultsTable" class="portlet-table table table-bordered table-hover" style="width:100%;">
-                    <thead>
-                        <tr>
-                            <th><spring:message code="name"/></th>
-                            <th><spring:message code="username"/></th>
-                        </tr>
-                    </thead>
-                </table>
+            <table id="${n}resultsTable" class="portlet-table table table-bordered table-hover" style="width:100%;">
+                <thead>
+                    <tr>
+                        <th><spring:message code="name"/></th>
+                        <th><spring:message code="username"/></th>
+                    </tr>
+                </thead>
+            </table>
         </div>
 
     </div>
@@ -178,7 +187,7 @@ up.jQuery(function() {
             },
             aoColumns: [
                 { mData: 'attributes.displayName', sType: 'string', sWidth: '50%' },  // Name
-                { mData: 'attributes.username', sType: 'string', sWidth: '50%' }  // User Name 
+                { mData: 'attributes.username', sType: 'string', sWidth: '50%' }  // User Name
             ],
             fnInitComplete: function (oSettings) {
                 personList_configuration.main.table.fnDraw();
@@ -257,7 +266,7 @@ up.jQuery(function() {
             }
             showSearchResults(queryData);
             return false;
-        }); 
+        });
     });
 });
 </script>

--- a/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/self-edit-account/editLocalAccount.jsp
@@ -32,7 +32,7 @@
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="edit.my.account"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
 
@@ -44,14 +44,14 @@
                     <form:errors path="*" element="div"/>
                 </div> <!-- end: portlet-msg -->
             </spring:hasBindErrors>
-        
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="titlebar">
                     <h3 class="title" role="heading"><spring:message code="my.account.details"/></h3>
                 </div>
                 <div id="${n}userAttributes" class="content">
-                
+
                     <table class="portlet-table table table-hover">
                         <tbody>
 
@@ -59,16 +59,23 @@
                             <c:forEach items="${ editAttributes }" var="attribute">
                                 <tr>
                                     <td class="attribute-name">
-                                        <strong><spring:message code="${ attribute.label }"/></strong>
+                                        <label for="${ n }${ attribute.name }">
+                                            <strong>
+                                                <spring:message code="${ attribute.label }"/>
+                                            </strong>
+                                        </label>
                                     </td>
                                     <td>
-                                          <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
-                                          <editPortlet:preferenceInput input="${ attribute.preferenceInput.value }" 
-                                            path="${ paramPath }" values="${ accountForm.attributes[attribute.name].value }"/>
+                                        <c:set var="paramPath" value="attributes['${ attribute.name }'].value"/>
+                                        <editPortlet:preferenceInput
+                                            id="${ n }${ attribute.name }"
+                                            input="${ attribute.preferenceInput.value }"
+                                            path="${ paramPath }"
+                                            values="${ accountForm.attributes[attribute.name].value }" />
                                     </td>
                                 </tr>
                             </c:forEach>
-                            
+
                         </tbody>
                     </table>
 
@@ -84,31 +91,51 @@
                     <table class="portlet-table table table-hover">
                         <thead>
                             <tr>
-                                <th><spring:message code="attribute.name"/></th>
-                                <th><spring:message code="attribute.value"/></th>
+                                <th>
+                                    <spring:message code="attribute.name"/>
+                                </th>
+                                <th>
+                                    <spring:message code="attribute.value"/>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
 
                             <!--  Password and confirm password -->
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="password"/></strong></td>
-                                <td><form:password id="${n}password" path="password"/></td>
+                                <td class="attribute-name">
+                                  <label for="${n}password">
+                                      <strong>
+                                          <spring:message code="password"/>
+                                      </strong>
+                                  </label>
+                                </td>
+                                <td>
+                                    <form:password autocomplete="new-password" id="${n}password" path="password"/>
+                                </td>
                             </tr>
                             <tr>
-                                <td class="attribute-name"><strong><spring:message code="confirm.password"/></strong></td>
-                                <td><form:password id="${n}confirmPassword" path="confirmPassword"/></td>
+                                <td class="attribute-name">
+                                    <label for="${n}confirmPassword">
+                                        <strong>
+                                            <spring:message code="confirm.password"/>
+                                        </strong>
+                                    </label>
+                                </td>
+                                <td>
+                                    <form:password autcomplete="new-password" id="${n}confirmPassword" path="confirmPassword"/>
+                                </td>
                             </tr>
 
                         </tbody>
                     </table>
                 </div>
-            </div>    
-            
+            </div>
+
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-            
+
                     <div class="buttons">
                         <input class="button btn primary" type="submit" value="<spring:message code="save"/>" name="_eventId_save"/>
                         <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
@@ -117,7 +144,7 @@
             </div>
 
         </form:form>
-        
+
     </div>
 
     <div id="${n}parameterForm" style="display:none">
@@ -125,8 +152,8 @@
             <spring:message code="attribute.name"/>: <input name="name"/>
             <input type="submit" value="<spring:message code="add"/>"/>
         </form>
-    </div>    
-    
+    </div>
+
 </div>
 
 <script type="text/javascript">
@@ -134,7 +161,7 @@
         var $ = up.jQuery;
         $(document).ready(function(){
             up.ParameterEditor(
-                $("#${n}userAttributes"), 
+                $("#${n}userAttributes"),
                 {
                     parameterBindName: 'attributes',
                     multivalued: true,

--- a/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
+++ b/uportal-war/src/main/webapp/WEB-INF/tags/edit-portlet/preferenceInput.tag
@@ -25,6 +25,7 @@
 <%@ attribute name="path"    required="true" %>
 <%@ attribute name="name"    required="false" %>
 <%@ attribute name="values"  required="false" type="java.util.Collection" %>
+<%@ attribute name="id"    required="false" %>
 
 <c:choose>
 
@@ -51,10 +52,10 @@
       <!-- Textarea -->
         <c:choose>
             <c:when test="${ values != null }">
-                <textarea class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
+                <textarea id="${ id }" class="form-control">${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}</textarea>
             </c:when>
             <c:otherwise>
-                <form:textarea path="${path}"/>
+                <form:textarea id="${ id }" path="${path}"/>
             </c:otherwise>
         </c:choose>
       </c:when>
@@ -62,16 +63,16 @@
       <!-- Text input -->
         <c:choose>
             <c:when test="${ values != null }">
-                <input name="${fn:escapeXml(path)}" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
+                <input name="${fn:escapeXml(path)}" id="${ id }" value="${ fn:escapeXml(fn:length(values) > 0 ? values[0] : '' )}" class="form-control" />
             </c:when>
             <c:otherwise>
-                <form:input path="${path}"/>
+                <form:input id="${ id }" path="${ path }"/>
             </c:otherwise>
         </c:choose>
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.jasig.portal.portletpublishing.xml.SingleChoicePreferenceInput') }">
   <!-- Single-value choice input types -->
     <c:choose>
@@ -90,7 +91,7 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
   <c:when test="${ up:instanceOf(input, 'org.jasig.portal.portletpublishing.xml.MultiChoicePreferenceInput') }">
   <!-- Multi-value choice input types -->
     <c:choose>
@@ -109,5 +110,5 @@
       </c:otherwise>
     </c:choose>
   </c:when>
-  
+
 </c:choose>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4770

#### Issue

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.

When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.

Code Snippet

``` html
<input id="username" name="username" type="text" value="">
...all text input/password instances.
This text input element does not have a name available to an accessibility API. Valid names are: label element, title attribute.
Code Snippet
<input id="Pluto_40_ctf9_14_queryValue" type="text" name="queryValue" data-com.agilebits.onepassword.user-edited="yes">
```

This select element does not have a name available to an accessibility API. Valid names are: label element, title attribute.

Code Snippet

``` html
<select id="Pluto_40_ctf9_14_queryAttribute" name="queryAttribute"> <optio...</select>
<select><option value="">Name</option><...</select>
<select><option value="">Username</opti...</select>
```

This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.

When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.

Code Snippet

``` html
<select id="Pluto_40_ctf9_14_queryAttribute" name="queryAttribute"> <optio...</select>
<input id="Pluto_40_ctf9_14_queryValue" type="text" name="queryValue" data-com.agilebits.onepassword.user-edited="yes">
<select><option value="">Name</option><...</select>
<select><option value="">Username</opti...</select>
```

#### Resolution

Added `<label>` for inputs.