### PR TITLE
UP-4776: Support filters on body background image - rel-4-3-patches

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -21,12 +21,28 @@
 
 #portalPageBody {
     background-color: @content-background-color;
-    background-image: @portal-page-body-background-image;
     min-height: 300px;
     /* Need for the offcanvas open effect */
     position: relative;
-    /* Do not change this z-index value without side effects on bootstrap modal for rate this portlet see comments and further references in defaultSkin/skin.less */ 
+    /* Do not change this z-index value without side effects on bootstrap modal for rate this portlet see comments and further references in defaultSkin/skin.less */
     z-index: auto;
+
+    // add background image in a pseudo dom tag
+    &::before {
+      // empty content
+      content: '';
+
+      // background positioning and sizing
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      background-size: cover;
+
+      // add image and filter(s)
+      background-image: @portal-page-body-background-image;
+      filter: @portal-page-body-background-image-filter;
+    }
 
     .portal-page-column {
         .portal-page-column-inner {

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
@@ -155,8 +155,8 @@
  */
 @body-background-color: @footer-secondary-background-color;  // default to match footer-second;  prevents 'gaps' at the bottom of short pages
 @body-background-image: none;
-@portal-page-body-background-image: url(./common/images/furley_bg.png);
-/* Using the furley pattern from http://subtlepatterns.com */
+@portal-page-body-background-image: url(./common/images/furley_bg.png); // Using the furley pattern from http://subtlepatterns.com
+@portal-page-body-background-image-filter: none; // for full list of filter effects see: https://developer.mozilla.org/en-US/docs/Web/CSS/filter
 
 /**
  * User bar styles


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4776

#### Improvement

Sometimes images need to be adjusted to meet stylistic constraints or accessibility contrast requirements.
Offering filters for background image would allow images to be adjusted dynamically, without modifying the original image.
And could be used with dynamic skins to allow different tenants to re-use the same image, applying different filters to match the image with the rest of the skin.

#### Resolution

I added a `@portal-page-body-background-image-filter` variable that pairs with the existing `@portal-page-body-background-image` to allow filtering.

#### Note on semver

This changes default image strategy from tiling to cover background, to expand to cover background with a single copy of image.
This change could be safer to land in version 5 only.

#### Example

*Standard*

![screencapture-localhost-8080-uportal-f-welcome-normal-render-up-1480446079342](https://cloud.githubusercontent.com/assets/3107513/20725005/b1df557a-b62d-11e6-828f-db650a77094b.png)

*Darkened*

![screencapture-localhost-8080-uportal-f-welcome-normal-render-up-1480446790245](https://cloud.githubusercontent.com/assets/3107513/20725011/b95d86a0-b62d-11e6-8391-e3548fd9c4b1.png)

*Sepia*

![screencapture-localhost-8080-uportal-f-welcome-normal-render-up-1480447233358](https://cloud.githubusercontent.com/assets/3107513/20725188/432b93b8-b62e-11e6-9d96-0b7fe1c41a01.png)
