### PR TITLE
UP-4785:  Support for multiple guest users (who may have different content)

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/IUserIdentityStore.java
+++ b/uportal-war/src/main/java/org/apereo/portal/IUserIdentityStore.java
@@ -49,13 +49,6 @@ public interface IUserIdentityStore {
   public void removePortalUID(int uPortalUID) throws Exception;
 
   /**
-   * Return the username to be used for authorization (exit hook)
-   * @param person
-   * @return usernmae
-   */
-  public String getUsername(IPerson person);
-  
-  /**
    * Gets a portal user name that is associated with the specified portal
    * ID.
    * 

--- a/uportal-war/src/main/java/org/apereo/portal/RDBMUserIdentityStore.java
+++ b/uportal-war/src/main/java/org/apereo/portal/RDBMUserIdentityStore.java
@@ -159,7 +159,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
         this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus arg0) {
-                if (PersonFactory.GUEST_USERNAME.equals(userName)) {
+                if (PersonFactory.GUEST_USERNAMES.contains(userName)) {
                     throw new IllegalArgumentException("CANNOT RESET LAYOUT FOR A GUEST USER");
                 }
 
@@ -240,15 +240,6 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
     }
 
     /**
-     * Return the username to be used for authorization (exit hook)
-     * @param person
-     * @return usernmae
-     */
-    public String getUsername(IPerson person) {
-        return (String)person.getAttribute(IPerson.USERNAME);
-    }
-
-    /**
      * Get the portal user ID for this person object.
      * @param person
      * @param createPortalData indicating whether to try to create all uPortal data for this user from template prototype
@@ -261,7 +252,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
         String username = (String)person.getAttribute(IPerson.USERNAME);
 
         // only synchronize a non-guest request.
-        if (PersonFactory.GUEST_USERNAME.equals(username)) {
+        if (PersonFactory.GUEST_USERNAMES.contains(username)) {
             uid = __getPortalUID(person, createPortalData);
         } else {
             Object lock = getLock(person);
@@ -322,7 +313,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
         PortalUser portalUser = null;
 
         try {
-            String userName = getUsername(person);
+            String userName = person.getUserName();
             String templateName = getTemplateName(person);
             portalUser = getPortalUser(userName);
 
@@ -748,7 +739,7 @@ public class RDBMUserIdentityStore  implements IUserIdentityStore {
                                     "INSERT INTO UP_USER (USER_ID, USER_NAME, USER_DFLT_USR_ID, USER_DFLT_LAY_ID, NEXT_STRUCT_ID, LST_CHAN_UPDT_DT)" +
                                             "VALUES (?, ?, ?, ?, null, null)";
 
-                            String userName = getUsername(person);
+                            String userName = person.getUserName();
 
                             insertStmt = con.prepareStatement(insert);
                             insertStmt.setInt(1, newUID);

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -1441,7 +1441,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
     private boolean resetLayout(IPerson person)
     {
         final String userName = person.getUserName();
-        if (PersonFactory.GUEST_USERNAME.equals(userName)) {
+        if (PersonFactory.GUEST_USERNAMES.contains(userName)) {
             throw new IllegalArgumentException("CANNOT RESET LAYOUT FOR A GUEST USER: " + person);
         }
         LOG.warn("Resetting user layout for: " + userName, new Throwable());

--- a/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
@@ -49,7 +49,11 @@ public class PersonFactory {
             PropertiesManager.getProperty("org.apereo.portal.security.PersonFactory.guest_user_names", "guest");
 
     /**
-     * The guest user names specified in portal.properties.
+     * Collection of guest user names specified in portal.properties as
+     * <code>org.apereo.portal.security.PersonFactory.guest_user_names</code>.
+     * The value of this property is a comma-delimited list.
+     *
+     * @since 5.0
      */
     public static final List<String> GUEST_USERNAMES = Collections.unmodifiableList(
             Arrays.asList(GUEST_USERNAMES_PROPERTY.split(","))

--- a/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
@@ -52,9 +52,7 @@ public class PersonFactory {
      * The guest user names specified in portal.properties.
      */
     public static final List<String> GUEST_USERNAMES = Collections.unmodifiableList(
-            Arrays.asList(
-                    GUEST_USERNAMES_PROPERTY.split(",")
-            )
+            Arrays.asList(GUEST_USERNAMES_PROPERTY.split(","))
     );
 
     /**

--- a/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/PersonFactory.java
@@ -18,12 +18,13 @@
  */
 package org.apereo.portal.security;
 
-import org.apereo.portal.IUserIdentityStore;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apereo.portal.properties.PropertiesManager;
 import org.apereo.portal.security.provider.PersonImpl;
 import org.apereo.portal.security.provider.RestrictedPerson;
-import org.apereo.portal.spring.locator.UserIdentityStoreLocator;
-import org.apereo.portal.utils.threading.SingletonDoubleCheckedCreator;
 
 /**
  * Creates a person.
@@ -39,33 +40,22 @@ import org.apereo.portal.utils.threading.SingletonDoubleCheckedCreator;
  *       <code>org.apereo.portal.security.PersonFactory.guest_user_name</code>
  *       in <code>portal.properties</code>.</li>
  * </ol>
+ *
  * @author Ken Weiner, kweiner@unicon.net
- * @version $Revision$
  */
 public class PersonFactory {
-    
+
+    private static final String GUEST_USERNAMES_PROPERTY =
+            PropertiesManager.getProperty("org.apereo.portal.security.PersonFactory.guest_user_names", "guest");
+
     /**
-     * The guest user name specified in portal.properties.
+     * The guest user names specified in portal.properties.
      */
-    public static final String GUEST_USERNAME = 
-        PropertiesManager.getProperty("org.apereo.portal.security.PersonFactory.guest_user_name", "guest");
-    
-    private static final SingletonDoubleCheckedCreator<Integer> GUEST_USER_ID_LOADER = new SingletonDoubleCheckedCreator<Integer>() {
-        /* (non-Javadoc)
-         * @see org.apereo.portal.utils.threading.SingletonDoubleCheckedCreator#createSingleton(java.lang.Object[])
-         */
-        @Override
-        protected Integer createSingleton(Object... args) {
-            final IPerson person = (IPerson)args[0];
-            final IUserIdentityStore userIdentityStore = UserIdentityStoreLocator.getUserIdentityStore();
-            try {
-                return userIdentityStore.getPortalUID(person);
-            }
-            catch (Exception e) {
-                throw new RuntimeException("Error while finding user id for person: "  + person, e);
-            }
-        }
-    };
+    public static final List<String> GUEST_USERNAMES = Collections.unmodifiableList(
+            Arrays.asList(
+                    GUEST_USERNAMES_PROPERTY.split(",")
+            )
+    );
 
     /**
      * Creates an empty <code>IPerson</code> implementation. 
@@ -87,26 +77,11 @@ public class PersonFactory {
     }
 
     /**
-     * Creates a <i>guest</i> user.
-     * @return <i>guest</i> user
-     * @throws Exception
-     */
-    public static IPerson createGuestPerson() throws Exception {
-        IPerson person = createPerson();
-        person.setAttribute(IPerson.USERNAME, GUEST_USERNAME);
-        final int guestUserId = GUEST_USER_ID_LOADER.get(person);
-        person.setID(guestUserId);
-        person.setSecurityContext(InitialSecurityContextFactory.getInitialContext("root"));
-        return person;
-    }
-    
-    /**
      * Creates a <i>restricted</i> user.
      * @return <i>restricted</i> user
      */
     public static RestrictedPerson createRestrictedPerson() {
         IPerson person = createPerson();
-        
         return new RestrictedPerson(person);
     }
     

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
@@ -56,7 +56,12 @@ public abstract class AbstractPersonManager implements IPersonManager {
     }
 
     /**
-     * Creates a <i>guest</i> user.
+     * Creates a new <i>guest</i> user based on the value of the
+     * <code>org.apereo.portal.security.PersonFactory.guest_user_names</code>
+     * property in portal.properties and (optionally) any beans that implement
+     * {@link IGuestUsernameSelector}.  This approach supports pluggable,
+     * open-ended strategies for multiple guest users who may have different
+     * content.
      *
      * @since 5.0
      */

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
@@ -18,7 +18,6 @@
  */
 package org.apereo.portal.security.provider;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/AbstractPersonManager.java
@@ -18,11 +18,96 @@
  */
 package org.apereo.portal.security.provider;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apereo.portal.IUserIdentityStore;
+import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
+import org.apereo.portal.security.InitialSecurityContextFactory;
+import org.apereo.portal.security.PersonFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Eric Dalquist
  */
 public abstract class AbstractPersonManager implements IPersonManager {
+
+    private final Map<String,Integer> guestUserIds = new HashMap<>();
+
+    @Autowired(required = false)
+    private List<IGuestUsernameSelector> guestUsernameSelectors;
+
+    @Autowired
+    private IUserIdentityStore userIdentityStore;
+
+    @PostConstruct
+    public void init() {
+        // Make sure we have a guestUsernameSelectors collection & sort it
+        if (guestUsernameSelectors == null) {
+            guestUsernameSelectors = Collections.emptyList();
+        }
+        Collections.sort(guestUsernameSelectors);
+    }
+
+    /**
+     * Creates a <i>guest</i> user.
+     *
+     * @since 5.0
+     */
+    protected IPerson createGuestPerson(HttpServletRequest request) throws Exception {
+
+        // First we need to know the guest username
+        String username = PersonFactory.GUEST_USERNAMES.get(0);  // First item is the default
+
+        // Pluggable strategy for supporting multiple guest users
+        for (IGuestUsernameSelector selector : guestUsernameSelectors) {
+            final String s = selector.selectGuestUsername(request);
+            if (s != null) {
+                username = s;
+                break;
+            }
+        }
+
+        // Sanity check...
+        if (!PersonFactory.GUEST_USERNAMES.contains(username)) {
+            final String msg = "The specified guest username is not in the configured list:  " + username;
+            throw new IllegalStateException(msg);
+        }
+
+        Integer guestUserId = guestUserIds.get(username);
+        if (guestUserId == null) {
+            // Not yet looked up
+            loadGuestUserId(username, guestUserIds);
+            guestUserId = guestUserIds.get(username);
+        }
+
+        final IPerson rslt = PersonFactory.createPerson();
+        rslt.setAttribute(IPerson.USERNAME, username);
+        rslt.setID(guestUserId);
+        rslt.setSecurityContext(InitialSecurityContextFactory.getInitialContext("root"));
+
+        return rslt;
+
+    }
+
+    private synchronized void loadGuestUserId(String username, Map<String,Integer> map) {
+        if (map.containsKey(username)) {
+            // Already have it
+            return;
+        }
+        final Integer userId = userIdentityStore.getPortalUserId(username);
+        if (userId == null) {
+            final String msg = "The specified guest user account does not exist in the portal database:  " + username;
+            throw new IllegalStateException(msg);
+        }
+        map.put(username, userId);
+    }
 
 }

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/ExtendedPersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/ExtendedPersonManager.java
@@ -65,7 +65,7 @@ public class ExtendedPersonManager extends AbstractPersonManager {
 		if (person == null) {
 			try {
 				// Create a guest person
-				person = PersonFactory.createGuestPerson();
+				person = createGuestPerson(request);
 				merger.mergeAttributes(person.getAttributeMap(), descriptors.getAttributes());
 			} catch (Exception e) {
 				// Log the exception

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/IGuestUsernameSelector.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/IGuestUsernameSelector.java
@@ -1,0 +1,18 @@
+package org.apereo.portal.security.provider;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This interface supports pluggable strategies for multiple guest user
+ * accounts.  Zero instances of this interface are required, in which case the
+ * behavior is just like uPortal 4 (one guest user account).  Instances are
+ * sorted in natural order.
+ *
+ * @since 5.0
+ * @author drewwills
+ */
+public interface IGuestUsernameSelector extends Comparable<IGuestUsernameSelector> {
+
+    String selectGuestUsername(HttpServletRequest req);
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/PersonImpl.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/PersonImpl.java
@@ -232,9 +232,7 @@ public class PersonImpl implements IPerson {
      * <p>
      * This person is a "guest" if both of the following are true:
      * <ol>
-     *   <li>This person's user name matches the value of the property
-     *       <code>org.apereo.portal.security.PersonImpl.guest_user_name</code>
-     *       in <code>portal.properties</code>.</li>
+     *   <li>This person's user name is listed as a guest user account.</li>
      *   <li>This person does not have a live instance ISecurityContext that 
      *       states he/she has been successfully authenticated.  (It can be 
      *       either null or unauthenticated.)</li>
@@ -244,13 +242,13 @@ public class PersonImpl implements IPerson {
      */
     @Override
     public boolean isGuest() {
-        boolean isGuest = false;  // default
+        boolean rslt = false;  // default
         String userName = (String) getAttribute(IPerson.USERNAME);
-        if (PersonFactory.GUEST_USERNAME.equalsIgnoreCase(userName) && 
+        if (PersonFactory.GUEST_USERNAMES.contains(userName) &&
                 (m_securityContext == null || !m_securityContext.isAuthenticated())) {
-            isGuest = true;
+            rslt = true;
         }
-        return isGuest;
+        return rslt;
     }
 
     /**
@@ -311,7 +309,7 @@ public class PersonImpl implements IPerson {
     /**
      * This method helps the PersonImpl <i>fail fast</i> if it is initialized in
      * an invalid state.  An instance of this class that does not have a value
-     * for {@link IPerson.USERNAME} cannot function properly.  It would be
+     * for <code>IPerson.USERNAME</code> cannot function properly.  It would be
      * unusable for groups, permissions, layouts, authenticated status, and
      * probably a whole host of other things.  It's best if we raise the alarm
      * immediately, otherwise the issue may be much more time consuming to

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/RemoteUserPersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/RemoteUserPersonManager.java
@@ -69,7 +69,7 @@ public class RemoteUserPersonManager extends AbstractPersonManager {
 
 		try {
 			// Create a new instance of a person
-			person = PersonFactory.createGuestPerson();
+			person = createGuestPerson(request);
 			
 			// If the user has authenticated with the server which has implemented web authentication,
 			// the REMOTE_USER environment variable will be set.			

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/RestrictedPerson.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/RestrictedPerson.java
@@ -30,7 +30,6 @@ import org.apereo.portal.security.ISecurityContext;
  * object and prevents access to the
  * underlying security context.
  * @author Ken Weiner, kweiner@unicon.net
- * @version $Revision$
  */
 public class RestrictedPerson implements IPerson {
     private static final long serialVersionUID = 1L;

--- a/uportal-war/src/main/java/org/apereo/portal/security/provider/SimplePersonManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/provider/SimplePersonManager.java
@@ -43,24 +43,27 @@ public class SimplePersonManager extends AbstractPersonManager {
   public IPerson getPerson (HttpServletRequest request) throws PortalSecurityException {
     HttpSession session = request.getSession(false);
     IPerson person = null;
+
     // Return the person object if it exists in the user's session
-    if (session != null)
+    if (session != null) {
       person = (IPerson)session.getAttribute(PERSON_SESSION_KEY);
+    }
+
     if (person == null) {
       try {
         // Create a guest person
-        person = PersonFactory.createGuestPerson();
+        person = createGuestPerson(request);
       } catch (Exception e) {
         // Log the exception
         log.error("Exception creating guest person.", e);
       }
       // Add this person object to the user's session
-      if (person != null && session != null)
+      if (person != null && session != null) {
         session.setAttribute(PERSON_SESSION_KEY, person);
+      }
     }
+
     return person;
   }
+
 }
-
-
-

--- a/uportal-war/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
+++ b/uportal-war/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
@@ -27,9 +27,9 @@ import org.apereo.portal.portlets.groupselector.EntityEnum;
 import org.apereo.portal.security.IAuthorizationPrincipal;
 import org.apereo.portal.security.IPermission;
 import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.PersonFactory;
 import org.apereo.portal.services.AuthorizationService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -50,9 +50,6 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
     public void setGroupListHelper(IGroupListHelper groupListHelper) {
         this.groupListHelper = groupListHelper;
     }
-
-    @Value("${org.apereo.portal.security.PersonFactory.guest_user_name}")
-    private String anonymousUsername;
 
     private AuthorizationService authorizationService;
 
@@ -138,7 +135,7 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
      * Prepare a uPortal IAuthorizationPrincipal based in the Spring principal
      */
     private IAuthorizationPrincipal getAuthorizationPrincipal(Authentication authentication) {
-        String username = anonymousUsername;  // default -- unauthenticated user
+        String username = PersonFactory.GUEST_USERNAMES.get(0);  // default -- unauthenticated user
         Object authPrincipal = authentication.getPrincipal();
         if (authPrincipal instanceof UserDetails) {
             // User is authenticated

--- a/uportal-war/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
+++ b/uportal-war/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
@@ -21,14 +21,18 @@ package org.apereo.portal.spring.security.evaluator;
 
 import java.io.Serializable;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apereo.portal.layout.dlm.remoting.IGroupListHelper;
 import org.apereo.portal.layout.dlm.remoting.JsonEntityBean;
 import org.apereo.portal.portlets.groupselector.EntityEnum;
 import org.apereo.portal.security.IAuthorizationPrincipal;
 import org.apereo.portal.security.IPermission;
 import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.PersonFactory;
 import org.apereo.portal.services.AuthorizationService;
+import org.apereo.portal.url.IPortalRequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
@@ -44,9 +48,15 @@ import org.springframework.security.core.userdetails.UserDetails;
  */
 public class PortalPermissionEvaluator implements PermissionEvaluator {
 
+    @Autowired
+    private IPortalRequestUtils portalRequestUtils;
+
+    @Autowired
+    private IPersonManager personManager;
+
     private IGroupListHelper groupListHelper;
 
-    @Autowired(required = true)
+    @Autowired
     public void setGroupListHelper(IGroupListHelper groupListHelper) {
         this.groupListHelper = groupListHelper;
     }
@@ -135,14 +145,23 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
      * Prepare a uPortal IAuthorizationPrincipal based in the Spring principal
      */
     private IAuthorizationPrincipal getAuthorizationPrincipal(Authentication authentication) {
-        String username = PersonFactory.GUEST_USERNAMES.get(0);  // default -- unauthenticated user
+
+        String username = PersonFactory.GUEST_USERNAMES.get(0);  // default -- first unauthenticated user
+
         Object authPrincipal = authentication.getPrincipal();
         if (authPrincipal instanceof UserDetails) {
             // User is authenticated
             UserDetails userDetails = (UserDetails) authPrincipal;
             username = userDetails.getUsername();
+        } else {
+            // Which guest user are we?
+            final HttpServletRequest req = portalRequestUtils.getCurrentPortalRequest();
+            final IPerson person = personManager.getPerson(req);
+            username = person.getUserName();
         }
+
         return authorizationService.newPrincipal(username, IPerson.class);
+
     }
 
     private AuthorizableActivity getViewActivity(final String activityKey, final JsonEntityBean entity) {

--- a/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
@@ -38,14 +38,14 @@
         <context:include-filter type="regex" expression=".*\.account\.UserAccountHelper" />
     </context:component-scan>
     <context:component-scan base-package="org.apereo.portal">
-        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.portlets\..+"/>
-        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.mvc\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.json\.rendering\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.layout\.dlm\.remoting\..+"/>
-        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.remoting\..+"/>
-        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.rest\..+"/>
+        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.portlets\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.redirect\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.rendering\..+"/>
+        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.rest\..+"/>
+        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.mvc\..+"/>
+        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.remoting\..+"/>
     </context:component-scan>
     <!-- TODO:  Remove! -->
     <context:component-scan base-package="org.jasig.portal">

--- a/uportal-war/src/main/resources/properties/portal.properties
+++ b/uportal-war/src/main/resources/properties/portal.properties
@@ -533,13 +533,15 @@ org.apereo.portal.portlets.googleWebSearch.search.result.type=googleCustom
 org.apereo.portal.portlets.passwordEncryptionKey=changeme
 
 ##
-## Controls the user that represents a "Guest" user in the portal.
-## Users are considered guests when they have this user name and
-## they are not authenticated with the portal.
-## Tip: Make sure the value of this property is not a real user name
+## Comma-delimited list of user accounts that are "Guest" users in the portal.
+## Users are considered guests when they have one of these user names and
+## they are not authenticated with the portal.  The first username in the list
+## is the default.
+##
+## Tip: Make sure the value of this property does not contain a real user name
 ## within your organization.
 ##
-org.apereo.portal.security.PersonFactory.guest_user_name=guest
+org.apereo.portal.security.PersonFactory.guest_user_names=guest
 
 ##
 ## Sets if permission check results will be cached by the entity caching service

--- a/uportal-war/src/main/resources/properties/portal.properties
+++ b/uportal-war/src/main/resources/properties/portal.properties
@@ -533,13 +533,16 @@ org.apereo.portal.portlets.googleWebSearch.search.result.type=googleCustom
 org.apereo.portal.portlets.passwordEncryptionKey=changeme
 
 ##
-## Comma-delimited list of user accounts that are "Guest" users in the portal.
-## Users are considered guests when they have one of these user names and
-## they are not authenticated with the portal.  The first username in the list
-## is the default.
+## Comma-delimited list (without extra whitespace) of user accounts that are
+## "Guest" users in the portal.  Users are considered guests when they have one
+## of these user names and they are not authenticated with the portal.  The
+## first username in the list is the default.
 ##
-## Tip: Make sure the value of this property does not contain a real user name
-## within your organization.
+## Tip #1: Make sure you add each username below to Guests.group-membership.xml
+## in src/main/data and import.
+##
+## Tip #2: Make sure the value of this property does not contain a real user's
+## username within your organization.
 ##
 org.apereo.portal.security.PersonFactory.guest_user_names=guest
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4785

Since the dawn of time uPortal has assigned all unauthenticated users to the same user account:  _guest_.  Not all uPortal deployments support anonymous access, but the vast majority of those that do show *EXACTLY* the same content to every unauthenticated user.

But sometimes that's not what you want.  Sometimes you want to offer a customized guest experience based on the campus, tenancy, language, _etc._ that is used to access the portal (even anonymously).  This task has been difficult, traditionally, due to how aggressively content -- especially guest content -- is cached in the portal.

We should provide the ability to configure multiple guest accounts, and a pluggable, open-ended way to choose a guest account when a user accesses the portal anonymously.

This improvement should (I believe) supersede the need to implement several other tickets in JIRA that describe (risky?) changes to how caching works intending to support varied guest experiences.  I think this feature will cover those use cases, and I believe it will be less risky & disruptive to the codebase as a whole.  (I will try to link all those issues.)
