### PR TITLE
NOJIRA: Upgrade from Font Awesome 4.0.3 to 4.7.0

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
@@ -28,8 +28,8 @@
   <css included="plain">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.min.css</css>
 
-  <css included="plain">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fontawesome/4.7.0/css/font-awesome.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
 
   <css included="plain" resource="true">/rs/bootstrap-plugins/accessibility/1.0.2/css/bootstrap-accessibility.css</css>
   <css included="aggregated" resource="true">/rs/bootstrap-plugins/accessibility/1.0.2/css/bootstrap-accessibility.min.css</css>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement] is signed
-   [x] commit message follows [commit guidelines]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Upgrades Font Awesome from 4.0.3 to 4.7.0 adding even more awesomeness.

From https://github.com/Jasig/resource-server/pull/46

> https://issues.jasig.org/browse/RESSERV-91
>
> Font Awesome 4.7 adds accessibility icons and additional documentation for making icon usage accessible. (http://fontawesome.io/whats-new/)
> Font Awesome 4.7.x will also likely be the last minor release of the 4.x series.

##### SemVer Note

This would be a candidate for cherry picking to `rel-4-3-patches`.

<!-- Reference Links -->
[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
