### PR TITLE
Support redistribution of CC-BY-SA furley_bg.png

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -76,6 +76,7 @@ This project includes:
   Ehcache Spring Annotations - Core under Apache 2
   Ehcache Web Filters under The Apache Software License, Version 2.0
   ezmorph under The Apache Software License, Version 2.0
+  furley_bg.png under Creative Commons Attribution-ShareAlike 3.0 Unported
   Google Visualization Data Source Library under The Apache Software License, Version 2.0
   Groovy under The Apache Software License, Version 2.0
   Grouper Client under Apache 2

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/images/README.md
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/images/README.md
@@ -1,0 +1,5 @@
+# `furley_bg.png` must not be modified
+
+The file `furley_bg.png` is [a third party asset](https://subtlepatterns.com/light-sketch/) included under [the CC-BY-SA 3.0 license](https://creativecommons.org/licenses/by-sa/3.0/).
+
+[This is permissible](https://www.apache.org/legal/resolved#cc-sa) so long as the binary artifact is not modified.


### PR DESCRIPTION
Apparently uPortal (well, Apache-licensed projects) [can redistribute unmodified CC-BY-SA media](https://www.apache.org/legal/resolved#cc-sa), but really should acknowledge that it is doing so in the `NOTICE`.

This changeset spiffs up the acknowledgement that this is how uPortal is redistributing this asset and that this is okay.