### PR TITLE
UP-4771: Label radio buttons in User Locales Selector Portlet - master

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/locale-selector/selectLocale.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/locale-selector/selectLocale.jsp
@@ -22,34 +22,34 @@
 <portlet:actionURL var="queryUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>
-    
+
 <!-- Portlet -->
 <div class="fl-widget portlet loc-sel view-select" role="section">
-  
+
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-    	<h2 class="title" role="heading"><spring:message code="set.language.preference"/></h2>
+    	 <h2 class="title" role="heading"><spring:message code="set.language.preference"/></h2>
     </div>
-    
+
     <!-- Portlet Content -->
     <div class="fl-widget-content content portlet-content" role="main">
-    
-    	<div class="portlet-form">
-            <form action="${queryUrl}" method="POST">
-                <ul style="margin:0">
-                    <c:forEach items="${ locales }" var="locale">
-                        <li style="list-style:none;padding:0.2em 0 0.2em 0">
-                        <input type="radio" name="locale" value="${ fn:escapeXml(locale.code )}" ${ locale.code == currentLocale ? "checked" : '' }/>
-                        <img src="/ResourceServingWebapp/rs/famfamfam/flags/${ fn:escapeXml(fn:toLowerCase(locale.locale.country) )}.png"/>
-                        ${ fn:escapeXml(locale.displayLanguage )}
-                    </li>
-                    </c:forEach>
-                </ul>
-                <div class="buttons">
-                    <input class="button btn primary" type="submit" value="<spring:message code="update"/>" name="_eventId_updateLocale"/>
-                </div>
-            </form>
-    	</div>
-        
+      	<div class="portlet-form">
+              <form action="${queryUrl}" method="POST">
+                  <ul style="margin:0">
+                      <c:forEach items="${ locales }" var="locale">
+                          <li style="list-style:none;padding:0.2em 0 0.2em 0">
+                              <input type="radio" name="locale" id="${ fn:escapeXml(locale.code) }" value="${ fn:escapeXml(locale.code) }" ${ locale.code == currentLocale ? "checked" : '' }/>
+                              <img src="/ResourceServingWebapp/rs/famfamfam/flags/${ fn:escapeXml(fn:toLowerCase(locale.locale.country) )}.png"/>
+                              <label for="${ fn:escapeXml(locale.code) }">
+                                  ${ fn:escapeXml(locale.displayLanguage) }
+                              </label>
+                          </li>
+                      </c:forEach>
+                  </ul>
+                  <div class="buttons">
+                      <input class="btn btn-primary" type="submit" value="<spring:message code="update"/>" name="_eventId_updateLocale"/>
+                  </div>
+              </form>
+      	</div>
     </div>
 </div>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4771

#### Issue

This radio input element does not have a name available to an accessibility API. Valid names are: label element, title attribute.

*Code Snippet*

``` html
<input type="radio" name="locale" value="en_US">
```

...all radio button instances.

label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.

When a form control does not have a name exposed to assistive technologies, users will not be able to identify the purpose of the form control. The name can be provided in multiple ways, including the label element. Other options include use of the title attribute and aria-label which are used to directly provide text that is used for the accessibility name or aria-labelledby which indicates an association with other text on a page that is providing the name. Button controls can have a name assigned in other ways, as indicated below, but in certain situations may require use of label, title, aria-label, or aria-labelledby.

*Code Snippet*

``` html
<input type="radio" name="locale" value="en_US">
```

...all radio button instances.

#### Resolution

Add `<label>` for `<input type="radio"/>`