### PR TITLE
UP-4790:  (master branch) Cache entries that establish a user's group affiliations ar…

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/groups/GroupsCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/GroupsCacheAuthenticationListener.java
@@ -41,19 +41,32 @@ import org.springframework.stereotype.Component;
 @Component
 public class GroupsCacheAuthenticationListener implements IAuthenticationListener {
 
-    @Autowired
-    @Qualifier(value = "org.apereo.portal.groups.GroupMemberImpl.parentGroups")
     private Cache parentGroupsCache;
 
-    @Autowired
-    @Qualifier(value = "org.apereo.portal.groups.EntityGroupImpl.children")
     private Cache childrenCache;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    @Override
-    public void userAuthenticateed(IPerson user) {
+    @Autowired
+    @Qualifier(value = "org.apereo.portal.groups.GroupMemberImpl.parentGroups")
+    public void setParentGroupsCache(Cache parentGroupsCache) {
+        this.parentGroupsCache = parentGroupsCache;
+    }
 
+    @Autowired
+    @Qualifier(value = "org.apereo.portal.groups.EntityGroupImpl.children")
+    public void setChildrenCache(Cache childrenCache) {
+        this.childrenCache = childrenCache;
+    }
+
+    @Override
+    public void userAuthenticated(IPerson user) {
+
+        /*
+         * Used to log the time it takes to complete this operation;  the author
+         * has some anxiety about running time with large numbers of elements in
+         * the cache.
+         */
         final long timestamp = System.currentTimeMillis();
 
         /*

--- a/uportal-war/src/main/java/org/apereo/portal/groups/GroupsCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/GroupsCacheAuthenticationListener.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups;
+
+import java.util.Set;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+import org.apereo.portal.EntityIdentifier;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.services.IAuthenticationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Responsible for removing some membership-related cache entries when a user
+ * authenticates so they can be evaluated afresh.
+ *
+ * @author drewwills
+ */
+@Component
+public class GroupsCacheAuthenticationListener implements IAuthenticationListener {
+
+    @Autowired
+    @Qualifier(value = "org.apereo.portal.groups.GroupMemberImpl.parentGroups")
+    private Cache parentGroupsCache;
+
+    @Autowired
+    @Qualifier(value = "org.apereo.portal.groups.EntityGroupImpl.children")
+    private Cache childrenCache;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void userAuthenticateed(IPerson user) {
+
+        final long timestamp = System.currentTimeMillis();
+
+        /*
+         * Group/member relationships are cached 2 ways:  child-to-parents and
+         * parent-to-children.  We need to flush both.
+         */
+        final EntityIdentifier ei = user.getEntityIdentifier();
+        final Element parentGroupsElement = parentGroupsCache.get(ei);
+        if (parentGroupsElement != null) {
+            // We have some flushing work to do...
+            int numPurged = 1;
+            final Set<IEntityGroup> parentGroups = (Set<IEntityGroup>) parentGroupsElement.getObjectValue();
+            for (IEntityGroup group : parentGroups) {
+                final EntityIdentifier uei = group.getUnderlyingEntityIdentifier();
+                if (childrenCache.remove(uei)) {
+                    ++numPurged;
+                }
+            }
+            parentGroupsCache.remove(ei);
+            logger.debug("Purged {} local group cache entries for authenticated user '{}' in {}ms",
+                    numPurged, user.getUserName(), Long.toBinaryString(System.currentTimeMillis() - timestamp));
+        }
+
+    }
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups.pags.dao;
+
+import net.sf.ehcache.Element;
+import net.sf.ehcache.search.attribute.AttributeExtractor;
+import net.sf.ehcache.search.attribute.AttributeExtractorException;
+import org.apereo.portal.EntityIdentifier;
+
+/**
+ * Used within Ehcache to find keys that reference the specified username.
+ *
+ * @author drewwills
+ */
+public class EhcacheMemberIdAttributeExtractor implements AttributeExtractor {
+
+    @Override
+    public Object attributeFor(Element element, String attributeName) throws AttributeExtractorException {
+        final MembershipCacheKey membershipCacheKey = (MembershipCacheKey) element.getObjectKey();
+        final EntityIdentifier ei = membershipCacheKey.getMemberId();
+        return ei.getKey();
+    }
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
@@ -27,7 +27,7 @@ import org.apereo.portal.EntityIdentifier;
 /**
  * Used within Ehcache to find keys that reference the specified username.
  *
- * @author drewwills
+ * @since 5.0
  */
 public class EhcacheMemberIdAttributeExtractor implements AttributeExtractor {
 

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
@@ -18,7 +18,6 @@
  */
 package org.apereo.portal.groups.pags.dao;
 
-import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -118,7 +117,7 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
             }
         }
 
-        final MembershipCacheKey cacheKey = new MembershipCacheKey(group.getEntityIdentifier(), member.getEntityIdentifier());
+        final MembershipCacheKey cacheKey = new MembershipCacheKey(group.getEntityIdentifier(), member.getUnderlyingEntityIdentifier());
         Element element = membershipCache.get(cacheKey);
         if (element == null) {
 
@@ -446,60 +445,6 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
         }
         final IPersonAttributesGroupDefinition rslt = pagsGroups.isEmpty() ? null : pagsGroups.iterator().next();
         return rslt;
-    }
-
-    /*
-     * Nested Types
-     */
-
-    private static final class MembershipCacheKey implements Serializable {
-
-        private static final long serialVersionUID = 1L;
-
-        private final EntityIdentifier groupId;
-        private final EntityIdentifier memberId;
-
-        public MembershipCacheKey(final EntityIdentifier groupId, final EntityIdentifier memberId) {
-            this.groupId = groupId;
-            this.memberId = memberId;
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
-            result = prime * result + ((memberId == null) ? 0 : memberId.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            MembershipCacheKey other = (MembershipCacheKey) obj;
-            if (groupId == null) {
-                if (other.groupId != null)
-                    return false;
-            } else if (!groupId.equals(other.groupId))
-                return false;
-            if (memberId == null) {
-                if (other.memberId != null)
-                    return false;
-            } else if (!memberId.equals(other.memberId))
-                return false;
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return "MembershipCacheKey [groupId=" + groupId + ", memberId=" + memberId + "]";
-        }
-
     }
 
 }

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/MembershipCacheKey.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/MembershipCacheKey.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups.pags.dao;
+
+import java.io.Serializable;
+
+import org.apereo.portal.EntityIdentifier;
+
+/**
+ * @author drewwills
+ */
+/* package-private */ final class MembershipCacheKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final EntityIdentifier groupId;
+    private final EntityIdentifier memberId;
+
+    public MembershipCacheKey(final EntityIdentifier groupId, final EntityIdentifier memberId) {
+        this.groupId = groupId;
+        this.memberId = memberId;
+    }
+
+    public EntityIdentifier getGroupId() {
+        return groupId;
+    }
+
+    public EntityIdentifier getMemberId() {
+        return memberId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
+        result = prime * result + ((memberId == null) ? 0 : memberId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MembershipCacheKey other = (MembershipCacheKey) obj;
+        if (groupId == null) {
+            if (other.groupId != null)
+                return false;
+        } else if (!groupId.equals(other.groupId))
+            return false;
+        if (memberId == null) {
+            if (other.memberId != null)
+                return false;
+        } else if (!memberId.equals(other.memberId))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "MembershipCacheKey [groupId=" + groupId + ", memberId=" + memberId + "]";
+    }
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/MembershipCacheKey.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/MembershipCacheKey.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 import org.apereo.portal.EntityIdentifier;
 
 /**
- * @author drewwills
+ * @since 5.0
  */
 /* package-private */ final class MembershipCacheKey implements Serializable {
 

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
  * attributes -- and therefore different PAGS affiliations -- based on
  * information passed to the authentication process.
  *
- * @author drewwills
+ * @since 5.0
  */
 @Component
 public class PagsMembershipCacheAuthenticationListener implements IAuthenticationListener {

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups.pags.dao;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.search.Attribute;
+import net.sf.ehcache.search.Query;
+import net.sf.ehcache.search.Result;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.services.IAuthenticationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Responsible for flushing PAGS membership-related cache entries when a user
+ * authenticates so they can be evaluated afresh.  Users may have different
+ * attributes -- and therefore different PAGS affiliations -- based on
+ * information passed to the authentication process.
+ *
+ * @author drewwills
+ */
+@Component
+public class PagsMembershipCacheAuthenticationListener implements IAuthenticationListener {
+
+    private static final String SEARCH_ATTRIBUTE_NAME = "memberId";
+
+    @Autowired
+    @Qualifier(value = "org.apereo.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership")
+    private Cache membershipCache;
+
+    private Attribute<String> usernameSearchAttribute;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostConstruct
+    public void init() {
+        usernameSearchAttribute = membershipCache.getSearchAttribute(SEARCH_ATTRIBUTE_NAME);
+    }
+
+    @Override
+    public void userAuthenticateed(IPerson user) {
+
+        final long timestamp = System.currentTimeMillis();
+
+        /*
+         * Query the membershipCache (ehcache) for elements that
+         * reference the specified user and remove them.
+         */
+        final Query query = membershipCache.createQuery()
+                .includeKeys()
+                .addCriteria(usernameSearchAttribute.eq(user.getEntityIdentifier().getKey()))
+                .end();
+        final List<Result> queryResults = query.execute().all();
+        for (Result r : queryResults) {
+            membershipCache.remove(r.getKey());
+        }
+
+        logger.debug("Purged {} PAGS membership cache entries for authenticated user '{}' in {}ms",
+                queryResults.size(), user.getUserName(), Long.toBinaryString(System.currentTimeMillis() - timestamp));
+
+    }
+
+}

--- a/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
@@ -61,9 +61,13 @@ public class PagsMembershipCacheAuthenticationListener implements IAuthenticatio
         usernameSearchAttribute = membershipCache.getSearchAttribute(SEARCH_ATTRIBUTE_NAME);
     }
 
-    @Override
-    public void userAuthenticateed(IPerson user) {
+    public void userAuthenticated(IPerson user) {
 
+        /*
+         * Used to log the time it takes to complete this operation;  the author
+         * has some anxiety about running time with large numbers of elements in
+         * the cache.
+         */
         final long timestamp = System.currentTimeMillis();
 
         /*

--- a/uportal-war/src/main/java/org/apereo/portal/services/Authentication.java
+++ b/uportal-war/src/main/java/org/apereo/portal/services/Authentication.java
@@ -21,6 +21,7 @@ package org.apereo.portal.services;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -74,6 +75,9 @@ public class Authentication {
     private IPortalAuthEventFactory portalEventFactory;
     private IPersonAttributeDao personAttributeDao;
     private UsernameTaggedCacheEntryPurger usernameTaggedCacheEntryPurger;
+
+    @Autowired
+    private Set<IAuthenticationListener> authenticationListeners;
 
     @Autowired
     public void setUsernameTaggedCacheEntryPurger(UsernameTaggedCacheEntryPurger usernameTaggedCacheEntryPurger) {
@@ -139,8 +143,19 @@ public class Authentication {
 
             threadNamingRequestFilter.updateCurrentUsername(userName);
 
-            //Clear all existing group data about the person
-            GroupService.finishedSession(person);
+            /*
+             * Clear cached group info for this user.
+             *
+             * There seem to be 2 systems in place for this information:
+             *   - The old system based on EntityCachingService
+             *   - The new system based on ehcache
+             *
+             * For uPortal 5, we should work to remove the old system.
+             */
+            GroupService.finishedSession(person);  // Old system
+            for (IAuthenticationListener authListener : authenticationListeners) {  // New system
+                authListener.userAuthenticateed(person);
+            }
 
             //Clear all existing cached data about the person
             this.usernameTaggedCacheEntryPurger.purgeTaggedCacheEntries(userName);

--- a/uportal-war/src/main/java/org/apereo/portal/services/Authentication.java
+++ b/uportal-war/src/main/java/org/apereo/portal/services/Authentication.java
@@ -154,7 +154,7 @@ public class Authentication {
              */
             GroupService.finishedSession(person);  // Old system
             for (IAuthenticationListener authListener : authenticationListeners) {  // New system
-                authListener.userAuthenticateed(person);
+                authListener.userAuthenticated(person);
             }
 
             //Clear all existing cached data about the person

--- a/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
@@ -28,6 +28,6 @@ import org.apereo.portal.security.IPerson;
  */
 public interface IAuthenticationListener {
 
-    void userAuthenticateed(IPerson user);
+    void userAuthenticated(IPerson user);
 
 }

--- a/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
@@ -24,7 +24,7 @@ import org.apereo.portal.security.IPerson;
 /**
  * Beans that implement this interface will be notified whenever a user authenticates.
  *
- * @author drewwills
+ * @since 5.0
  */
 public interface IAuthenticationListener {
 

--- a/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/apereo/portal/services/IAuthenticationListener.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.services;
+
+import org.apereo.portal.security.IPerson;
+
+/**
+ * Beans that implement this interface will be notified whenever a user authenticates.
+ *
+ * @author drewwills
+ */
+public interface IAuthenticationListener {
+
+    void userAuthenticateed(IPerson user);
+
+}

--- a/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/applicationContext.xml
@@ -28,7 +28,6 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-        
 
     <aop:aspectj-autoproxy/>
     
@@ -47,10 +46,7 @@
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.mvc\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.remoting\..+"/>
     </context:component-scan>
-    <!-- TODO:  Remove! -->
-    <context:component-scan base-package="org.jasig.portal">
-    </context:component-scan>
-    
+
     <bean id="primaryPropertyPlaceholderConfigurer" class="org.springframework.context.support.PortalPropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1983,7 +1983,11 @@
      +-->
     <cache name="org.apereo.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership"
            eternal="false" overflowToDisk="false" diskPersistent="false"
-           maxElementsInMemory="312500" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+           maxElementsInMemory="312500" timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true">
+        <searchable>
+            <searchAttribute name="memberId" class="org.apereo.portal.groups.pags.dao.EhcacheMemberIdAttributeExtractor"/>
+        </searchable>
+    </cache>
 
     <!--
      | Stores objects of type PagsGroup, which are the Hibernate/JPA-managed

--- a/uportal-war/src/test/java/org/apereo/portal/groups/GroupsCacheAuthenticationListenerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/groups/GroupsCacheAuthenticationListenerTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups;
+
+import java.util.Collections;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.PersonFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author drewwills
+ */
+public class GroupsCacheAuthenticationListenerTest {
+
+    @Test
+    public void testUserAuthenticated() {
+
+        final IPerson person = PersonFactory.createPerson();
+        person.setAttribute(IPerson.USERNAME, "mock.person");
+
+        final IEntityGroup group = new MockEntityGroup("mock.group", IPerson.class);
+
+        final CacheManager cacheManager = CacheManager.getInstance();
+
+        final Cache parentGroupsCache = new Cache(
+                "parentGroupsCache",
+                100,
+                false,
+                false,
+                0,
+                0);
+        cacheManager.addCache(parentGroupsCache);
+        parentGroupsCache.put(new Element(person.getEntityIdentifier(), Collections.singleton(group)));
+
+        final Cache childrenCache = new Cache(
+                "childrenCache",
+                100,
+                false,
+                false,
+                0,
+                0);
+        cacheManager.addCache(childrenCache);
+        childrenCache.put(new Element(group.getUnderlyingEntityIdentifier(), new Object()));
+
+        Assert.assertEquals(parentGroupsCache.getSize(), 1);
+        Assert.assertEquals(childrenCache.getSize(), 1);
+
+        final GroupsCacheAuthenticationListener listener = new GroupsCacheAuthenticationListener();
+        listener.setParentGroupsCache(parentGroupsCache);
+        listener.setChildrenCache(childrenCache);
+        listener.userAuthenticated(person);
+
+        Assert.assertEquals(parentGroupsCache.getSize(), 0);
+        Assert.assertEquals(childrenCache.getSize(), 0);
+
+    }
+
+}

--- a/uportal-war/src/test/java/org/apereo/portal/groups/GroupsCacheAuthenticationListenerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/groups/GroupsCacheAuthenticationListenerTest.java
@@ -67,7 +67,7 @@ public class GroupsCacheAuthenticationListenerTest {
         Assert.assertEquals(parentGroupsCache.getSize(), 1);
         Assert.assertEquals(childrenCache.getSize(), 1);
 
-        final GroupsCacheAuthenticationListener listener = new GroupsCacheAuthenticationListener();
+        final LocalGroupsCacheAuthenticationListener listener = new LocalGroupsCacheAuthenticationListener();
         listener.setParentGroupsCache(parentGroupsCache);
         listener.setChildrenCache(childrenCache);
         listener.userAuthenticated(person);

--- a/uportal-war/src/test/java/org/apereo/portal/groups/MockEntityGroup.java
+++ b/uportal-war/src/test/java/org/apereo/portal/groups/MockEntityGroup.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups;
+
+import java.util.Set;
+
+import javax.naming.Name;
+
+import org.apereo.portal.EntityIdentifier;
+import org.apereo.portal.IBasicEntity;
+
+/**
+ * @author drewwills
+ */
+public class MockEntityGroup implements IEntityGroup {
+
+    private final EntityIdentifier underlyingEntityIdentifier;
+
+    public MockEntityGroup(String groupKey, Class<? extends IBasicEntity> entityType) {
+        this.underlyingEntityIdentifier = new EntityIdentifier(groupKey, entityType);
+    }
+
+    @Override
+    public Set<IEntityGroup> getAncestorGroups() throws GroupsException {
+        return null;
+    }
+
+    @Override
+    public Set<IEntityGroup> getParentGroups() throws GroupsException {
+        return null;
+    }
+
+    @Override
+    public String getKey() {
+        return null;
+    }
+
+    @Override
+    public Class<? extends IBasicEntity> getLeafType() {
+        return null;
+    }
+
+    @Override
+    public Class getType() {
+        return null;
+    }
+
+    @Override
+    public EntityIdentifier getUnderlyingEntityIdentifier() {
+        return underlyingEntityIdentifier;
+    }
+
+    @Override
+    public boolean isDeepMemberOf(IEntityGroup group) throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isMemberOf(IEntityGroup group) throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public IEntityGroup asGroup() {
+        return null;
+    }
+
+    @Override
+    public boolean hasMembers() throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public boolean contains(IGroupMember gm) throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public boolean deepContains(IGroupMember gm) throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public Set<IGroupMember> getChildren() throws GroupsException {
+        return null;
+    }
+
+    @Override
+    public Set<IGroupMember> getDescendants() throws GroupsException {
+        return null;
+    }
+
+    @Override
+    public void addChild(IGroupMember gm) throws GroupsException {
+
+    }
+
+    @Override
+    public void delete() throws GroupsException {
+
+    }
+
+    @Override
+    public String getCreatorID() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public String getLocalKey() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Name getServiceName() {
+        return null;
+    }
+
+    @Override
+    public boolean isEditable() throws GroupsException {
+        return false;
+    }
+
+    @Override
+    public void removeChild(IGroupMember gm) throws GroupsException {
+
+    }
+
+    @Override
+    public void setCreatorID(String userID) {
+
+    }
+
+    @Override
+    public void setDescription(String name) {
+
+    }
+
+    @Override
+    public void setName(String name) throws GroupsException {
+
+    }
+
+    @Override
+    public void update() throws GroupsException {
+
+    }
+
+    @Override
+    public void updateMembers() throws GroupsException {
+
+    }
+
+    @Override
+    public void setLocalGroupService(IIndividualGroupService groupService) throws GroupsException {
+
+    }
+
+    @Override
+    public EntityIdentifier getEntityIdentifier() {
+        return null;
+    }
+}

--- a/uportal-war/src/test/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractorTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractorTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.groups.pags.dao;
+
+import net.sf.ehcache.Element;
+import org.apereo.portal.EntityIdentifier;
+import org.apereo.portal.security.IPerson;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author drewwills
+ */
+public class EhcacheMemberIdAttributeExtractorTest {
+
+    @Test
+    public void testAttributeFor() {
+        final EntityIdentifier parentEntityIdentifier = new EntityIdentifier("mock.group", IPerson.class);
+        final String memberId = "mock.user";
+        final EntityIdentifier childEntityIdentifier = new EntityIdentifier(memberId, IPerson.class);
+        final MembershipCacheKey membershipCacheKey = new MembershipCacheKey(parentEntityIdentifier, childEntityIdentifier);
+        final Element element = new Element(membershipCacheKey, new Object());
+        final EhcacheMemberIdAttributeExtractor attributeExtractor = new EhcacheMemberIdAttributeExtractor();
+        Assert.assertEquals(attributeExtractor.attributeFor(element, null), memberId);
+    }
+
+}


### PR DESCRIPTION
…e not invalidated when that user authenticates

https://issues.jasig.org/browse/UP-4790

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement] is signed
-   [x] commit message follows [commit guidelines]

##### Description of change
<!-- Provide a description of the change below this comment. -->

We have some use cases that involve passing parameters to the login process that drive user attributes and (in turn) group affiliations.  We are having trouble because group affiliations are very aggressively cached.

In other words, your attributes may be different from one authentication to the next, but the changes are ignored as far as calculating you group affiliations... because the group affiliations are not recalculated (they are taken from cache).

Just like the layout DOM and a few other items in the portal, we need to remove the cache elements that tie you to groups whenever you authenticate.

<!-- Reference Links -->
[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
