### PR TITLE
Ability to alter soffit modelandview, only send encryptedToken

### DIFF
--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -82,8 +82,6 @@ public class SoffitRendererController {
      */
     public static final String CACHE_MAXAGE_PROPERTY_FORMAT = PROPERTY_PREFIX + "%s.cache.max-age";
 
-    private static final String PORTAL_REQUEST_MODEL_NAME = "portalRequest";
-
     private static final String DEFAULT_MODE = "view";
     private static final String DEFAULT_WINDOW_STATE = "normal";
 
@@ -123,8 +121,10 @@ public class SoffitRendererController {
         // Set up cache headers appropriately
         configureCacheHeaders(res, module);
 
-        return new ModelAndView(viewName.toString(), PORTAL_REQUEST_MODEL_NAME, portalRequest);
+        ModelAndView mav = new ModelAndView(viewName.toString());
+        mav.addObject("token", getBearer(req).getEncryptedToken());
 
+        return mav;
     }
 
     @ModelAttribute("bearer")


### PR DESCRIPTION
Trying to modify the PortalRequest is causing a bunch of issues with trying to access the Bearer encryptedToken. So I believe that just passing the encryptedToken around allows for a few things. One, it allows for the render modelandview for the soffit to be altered thus allowing for user specific data to be     added. Also, it has the added security benefit of only having the encryptedToken visible. 