### PR TITLE
UP-4790:  (rel-4-3-patches branch) Cache entries that establish a user's group affiliations ar…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/GroupsCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/GroupsCacheAuthenticationListener.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.groups;
+
+import java.util.Set;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+import org.jasig.portal.EntityIdentifier;
+import org.jasig.portal.security.IPerson;
+import org.jasig.portal.services.IAuthenticationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Responsible for removing some membership-related cache entries when a user
+ * authenticates so they can be evaluated afresh.
+ *
+ * @author drewwills
+ */
+@Component
+public class GroupsCacheAuthenticationListener implements IAuthenticationListener {
+
+    @Autowired
+    @Qualifier(value = "org.jasig.portal.groups.GroupMemberImpl.parentGroups")
+    private Cache parentGroupsCache;
+
+    @Autowired
+    @Qualifier(value = "org.jasig.portal.groups.EntityGroupImpl.children")
+    private Cache childrenCache;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void userAuthenticateed(IPerson user) {
+
+        final long timestamp = System.currentTimeMillis();
+
+        /*
+         * Group/member relationships are cached 2 ways:  child-to-parents and
+         * parent-to-children.  We need to flush both.
+         */
+        final EntityIdentifier ei = user.getEntityIdentifier();
+        final Element parentGroupsElement = parentGroupsCache.get(ei);
+        if (parentGroupsElement != null) {
+            // We have some flushing work to do...
+            int numPurged = 1;
+            final Set<IEntityGroup> parentGroups = (Set<IEntityGroup>) parentGroupsElement.getObjectValue();
+            for (IEntityGroup group : parentGroups) {
+                final EntityIdentifier uei = group.getUnderlyingEntityIdentifier();
+                if (childrenCache.remove(uei)) {
+                    ++numPurged;
+                }
+            }
+            parentGroupsCache.remove(ei);
+            logger.debug("Purged {} local group cache entries for authenticated user '{}' in {}ms",
+                    numPurged, user.getUserName(), Long.toBinaryString(System.currentTimeMillis() - timestamp));
+        }
+
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/groups/GroupsCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/GroupsCacheAuthenticationListener.java
@@ -52,7 +52,7 @@ public class GroupsCacheAuthenticationListener implements IAuthenticationListene
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
-    public void userAuthenticateed(IPerson user) {
+    public void userAuthenticated(IPerson user) {
 
         final long timestamp = System.currentTimeMillis();
 

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EhcacheMemberIdAttributeExtractor.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.groups.pags.dao;
+
+import net.sf.ehcache.Element;
+import net.sf.ehcache.search.attribute.AttributeExtractor;
+import net.sf.ehcache.search.attribute.AttributeExtractorException;
+import org.jasig.portal.EntityIdentifier;
+
+/**
+ * Used within Ehcache to find keys that reference the specified username.
+ *
+ * @author drewwills
+ */
+public class EhcacheMemberIdAttributeExtractor implements AttributeExtractor {
+
+    @Override
+    public Object attributeFor(Element element, String attributeName) throws AttributeExtractorException {
+        final MembershipCacheKey membershipCacheKey = (MembershipCacheKey) element.getObjectKey();
+        final EntityIdentifier ei = membershipCacheKey.getMemberId();
+        return ei.getKey();
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/EntityPersonAttributesGroupStore.java
@@ -18,7 +18,6 @@
  */
 package org.jasig.portal.groups.pags.dao;
 
-import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -118,7 +117,7 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
             }
         }
 
-        final MembershipCacheKey cacheKey = new MembershipCacheKey(group.getEntityIdentifier(), member.getEntityIdentifier());
+        final MembershipCacheKey cacheKey = new MembershipCacheKey(group.getEntityIdentifier(), member.getUnderlyingEntityIdentifier());
         Element element = membershipCache.get(cacheKey);
         if (element == null) {
 
@@ -446,60 +445,6 @@ public class EntityPersonAttributesGroupStore implements IEntityGroupStore, IEnt
         }
         final IPersonAttributesGroupDefinition rslt = pagsGroups.isEmpty() ? null : pagsGroups.iterator().next();
         return rslt;
-    }
-
-    /*
-     * Nested Types
-     */
-
-    private static final class MembershipCacheKey implements Serializable {
-
-        private static final long serialVersionUID = 1L;
-
-        private final EntityIdentifier groupId;
-        private final EntityIdentifier memberId;
-
-        public MembershipCacheKey(final EntityIdentifier groupId, final EntityIdentifier memberId) {
-            this.groupId = groupId;
-            this.memberId = memberId;
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
-            result = prime * result + ((memberId == null) ? 0 : memberId.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            MembershipCacheKey other = (MembershipCacheKey) obj;
-            if (groupId == null) {
-                if (other.groupId != null)
-                    return false;
-            } else if (!groupId.equals(other.groupId))
-                return false;
-            if (memberId == null) {
-                if (other.memberId != null)
-                    return false;
-            } else if (!memberId.equals(other.memberId))
-                return false;
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return "MembershipCacheKey [groupId=" + groupId + ", memberId=" + memberId + "]";
-        }
-
     }
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/MembershipCacheKey.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/MembershipCacheKey.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.groups.pags.dao;
+
+import java.io.Serializable;
+
+import org.jasig.portal.EntityIdentifier;
+
+/**
+ * @author drewwills
+ */
+/* package-private */ final class MembershipCacheKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final EntityIdentifier groupId;
+    private final EntityIdentifier memberId;
+
+    public MembershipCacheKey(final EntityIdentifier groupId, final EntityIdentifier memberId) {
+        this.groupId = groupId;
+        this.memberId = memberId;
+    }
+
+    public EntityIdentifier getGroupId() {
+        return groupId;
+    }
+
+    public EntityIdentifier getMemberId() {
+        return memberId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
+        result = prime * result + ((memberId == null) ? 0 : memberId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MembershipCacheKey other = (MembershipCacheKey) obj;
+        if (groupId == null) {
+            if (other.groupId != null)
+                return false;
+        } else if (!groupId.equals(other.groupId))
+            return false;
+        if (memberId == null) {
+            if (other.memberId != null)
+                return false;
+        } else if (!memberId.equals(other.memberId))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "MembershipCacheKey [groupId=" + groupId + ", memberId=" + memberId + "]";
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.groups.pags.dao;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.search.Attribute;
+import net.sf.ehcache.search.Query;
+import net.sf.ehcache.search.Result;
+import org.jasig.portal.security.IPerson;
+import org.jasig.portal.services.IAuthenticationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Responsible for flushing PAGS membership-related cache entries when a user
+ * authenticates so they can be evaluated afresh.  Users may have different
+ * attributes -- and therefore different PAGS affiliations -- based on
+ * information passed to the authentication process.
+ *
+ * @author drewwills
+ */
+@Component
+public class PagsMembershipCacheAuthenticationListener implements IAuthenticationListener {
+
+    private static final String SEARCH_ATTRIBUTE_NAME = "memberId";
+
+    @Autowired
+    @Qualifier(value = "org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership")
+    private Cache membershipCache;
+
+    private Attribute<String> usernameSearchAttribute;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostConstruct
+    public void init() {
+        usernameSearchAttribute = membershipCache.getSearchAttribute(SEARCH_ATTRIBUTE_NAME);
+    }
+
+    @Override
+    public void userAuthenticateed(IPerson user) {
+
+        final long timestamp = System.currentTimeMillis();
+
+        /*
+         * Query the membershipCache (ehcache) for elements that
+         * reference the specified user and remove them.
+         */
+        final Query query = membershipCache.createQuery()
+                .includeKeys()
+                .addCriteria(usernameSearchAttribute.eq(user.getEntityIdentifier().getKey()))
+                .end();
+        final List<Result> queryResults = query.execute().all();
+        for (Result r : queryResults) {
+            membershipCache.remove(r.getKey());
+        }
+
+        logger.debug("Purged {} PAGS membership cache entries for authenticated user '{}' in {}ms",
+                queryResults.size(), user.getUserName(), Long.toBinaryString(System.currentTimeMillis() - timestamp));
+
+    }
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/PagsMembershipCacheAuthenticationListener.java
@@ -62,7 +62,7 @@ public class PagsMembershipCacheAuthenticationListener implements IAuthenticatio
     }
 
     @Override
-    public void userAuthenticateed(IPerson user) {
+    public void userAuthenticated(IPerson user) {
 
         final long timestamp = System.currentTimeMillis();
 

--- a/uportal-war/src/main/java/org/jasig/portal/services/Authentication.java
+++ b/uportal-war/src/main/java/org/jasig/portal/services/Authentication.java
@@ -155,7 +155,7 @@ public class Authentication {
              */
             GroupService.finishedSession(person);  // Old system
             for (IAuthenticationListener authListener : authenticationListeners) {  // New system
-                authListener.userAuthenticateed(person);
+                authListener.userAuthenticated(person);
             }
 
             //Clear all existing cached data about the person

--- a/uportal-war/src/main/java/org/jasig/portal/services/IAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/services/IAuthenticationListener.java
@@ -28,6 +28,6 @@ import org.jasig.portal.security.IPerson;
  */
 public interface IAuthenticationListener {
 
-    void userAuthenticateed(IPerson user);
+    void userAuthenticated(IPerson user);
 
 }

--- a/uportal-war/src/main/java/org/jasig/portal/services/IAuthenticationListener.java
+++ b/uportal-war/src/main/java/org/jasig/portal/services/IAuthenticationListener.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.services;
+
+import org.jasig.portal.security.IPerson;
+
+/**
+ * Beans that implement this interface will be notified whenever a user authenticates.
+ *
+ * @author drewwills
+ */
+public interface IAuthenticationListener {
+
+    void userAuthenticateed(IPerson user);
+
+}

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -1942,7 +1942,11 @@
      +-->
     <cache name="org.jasig.portal.groups.pags.dao.EntityPersonAttributesGroupStore.membership"
            eternal="false" overflowToDisk="false" diskPersistent="false"
-           maxElementsInMemory="50000" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true"/>
+           maxElementsInMemory="50000" timeToIdleSeconds="0" timeToLiveSeconds="180" memoryStoreEvictionPolicy="LRU" statistics="true">
+        <searchable>
+            <searchAttribute name="memberId" class="org.jasig.portal.groups.pags.dao.EhcacheMemberIdAttributeExtractor"/>
+        </searchable>
+    </cache>
 
     <!-- PAGS Store Cache, not replicated -->
     <cache name="org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupDefinitionImpl"


### PR DESCRIPTION
…e not invalidated when that user authenticates

https://issues.jasig.org/browse/UP-4790

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement] is signed
-   [x] commit message follows [commit guidelines]

##### Description of change
<!-- Provide a description of the change below this comment. -->

We have some use cases that involve passing parameters to the login process that drive user attributes and (in turn) group affiliations.  We are having trouble because group affiliations are very aggressively cached.

In other words, your attributes may be different from one authentication to the next, but the changes are ignored as far as calculating you group affiliations... because the group affiliations are not recalculated (they are taken from cache).

Just like the layout DOM and a few other items in the portal, we need to remove the cache elements that tie you to groups whenever you authenticate.

<!-- Reference Links -->
[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
