### PR TITLE
UP-4777: Guard for missing dynamic variable in skin generator - master

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/portlets/dynamicskin/FileSystemDynamicSkinService.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/dynamicskin/FileSystemDynamicSkinService.java
@@ -186,7 +186,13 @@ public class FileSystemDynamicSkinService implements DynamicSkinService {
             String prefName = prefNames.nextElement();
             if (prefName.startsWith(DynamicSkinService.CONFIGURABLE_PREFIX)) {
                 String nameWithoutPrefix = prefName.substring(DynamicSkinService.CONFIGURABLE_PREFIX.length());
-                str.append("@").append(nameWithoutPrefix).append(": ").append(prefs.getValue(prefName, "")).append(";\n");
+                String value = prefs.getValue(prefName, "");
+
+                if (value.trim().equals("")) {
+                    log.warn("Dynamic Skin Variable \"{}\" is not set", nameWithoutPrefix);
+                } else {
+                    str.append("@").append(nameWithoutPrefix).append(": ").append(value).append(";\n");
+                }
             }
         }
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4777

#### Issue

Skin generator crashes when there is a missing dynamic variable.

#### Resolution

Check if value is empty or missing, skip that variable and warn.