### PR TITLE
UP-4792:  Provide an annotation-based mechanism for soffits based on …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,11 @@ buildScan {
 }
 
 subprojects {
-    apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'checkstyle'
     apply plugin: 'findbugs'
+    apply plugin: 'idea'
+    apply plugin: 'java'
+    apply plugin: 'maven'
 
     repositories {
         mavenLocal()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,24 +1,32 @@
 # uPortal Documentation
 
-## Pages
+**NOTE:**  This area is a work-in-progress.  It is intended to serve as primary
+documentation for uPortal version 5.0 (expected mid-2017) and above.
+Documentation for earlier versions of uPortal is availabe in
+[Confluence](https://wiki.jasig.org).  See *Documentation for Previous Releases*
+below.
 
-*   [Ant Help](antHelp.txt)
-*   [Skinning uPortal](SKINNING_UPORTAL.md)
-*   [Using Angular](USING_ANGULAR.md)
-*   [Supported web browsers](SUPPORTED_BROWSERS.md)
-*   [Configuring using JNDI](configure-using-jndi.md)
+## Sections
+
+* [Ant Help](antHelp.txt)
+* [Implementing uPortal](implement/README.md)
+* [Skinning uPortal](SKINNING_UPORTAL.md)
+* [Using Angular](USING_ANGULAR.md)
+* [Supported web browsers](SUPPORTED_BROWSERS.md)
+* [Configuring using JNDI](configure-using-jndi.md)
+* [Developer's Guide](developer/README.md)
 
 ## External Links
 
-*   [Apereo Foundation Home](https://www.apereo.org/)
-*   [uPortal Wiki](https://wiki.jasig.org/display/UPC/Home)
+* [Apereo Foundation Home](https://www.apereo.org/)
+* [uPortal Wiki](https://wiki.jasig.org/display/UPC/Home)
 
 ## Documentation for Previous Releases
 
-*   [uPortal 4.3](https://wiki.jasig.org/display/UPM43/Home)
-*   [uPortal 4.2](https://wiki.jasig.org/display/UPM42/Home)
-*   [uPortal 4.1](https://wiki.jasig.org/display/UPM41/Home)
-*   [uPortal 4.0](https://wiki.jasig.org/display/UPM40/Home)
-*   [uPortal 3.2](https://wiki.jasig.org/display/UPM32/Home)
-*   [uPortal 3.1](https://wiki.jasig.org/display/UPM31/Home)
-*   [uPortal 3.0](https://wiki.jasig.org/display/UPM30/Home)
+* [uPortal 4.3](https://wiki.jasig.org/display/UPM43/Home)
+* [uPortal 4.2](https://wiki.jasig.org/display/UPM42/Home)
+* [uPortal 4.1](https://wiki.jasig.org/display/UPM41/Home)
+* [uPortal 4.0](https://wiki.jasig.org/display/UPM40/Home)
+* [uPortal 3.2](https://wiki.jasig.org/display/UPM32/Home)
+* [uPortal 3.1](https://wiki.jasig.org/display/UPM31/Home)
+* [uPortal 3.0](https://wiki.jasig.org/display/UPM30/Home)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,6 @@
+# Developer's Guide
+
+This section covers topics related to developing source code for uPortal -- both
+uPortal Framework sources and content modules for uPortal.
+
+1. [uPortal Soffits](soffits/README.md)

--- a/docs/developer/soffits/README.md
+++ b/docs/developer/soffits/README.md
@@ -1,0 +1,46 @@
+# uPortal Soffits
+
+Soffit is a technology for creating content that runs in [Apereo uPortal][].  It
+is intended as an alternative to [JSR-286 portlet development][].
+
+## Why Would I Want Soffits?
+
+You are a Java web application developer.  You are tasked with developing content
+for [Apereo uPortal]].
+
+You are not excited about doing Java Portlet development
+[in the traditional way][] or even using [Spring Portlet MVC][].  You correctly
+conclude that the Java Portlet APIs are _large_, _obtuse_, and _actively
+interfere_ with contemporary web development practices and frameworks that you
+want to be using.
+
+Apereo Soffit is an alternative approach to producing content for uPortal that
+is not based on JSR-286 or the portlet container.
+
+## Topics
+
+1. Minimal Soffit
+1. Publishing a Soffit
+1. Soffit Data Model
+1. Configuration Options
+
+## A Word on Modern Web User Interfaces
+
+Soffit assumes that you want to develop user interfaces using Javascript and
+modern frameworks like [React][], [AngularJS][], [Backbone.js][], _etc_.
+Normally a Soffit component will render one time;  considerations like state
+changes, transactions, persistence, _etc_. are typically handled with Javascript
+and REST.
+
+## Sample Soffit Applications
+
+There are several sample applications in [this repo][].
+
+[Apereo uPortal]: https://www.apereo.org/projects/uportal
+[JSR-286 portlet development]: https://jcp.org/en/jsr/detail?id=286
+[in the traditional way]: http://www.theserverside.com/tutorial/JSR-286-development-tutorial-An-introduction-to-portlet-programming
+[Spring Portlet MVC]: http://docs.spring.io/autorepo/docs/spring/3.2.x/spring-framework-reference/html/portlet.html
+[React]: https://facebook.github.io/react/
+[AngularJS]: https://angularjs.org/
+[Backbone.js]: http://backbonejs.org/
+[this repo]: https://github.com/drewwills/soffit-samples

--- a/docs/developer/soffits/README.md
+++ b/docs/developer/soffits/README.md
@@ -6,7 +6,7 @@ is intended as an alternative to [JSR-286 portlet development][].
 ## Why Would I Want Soffits?
 
 You are a Java web application developer.  You are tasked with developing content
-for [Apereo uPortal]].
+for [Apereo uPortal][].
 
 You are not excited about doing Java Portlet development
 [in the traditional way][] or even using [Spring Portlet MVC][].  You correctly
@@ -19,10 +19,10 @@ is not based on JSR-286 or the portlet container.
 
 ## Topics
 
-1. Minimal Soffit
-1. Publishing a Soffit
-1. Soffit Data Model
-1. Configuration Options
+1. [Minimal Soffit](minimal_soffit.md)
+1. [Publishing a Soffit](publishing_a_soffit.md)
+1. [Soffit Data Model](soffit_data_model.md)
+1. [Configuration Options](configuration_options.md)
 
 ## A Word on Modern Web User Interfaces
 
@@ -30,7 +30,7 @@ Soffit assumes that you want to develop user interfaces using Javascript and
 modern frameworks like [React][], [AngularJS][], [Backbone.js][], _etc_.
 Normally a Soffit component will render one time;  considerations like state
 changes, transactions, persistence, _etc_. are typically handled with Javascript
-and REST.
+and REST APIs.
 
 ## Sample Soffit Applications
 

--- a/docs/developer/soffits/README.md
+++ b/docs/developer/soffits/README.md
@@ -20,9 +20,9 @@ is not based on JSR-286 or the portlet container.
 ## Topics
 
 1. [Minimal Soffit](minimal_soffit.md)
-1. [Publishing a Soffit](publishing_a_soffit.md)
-1. [Soffit Data Model](soffit_data_model.md)
-1. [Configuration Options](configuration_options.md)
+2. [Publishing a Soffit](publishing_a_soffit.md)
+3. [Soffit Data Model](soffit_data_model.md)
+4. [Configuration Options](configuration_options.md)
 
 ## A Word on Modern Web User Interfaces
 

--- a/docs/developer/soffits/configuration_options.md
+++ b/docs/developer/soffits/configuration_options.md
@@ -1,0 +1,27 @@
+# Configuration Options
+
+## Caching
+
+Caching in soffits is available _via_ the standard HTTP header `Cache-Control`.
+
+### Example
+
+``` http
+Cache-Control: public, max-age=300
+```
+
+Cache scope may be `public` (shared by all users) or `private` (cached per-user).  Specify `max-age` in seconds.
+
+Cache re-validation is not yet supported, so...
+
+``` http
+Cache-Control: no-store
+```
+
+and...
+
+``` http
+Cache-Control: no-cache
+```
+
+currently have the same effect.

--- a/docs/developer/soffits/configuration_options.md
+++ b/docs/developer/soffits/configuration_options.md
@@ -2,7 +2,9 @@
 
 ## Caching
 
-Caching in soffits is available _via_ the standard HTTP header `Cache-Control`.
+Caching soffit content in the portal is available _via_ the standard HTTP header
+`Cache-Control`.  You must set `Cache-Control` as an HTTP response header to
+take advantage of this feature.
 
 ### Example
 
@@ -10,7 +12,8 @@ Caching in soffits is available _via_ the standard HTTP header `Cache-Control`.
 Cache-Control: public, max-age=300
 ```
 
-Cache scope may be `public` (shared by all users) or `private` (cached per-user).  Specify `max-age` in seconds.
+Cache scope may be `public` (shared by all users) or `private` (cached
+per-user).  Specify `max-age` in seconds.
 
 Cache re-validation is not yet supported, so...
 

--- a/docs/developer/soffits/minimal_soffit.md
+++ b/docs/developer/soffits/minimal_soffit.md
@@ -1,0 +1,72 @@
+
+# Minimal Soffit
+
+A soffit's interaction with the portal is HTTP-based.  It is posible to write a
+soffit in any language or platform that can accept, process, and respond to a
+connection over HTTP.  At the present time, the creators of Soffit expect to
+develop soffits mostly with [Java][] and [Spring Boot][].
+
+## Minimal Soffit Setup Instructions Using Spring Boot
+
+1. Use the [Spring Initializer][] to create a new Spring Boot project with the
+   following settings:
+    * Gradle Project (recommended)
+    * Packaging=*War* (recommended)
+    * Dependencies=*Cache* (recommended) & *Web* (required)
+    * Additional dependencies you intend to use (optional -- you can add them
+      later)
+1. Add Soffit as a dependency to your project (see below)
+1. Add the `tomcat-embed-jasper` dependency to your project (see below)
+1. Add the `@SoffitApplication` annotation to your application class (the one
+   annotated with `@SpringBootApplication`)
+1. Create the directory path `src/main/webapp/WEB-INF/soffit/`
+1. Choose a name for your soffit and create a directory with that name inside
+   `/soffit/` (above);  recommended:  use only lowercase letters and dashes
+   ('-') in the name
+1. Create a `view.jsp` file inside the directory named for your soffit;  add
+   your markup (_e.g._ `<h2>Hello World!</h2>`)
+1. In `src/main/resources/application.properties`, define the `server.port`
+   property and set it to an unused port (like 8090)
+1. Run the command `$gradle assemble` to build your application
+1. Run the command `$java -jar build/lib/{filename}.war` to start your
+   application
+
+That's it!  You now have a functioning, minimal Soffit application running on
+`localhost` at `server.port` (specify as a `-D` parameter or configure in
+`application.properties`).
+
+##### Adding the Soffit dependency
+
+Gradle Example:
+
+``` gradle
+compile("org.jasig.portal:uPortal-soffit-renderer:${soffitVersion}")
+```
+
+Maven Example:
+
+``` xml
+<dependency>
+    <groupId>org.jasig.portal</groupId>
+    <artifactId>uPortal-soffit-renderer</artifactId>
+    <version>${soffitVersion}</version>
+</dependency>
+```
+
+##### Adding the `tomcat-embed-jasper` dependency
+
+Gradle Example:
+
+``` gradle
+configurations {
+    providedRuntime
+}
+
+[...]
+
+providedRuntime('org.apache.tomcat.embed:tomcat-embed-jasper')
+```
+
+[Java]: http://www.oracle.com/technetwork/java/index.html
+[Spring Boot]: http://projects.spring.io/spring-boot/
+[Spring Initializer]: https://start.spring.io/

--- a/docs/developer/soffits/minimal_soffit.md
+++ b/docs/developer/soffits/minimal_soffit.md
@@ -32,10 +32,9 @@ develop soffits mostly with [Java][] and [Spring Boot][].
    application
 
 That's it!  You now have a functioning, minimal Soffit application running on
-`localhost` at `server.port` (specify as a `-D` parameter or configure in
-`application.properties`).
+`localhost` at `server.port`.
 
-##### Adding the Soffit dependency
+### Adding the Soffit dependency
 
 Gradle Example:
 
@@ -53,7 +52,7 @@ Maven Example:
 </dependency>
 ```
 
-##### Adding the `tomcat-embed-jasper` dependency
+### Adding the `tomcat-embed-jasper` dependency
 
 Gradle Example:
 

--- a/docs/developer/soffits/minimal_soffit.md
+++ b/docs/developer/soffits/minimal_soffit.md
@@ -8,28 +8,28 @@ develop soffits mostly with [Java][] and [Spring Boot][].
 
 ## Minimal Soffit Setup Instructions Using Spring Boot
 
-1. Use the [Spring Initializer][] to create a new Spring Boot project with the
-   following settings:
+1.  Use the [Spring Initializer][] to create a new Spring Boot project with the
+    following settings:
     * Gradle Project (recommended)
     * Packaging=*War* (recommended)
     * Dependencies=*Cache* (recommended) & *Web* (required)
     * Additional dependencies you intend to use (optional -- you can add them
       later)
-1. Add Soffit as a dependency to your project (see below)
-1. Add the `tomcat-embed-jasper` dependency to your project (see below)
-1. Add the `@SoffitApplication` annotation to your application class (the one
-   annotated with `@SpringBootApplication`)
-1. Create the directory path `src/main/webapp/WEB-INF/soffit/`
-1. Choose a name for your soffit and create a directory with that name inside
-   `/soffit/` (above);  recommended:  use only lowercase letters and dashes
-   ('-') in the name
-1. Create a `view.jsp` file inside the directory named for your soffit;  add
-   your markup (_e.g._ `<h2>Hello World!</h2>`)
-1. In `src/main/resources/application.properties`, define the `server.port`
-   property and set it to an unused port (like 8090)
-1. Run the command `$gradle assemble` to build your application
-1. Run the command `$java -jar build/lib/{filename}.war` to start your
-   application
+2.  Add Soffit as a dependency to your project (see below)
+3.  Add the `tomcat-embed-jasper` dependency to your project (see below)
+4.  Add the `@SoffitApplication` annotation to your application class (the one
+    annotated with `@SpringBootApplication`)
+5.  Create the directory path `src/main/webapp/WEB-INF/soffit/`
+6.  Choose a name for your soffit and create a directory with that name inside
+    `/soffit/` (above);  recommended:  use only lowercase letters and dashes
+    ('-') in the name
+7.  Create a `view.jsp` file inside the directory named for your soffit;  add
+    your markup (_e.g._ `<h2>Hello World!</h2>`)
+8.  In `src/main/resources/application.properties`, define the `server.port`
+    property and set it to an unused port (like 8090)
+9.  Run the command `$ gradle assemble` to build your application
+10. Run the command `$ java -jar build/lib/{filename}.war` to start your
+    application
 
 That's it!  You now have a functioning, minimal Soffit application running on
 `localhost` at `server.port`.

--- a/docs/developer/soffits/publishing_a_soffit.md
+++ b/docs/developer/soffits/publishing_a_soffit.md
@@ -1,0 +1,21 @@
+# Publishing a Soffit
+
+Follow these steps to view your soffit in uPortal.
+
+## In the Portlet Manager
+
+1. Select _Register New Portlet_
+1. Choose _Portlet_ in the list of types and click _Continue_
+1. Select _/uPortal_ and _Soffit Connector_ in the Summary Information screen
+   and click _Continue_
+1. Enter portlet metadata normally (_e.g._ name, tile, fname, groups,
+   categories, lifecycle state, _etc._)
+1. Under Portlet Preferences, override the value of
+   `org.apereo.portal.soffit.connector.SoffitConnectorController.serviceUrl`
+   with the URL of your soffit, _e.g._ `http://localhost:8090/soffit/my-soffit`
+   running independently (outside Tomcat) or
+   `http://localhost:8080/my-porject/soffit/my-soffit` running inside Tomcat
+1. Click _Save_
+
+After completing these steps, you should be able to find your soffit using the
+Search interface or add it to your layout with the Personalization Gallery.

--- a/docs/developer/soffits/publishing_a_soffit.md
+++ b/docs/developer/soffits/publishing_a_soffit.md
@@ -5,17 +5,17 @@ Follow these steps to view your soffit in uPortal.
 ## In the Portlet Manager
 
 1. Select _Register New Portlet_
-1. Choose _Portlet_ in the list of types and click _Continue_
-1. Select _/uPortal_ and _Soffit Connector_ in the Summary Information screen
+2. Choose _Portlet_ in the list of types and click _Continue_
+3. Select _/uPortal_ and _Soffit Connector_ in the Summary Information screen
    and click _Continue_
-1. Enter portlet metadata normally (_e.g._ name, tile, fname, groups,
+4. Enter portlet metadata normally (_e.g._ name, tile, fname, groups,
    categories, lifecycle state, _etc._)
-1. Under Portlet Preferences, override the value of
+5. Under Portlet Preferences, override the value of
    `org.apereo.portal.soffit.connector.SoffitConnectorController.serviceUrl`
    with the URL of your soffit, _e.g._ `http://localhost:8090/soffit/my-soffit`
    running independently (outside Tomcat) or
    `http://localhost:8080/my-porject/soffit/my-soffit` running inside Tomcat
-1. Click _Save_
+6. Click _Save_
 
 After completing these steps, you should be able to find your soffit using the
 Search interface or add it to your layout with the Personalization Gallery.

--- a/docs/developer/soffits/soffit_data_model.md
+++ b/docs/developer/soffits/soffit_data_model.md
@@ -4,14 +4,14 @@ To be of any use, real soffits must go beyond _Hello World!_  Soffit provides a
 rich data model for sharing data from the portal with your application.  There
 are (currently) four objects in this data model:
 
-* The [`Bearer`][] contains information about the user:  _username_,
+* The [Bearer][] contains information about the user:  _username_,
   _user attributes_, and _group affiliations_ in the portal
-* The [`PortalRequest`][] contains information about the request your soffit is
+* The [PortalRequest][] contains information about the request your soffit is
   filling, like _parameters_, _mode_, and _window state_
-* The [`Preferences`][] object contains a collection of publish-time settings
+* The [Preferences][] object contains a collection of publish-time settings
   for your soffit chosen by the administrator;  these are options you define for
   your needs;  using preferences is optional
-* The [`Definition`][] contains publish-time metadata about your soffit in the
+* The [Definition][] contains publish-time metadata about your soffit in the
   portal;  these are settings defined by and consumed by the portal itself, like
   _title_ and _chrome style_
 
@@ -29,7 +29,7 @@ example...
 
 Sometimes the Data Model provided by Soffit is not enough -- sometimes you need
 to define your own objects for rendering a JSP.  For Spring Boot-based Soffit
-applications, the [`@SoffitModelAttribute`] annotation satisfies this need.
+applications, the [@SoffitModelAttribute][] annotation satisfies this need.
 
 ### `@SoffitModelAttribute` Examples
 

--- a/docs/developer/soffits/soffit_data_model.md
+++ b/docs/developer/soffits/soffit_data_model.md
@@ -21,7 +21,7 @@ Each of these objects is defined within the Expression Language (EL) Context in
 which your `.jsp` files execute.  Use camel-case spelling to reference them, for
 example...
 
-```jsp
+``` jsp
 <h2>Hello ${bearer.username}</h2>
 ```
 
@@ -36,7 +36,7 @@ applications, the [@SoffitModelAttribute][] annotation satisfies this need.
 Annotate a Spring bean with `@SoffitModelAttribute` to make the entire bean
 available within your JSP.
 
-```
+``` java
 @SoffitModelAttribute("settings")
 @Component
 public class Settings {
@@ -51,7 +51,7 @@ public class Settings {
 Annotate a method on a Spring bean with `@SoffitModelAttribute` to have Soffit
 invoke the method and make the return value available within your JSP.
 
-```
+``` java
 @Component
 public class Attributes {
 

--- a/docs/developer/soffits/soffit_data_model.md
+++ b/docs/developer/soffits/soffit_data_model.md
@@ -1,0 +1,87 @@
+# Soffit Data Model
+
+To be of any use, real soffits must go beyond _Hello World!_  Soffit provides a
+rich data model for sharing data from the portal with your application.  There
+are (currently) four objects in this data model:
+
+* The [`Bearer`][] contains information about the user:  _username_,
+  _user attributes_, and _group affiliations_ in the portal
+* The [`PortalRequest`][] contains information about the request your soffit is
+  filling, like _parameters_, _mode_, and _window state_
+* The [`Preferences`][] object contains a collection of publish-time settings
+  for your soffit chosen by the administrator;  these are options you define for
+  your needs;  using preferences is optional
+* The [`Definition`][] contains publish-time metadata about your soffit in the
+  portal;  these are settings defined by and consumed by the portal itself, like
+  _title_ and _chrome style_
+
+## Accessing Data Model Objects in a JSP
+
+Each of these objects is defined within the Expression Language (EL) Context in
+which your `.jsp` files execute.  Use camel-case spelling to reference them, for
+example...
+
+```jsp
+<h2>Hello ${bearer.username}</h2>
+```
+
+## The `@SoffitModelAttribute` Annotation
+
+Sometimes the Data Model provided by Soffit is not enough -- sometimes you need
+to define your own objects for rendering a JSP.  For Spring Boot-based Soffit
+applications, the [`@SoffitModelAttribute`] annotation satisfies this need.
+
+### `@SoffitModelAttribute` Examples
+
+Annotate a Spring bean with `@SoffitModelAttribute` to make the entire bean
+available within your JSP.
+
+```
+@SoffitModelAttribute("settings")
+@Component
+public class Settings {
+
+    public int getMaxNumber() {
+        return 100;
+    }
+
+}
+```
+
+Annotate a method on a Spring bean with `@SoffitModelAttribute` to have Soffit
+invoke the method and make the return value available within your JSP.
+
+```
+@Component
+public class Attributes {
+
+    @SoffitModelAttribute("bearerJson")
+    public String getBearerJson(Bearer bearer) {
+        String rslt = null;
+        try {
+            rslt = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(bearer);
+        } catch (JsonProcessingException e) {
+            final String msg = "Unable to write the Bearer object to JSON";
+            throw new RuntimeException(msg, e);
+        }
+        return rslt;
+    }
+
+}
+```
+
+Signatures of methods annotated with `@SoffitModelAttribute` are flexible;  you
+may take any, all, or none of the following objects as parameters, in any order:
+
+* `HttpServletRequest`
+* `HttpServletResponse`
+* `Bearer`
+* `PortalRequest`
+* `Preferences`
+* `Definition`
+
+[Bearer]: ../../../uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
+[PortalRequest]: ../../../uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
+[Preferences]: ../../../uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
+[Definition]: ../../../uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
+[@SoffitModelAttribute]: ../../../uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java

--- a/docs/implement/README.md
+++ b/docs/implement/README.md
@@ -4,7 +4,7 @@ This section covers topics related to implementing the portal:  adding your
 users, groups, layouts, *etc.*
 
 1. Authentication (TBD)
-1. User Attributes (TBD)
-1. Groups and Permissions (TBD)
-1. Layout Management (TBD)
-1. Content (TBD)
+2. User Attributes (TBD)
+3. Groups and Permissions (TBD)
+4. Layout Management (TBD)
+5. Content (TBD)

--- a/docs/implement/README.md
+++ b/docs/implement/README.md
@@ -1,0 +1,10 @@
+# Implementing uPortal
+
+This section covers topics related to implementing the portal:  adding your
+users, groups, layouts, *etc.*
+
+1. Authentication (TBD)
+1. User Attributes (TBD)
+1. Groups and Permissions (TBD)
+1. Layout Management (TBD)
+1. Content (TBD)

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,5 +51,7 @@ hibernateVersion=4.2.19.Final
 httpclientVersion=4.5.2
 jasyptVersion=1.9.2
 jjwtVersion=0.6.0
+junitVersion=4.12
+mockitoVersion=2.7.6
 slf4jVersion=1.7.21
 springVersion=3.2.9.RELEASE

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
@@ -28,6 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
+/**
+ * @since 5.0
+ * @author drewwills
+ */
 public abstract class AbstractHeaderProvider implements IHeaderProvider {
 
     @Value("${org.apereo.portal.security.PersonFactory.guest_user_name:guest}")

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @since 5.0
- * @author drewwills
  */
 public abstract class AbstractHeaderProvider implements IHeaderProvider {
 

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
@@ -29,6 +29,7 @@ import org.apache.http.Header;
  * (and their values) sent by the {@link SoffitConnectorController} to the
  * remote Soffit.
  *
+ * @since 5.0
  * @author drewwills
  */
 public interface IHeaderProvider {

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
@@ -30,7 +30,6 @@ import org.apache.http.Header;
  * remote Soffit.
  *
  * @since 5.0
- * @author drewwills
  */
 public interface IHeaderProvider {
 

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PortalRequestHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PortalRequestHeaderProvider.java
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Prepares the custom 'X-Soffit-PortalRequest' HTTP header.
  *
  * @since 5.0
- * @author drewwills
  */
 public class PortalRequestHeaderProvider extends AbstractHeaderProvider {
 

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PreferencesHeaderProvider.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PreferencesHeaderProvider.java
@@ -39,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Prepares the custom 'X-Soffit-Preferences' HTTP header.
  *
  * @since 5.0
- * @author drewwills
  */
 public class PreferencesHeaderProvider extends AbstractHeaderProvider {
 

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorConfiguration.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.context.annotation.Configuration;
  * Defines beans for the Soffit Connector, which runs inside uPortal
  *
  * @since 5.0
- * @author drewwills
  */
 @Configuration
 public class SoffitConnectorConfiguration {

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorConfiguration.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Defines beans for the Soffit Connector, which runs inside uPortal
  *
+ * @since 5.0
  * @author drewwills
  */
 @Configuration

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
@@ -59,7 +59,6 @@ import org.springframework.web.portlet.bind.annotation.RenderMapping;
 
 /**
  * @since 5.0
- * @author drewwills
  */
 @Controller
 @RequestMapping(value={"VIEW","EDIT","HELP"})

--- a/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
+++ b/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
@@ -57,6 +57,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.portlet.bind.annotation.RenderMapping;
 
+/**
+ * @since 5.0
+ * @author drewwills
+ */
 @Controller
 @RequestMapping(value={"VIEW","EDIT","HELP"})
 public class SoffitConnectorController implements ApplicationContextAware {

--- a/uPortal-soffit-renderer/build.gradle
+++ b/uPortal-soffit-renderer/build.gradle
@@ -5,5 +5,8 @@ dependencies {
 
     compile "org.springframework:spring-webmvc:${springVersion}"
 
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.mockito:mockito-core:${mockitoVersion}"
+
     provided "${servletApiDependency}"
 }

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/ModelAttributeService.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/ModelAttributeService.java
@@ -47,7 +47,6 @@ import org.springframework.context.ApplicationContext;
  * {@link SoffitModelAttribute} annotation.
  *
  * @since 5.0
- * @author drewwills
  */
 public class ModelAttributeService {
 

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/ModelAttributeService.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/ModelAttributeService.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.soffit.renderer;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apereo.portal.soffit.model.v1_0.Bearer;
+import org.apereo.portal.soffit.model.v1_0.Definition;
+import org.apereo.portal.soffit.model.v1_0.PortalRequest;
+import org.apereo.portal.soffit.model.v1_0.Preferences;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Responsible for marshalling data required for rendering based on the
+ * {@link SoffitModelAttribute} annotation.
+ *
+ * @since 5.0
+ * @author drewwills
+ */
+public class ModelAttributeService {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private Map<AnnotatedElement,Object> modelAttributes;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostConstruct
+    public void init() {
+        /*
+         * Gather classes & methods that reference @SoffitMoldelAttribute
+         */
+        final Map<AnnotatedElement,Object> map = new HashMap<>();
+        final String[] beanNames = applicationContext.getBeanDefinitionNames();
+        for (String name : beanNames) {
+            final Object bean = applicationContext.getBean(name);
+            final Class clazz = AopUtils.isAopProxy(bean)
+                    ? AopUtils.getTargetClass(bean)
+                    : bean.getClass();
+            if (clazz.isAnnotationPresent(SoffitModelAttribute.class)) {
+                // The bean itself is the model attribute
+                map.put(clazz, bean);
+            } else {
+                // Check the bean for annotated methods...
+                for (Method m : clazz.getMethods()) {
+                    if (m.isAnnotationPresent(SoffitModelAttribute.class)) {
+                        map.put(m, bean);
+                    }
+                }
+            }
+        }
+        logger.debug("Found {} beans and/or methods referencing @SoffitModelAttribute", map.size());
+        modelAttributes = Collections.unmodifiableMap(map);
+    }
+
+    /* package-private */ Map<String,Object> gatherModelAttributes(String viewName, HttpServletRequest req,
+                HttpServletResponse res, PortalRequest portalRequest, Bearer bearer, Preferences preferences,
+                Definition definition) {
+
+        final Map<String,Object> rslt = new HashMap<>();
+
+        logger.debug("Processing model attributes for viewName='{}'", viewName);
+
+        for (Map.Entry<AnnotatedElement,Object> y : modelAttributes.entrySet()) {
+            final AnnotatedElement annotatedElement = y.getKey();
+            final Object bean = y.getValue();
+            final SoffitModelAttribute sma = annotatedElement.getAnnotation(SoffitModelAttribute.class);
+            if (attributeAppliesToView(sma, viewName)) {
+                logger.debug("The following  SoffitModelAttribute applies to viewName='{}':  {}", viewName, sma);
+                final String modelAttributeName = sma.value();
+                // Are we looking at a class or a method?
+                if (annotatedElement instanceof Class) {
+                    // The bean itself is the model attribute
+                    rslt.put(modelAttributeName, bean);
+                } else if (annotatedElement instanceof Method) {
+                    final Method m = (Method) annotatedElement;
+                    final Object modelAttribute = getModelAttributeFromMethod(bean, m, req, res,
+                                        portalRequest, bearer, preferences, definition);
+                    rslt.put(modelAttributeName, modelAttribute);
+                } else {
+                    final String msg = "Unsupported AnnotatedElement type:  " + AnnotatedElement.class.getName();
+                    throw new UnsupportedOperationException(msg);
+                }
+            }
+        }
+
+        logger.debug("Calculated the following model attributes for viewName='{}':  {}", viewName, rslt);
+
+        return rslt;
+
+    }
+
+    protected Object getModelAttributeFromMethod(Object bean, Method method, HttpServletRequest req, HttpServletResponse res,
+                PortalRequest portalRequest, Bearer bearer, Preferences preferences, Definition definition) {
+
+        // This Method must NOT have a void return type...
+        if (method.getReturnType().equals(Void.TYPE)) {
+            final String msg = "Methods annotated with SoffitModelAttribute must not specify a void return type;  " + method.getName();
+            throw new IllegalStateException(msg);
+        }
+        final Object[] parameters = prepareMethodParameters(method, req, res,
+                portalRequest, bearer, preferences, definition);
+        try {
+            final Object rslt = method.invoke(bean, parameters);
+            return rslt;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            final String msg = "Failed to generate a model attribute by invoking '" + method.getName()
+                                                    + "' on the following bean:  " + bean.toString();
+            throw new RuntimeException(msg);
+        }
+
+    }
+
+    protected Object[] prepareMethodParameters(Method method, HttpServletRequest req, HttpServletResponse res,
+                PortalRequest portalRequest, Bearer bearer, Preferences preferences, Definition definition) {
+
+        // Examine the parameters this Method declares and try to match them.
+        final Class<?>[] parameterTypes = method.getParameterTypes();
+        final Object[] rslt = new Object[parameterTypes.length];
+        for (int i=0; i < rslt.length; i++) {
+            final Class<?> pType = parameterTypes[i];
+            // At present, these are the parameter types we support...
+            if (HttpServletRequest.class.equals(pType)) {
+                rslt[i] = req;
+            } else if (HttpServletResponse.class.equals(pType)) {
+                rslt[i] = res;
+            } else if (PortalRequest.class.equals(pType)) {
+                rslt[i] = portalRequest;
+            } else if (Bearer.class.equals(pType)) {
+                rslt[i] = bearer;
+            } else if (Preferences.class.equals(pType)) {
+                rslt[i] = preferences;
+            } else if (Definition.class.equals(pType)) {
+                rslt[i] = definition;
+            } else {
+                final String msg = "Unsupported parameter type for SoffitModelAttribute method:  " + pType;
+                throw new UnsupportedOperationException(msg);
+            }
+        }
+
+        return rslt;
+
+    }
+
+    protected boolean attributeAppliesToView(SoffitModelAttribute attributeAnnotation, String viewName) {
+        final Pattern pattern = Pattern.compile(attributeAnnotation.viewRegex());
+        final Matcher matcher = pattern.matcher(viewName);
+        return matcher.matches();
+    }
+
+}

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitApplication.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitApplication.java
@@ -27,8 +27,8 @@ import org.springframework.context.annotation.Import;
  * This is a convenience annotation for configuring your Spring Boot application
  * with all required Soffit Renderer technology.
  *
- * @author drewwills
  * @since 5.0
+ * @author drewwills
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitApplication.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitApplication.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Import;
  * with all required Soffit Renderer technology.
  *
  * @since 5.0
- * @author drewwills
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
@@ -36,6 +36,7 @@ import java.lang.annotation.Target;
  *   <li>Soffit Data Model objects, i.e. PortalRequest, Bearer, Preferences, and Definition</li>
  * </ul>
  *
+ * @since 5.0
  * @author drewwills
  */
 @Target(value={ElementType.TYPE,ElementType.METHOD})

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation that binds a bean or the return value of a bean method to a named
  * model attribute, exposed to a web view.  This annotation is inspired by
- * Spring's <code>@ModelAttribute</code>.  Methods marked with this annotation
+ * Spring MVC's <code>ModelAttribute</code>.  Methods marked with this annotation
  * support a similar, flexible list of optional parameters (below):
  *
  * <ul>
@@ -44,7 +44,7 @@ import java.lang.annotation.Target;
 public @interface SoffitModelAttribute {
 
     /**
-     * The name of the model attribute to bind to.
+     * The name of the model attribute to bind to.  Required.
      */
     String value();
 

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.soffit.renderer;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that binds a bean or the return value of a bean method to a named
+ * model attribute, exposed to a web view.  This annotation is inspired by
+ * Spring's <code>@ModelAttribute</code>.  Methods marked with this annotation
+ * support a similar, flexible list of optional parameters (below):
+ *
+ * <ul>
+ *   <li>Request and/or Response objects</li>
+ *   <li>Soffit Data Model objects, i.e. PortalRequest, Bearer, Preferences, and Definition</li>
+ * </ul>
+ *
+ * @author drewwills
+ */
+@Target(value={ElementType.TYPE,ElementType.METHOD})
+@Retention(value=RetentionPolicy.RUNTIME)
+@Documented
+public @interface SoffitModelAttribute {
+
+    /**
+     * The name of the model attribute to bind to.
+     */
+    String value();
+
+    /**
+     * Allows the bean or method to restrict which views (by name) have access
+     * to this model attribute.  The specified regex expression must match the
+     * view name for the attribute to be available.  The default is
+     * <code>.*</code> (match all views).
+     */
+    String viewRegex() default ".*";
+
+}

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitModelAttribute.java
@@ -37,7 +37,6 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * @since 5.0
- * @author drewwills
  */
 @Target(value={ElementType.TYPE,ElementType.METHOD})
 @Retention(value=RetentionPolicy.RUNTIME)

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
@@ -38,11 +38,6 @@ import org.springframework.context.annotation.Configuration;
 public class SoffitRendererConfiguration {
 
     @Bean
-    public SoffitRendererController soffitRendererController() {
-        return new SoffitRendererController();
-    }
-
-    @Bean
     public BearerService bearerService() {
         return new BearerService();
     }
@@ -60,6 +55,16 @@ public class SoffitRendererConfiguration {
     @Bean
     public DefinitionService definitionService() {
         return new DefinitionService();
+    }
+
+    @Bean
+    public ModelAttributeService modelAttributeService() {
+        return new ModelAttributeService();
+    }
+
+    @Bean
+    public SoffitRendererController soffitRendererController() {
+        return new SoffitRendererController();
     }
 
 }

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
  * Add this single class to your application context, rather than several
  * individual beans.
  *
+ * @since 5.0
  * @author drewwills
  */
 @Configuration

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererConfiguration.java
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Configuration;
  * individual beans.
  *
  * @since 5.0
- * @author drewwills
  */
 @Configuration
 public class SoffitRendererConfiguration {

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -16,13 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apereo.portal.soffit.renderer;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -39,11 +47,12 @@ import org.apereo.portal.soffit.service.PortalRequestService;
 import org.apereo.portal.soffit.service.PreferencesService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -83,9 +92,15 @@ public class SoffitRendererController {
     public static final String CACHE_MAXAGE_PROPERTY_FORMAT = PROPERTY_PREFIX + "%s.cache.max-age";
 
     private static final String PORTAL_REQUEST_MODEL_NAME = "portalRequest";
+    private static final String BEARER_MODEL_NAME = "bearer";
+    private static final String PREFERENCES_MODEL_NAME = "preferences";
+    private static final String DEFINITION_MODEL_NAME = "definition";
 
     private static final String DEFAULT_MODE = "view";
     private static final String DEFAULT_WINDOW_STATE = "normal";
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     @Autowired
     private Environment environment;
@@ -106,70 +121,88 @@ public class SoffitRendererController {
     private String viewsLocation;
     private final Map<ViewTuple,String> availableViews = new HashMap<>();
 
+    private Map<AnnotatedElement,Object> modelAttributes;
+
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostConstruct
+    public void init() {
+        /*
+         * Gather classes & methods that reference @SoffitMoldelAttribute
+         */
+        final Map<AnnotatedElement,Object> map = new HashMap<>();
+        final String[] beanNames = applicationContext.getBeanDefinitionNames();
+        for (String name : beanNames) {
+            final Object bean = applicationContext.getBean(name);
+            final Class clazz = AopUtils.isAopProxy(bean)
+                    ? AopUtils.getTargetClass(bean)
+                    : bean.getClass();
+            if (clazz.isAnnotationPresent(SoffitModelAttribute.class)) {
+                // The bean itself is the model attribute
+                map.put(clazz, bean);
+            } else {
+                // Check the bean for annotated methods...
+                for (Method m : clazz.getMethods()) {
+                    if (m.isAnnotationPresent(SoffitModelAttribute.class)) {
+                        map.put(m, bean);
+                    }
+                }
+            }
+        }
+        logger.debug("Found {} beans and/or methods referencing @SoffitModelAttribute", map.size());
+        modelAttributes = Collections.unmodifiableMap(map);
+    }
 
     @RequestMapping(value="/{module}", method=RequestMethod.GET)
     public ModelAndView render(final HttpServletRequest req, final HttpServletResponse res, final @PathVariable String module) {
 
         logger.debug("Rendering for request URI '{}'", req.getRequestURI());
 
-        // PortalRequest
-        final String portalRequestToken = req.getHeader(Headers.PORTAL_REQUEST.getName());
-        final PortalRequest portalRequest = portalRequestService.parsePortalRequest(portalRequestToken);
+        // Soffit Object Model
+        final PortalRequest portalRequest = getPortalRequest(req);
+        final Bearer bearer = getBearer(req);
+        final Preferences preferences = getPreferences(req);
+        final Definition definition = getDefinition(req);
 
         // Select a view
         final String viewName = selectView(req, module, portalRequest);
 
+        final Map<String,Object> model = gatherModelAttributes(viewName, req, res, portalRequest, bearer, preferences, definition);
+        model.put(PORTAL_REQUEST_MODEL_NAME, portalRequest);
+        model.put(BEARER_MODEL_NAME, bearer);
+        model.put(PREFERENCES_MODEL_NAME, preferences);
+        model.put(DEFINITION_MODEL_NAME, definition);
+
         // Set up cache headers appropriately
         configureCacheHeaders(res, module);
 
-        return new ModelAndView(viewName.toString(), PORTAL_REQUEST_MODEL_NAME, portalRequest);
+        return new ModelAndView(viewName.toString(), model);
 
-    }
-
-    @ModelAttribute("bearer")
-    public Bearer getBearer(final HttpServletRequest req) {
-        final String authorizationHeader = req.getHeader(Headers.AUTHORIZATION.getName());
-        final String bearerToken = authorizationHeader.substring(Headers.BEARER_TOKEN_PREFIX.length());
-        return bearerService.parseBearerToken(bearerToken);
-    }
-
-    @ModelAttribute("preferences")
-    public Preferences getPreferences(final HttpServletRequest req) {
-        final String preferencesToken = req.getHeader(Headers.PREFERECES.getName());
-        return preferencesService.parsePreferences(preferencesToken);
-    }
-
-    @ModelAttribute("definition")
-    public Definition getDefinition(final HttpServletRequest req) {
-        final String definitionToken = req.getHeader(Headers.DEFINITION.getName());
-        return definitionService.parseDefinition(definitionToken);
     }
 
     /*
      * Implementation
      */
 
-    private void configureCacheHeaders(final HttpServletResponse res, final String module) {
+    private PortalRequest getPortalRequest(final HttpServletRequest req) {
+        final String portalRequestToken = req.getHeader(Headers.PORTAL_REQUEST.getName());
+        return portalRequestService.parsePortalRequest(portalRequestToken);
+    }
 
-        final String cacheScopeProperty = String.format(CACHE_SCOPE_PROPERTY_FORMAT, module);
-        final String cacheScopeValue = environment.getProperty(cacheScopeProperty);
-        logger.debug("Selecting cacheScopeValue='{}' for property '{}'", cacheScopeValue, cacheScopeProperty);
+    private Bearer getBearer(final HttpServletRequest req) {
+        final String authorizationHeader = req.getHeader(Headers.AUTHORIZATION.getName());
+        final String bearerToken = authorizationHeader.substring(Headers.BEARER_TOKEN_PREFIX.length());
+        return bearerService.parseBearerToken(bearerToken);
+    }
 
-        final String cacheMaxAgeProperty = String.format(CACHE_MAXAGE_PROPERTY_FORMAT, module);
-        final String cacheMaxAgeValue = environment.getProperty(cacheMaxAgeProperty);
-        logger.debug("Selecting cacheMaxAgeValue='{}' for property '{}'", cacheMaxAgeValue, cacheMaxAgeProperty);
+    private Preferences getPreferences(final HttpServletRequest req) {
+        final String preferencesToken = req.getHeader(Headers.PREFERECES.getName());
+        return preferencesService.parsePreferences(preferencesToken);
+    }
 
-        // Both must be specified, else we just use the default...
-        final String cacheControl = (StringUtils.isNotEmpty(cacheScopeValue) && StringUtils.isNotEmpty(cacheMaxAgeValue))
-                ? cacheScopeValue + ", max-age=" + cacheMaxAgeValue
-                : CACHE_CONTROL_NOSTORE;
-        logger.debug("Setting cache-control='{}' for module '{}'", cacheControl, module);
-
-        // TODO: support validation caching
-
-        res.setHeader(Headers.CACHE_CONTROL.getName(), cacheControl);
-
+    private Definition getDefinition(final HttpServletRequest req) {
+        final String definitionToken = req.getHeader(Headers.DEFINITION.getName());
+        return definitionService.parseDefinition(definitionToken);
     }
 
     private String selectView(final HttpServletRequest req, final String module, final PortalRequest portalRequest) {
@@ -246,6 +279,102 @@ public class SoffitRendererController {
         logger.debug("Calculated path '{}' for parts={}", rslt, parts);
 
         return rslt.toString();
+
+    }
+
+    private Map<String,Object> gatherModelAttributes(String viewName, HttpServletRequest req, HttpServletResponse res,
+                        PortalRequest portalRequest, Bearer bearer, Preferences preferences, Definition definition) {
+
+        final Map<String,Object> rslt = new HashMap<>();
+
+        logger.debug("Processing model attributes for viewName='{}'", viewName);
+
+        for (Map.Entry<AnnotatedElement,Object> y : modelAttributes.entrySet()) {
+            final AnnotatedElement annotatedElement = y.getKey();
+            final Object bean = y.getValue();
+            final SoffitModelAttribute sma = annotatedElement.getAnnotation(SoffitModelAttribute.class);
+            if (attributeAppliesToView(sma, viewName)) {
+                logger.debug("The following  SoffitModelAttribute applies to viewName='{}':  {}", viewName, sma);
+                final String modelAttributeName = sma.value();
+                // Are we looking at a class or a method?
+                if (annotatedElement instanceof Class) {
+                    // The bean itself is the model attribute
+                    rslt.put(modelAttributeName, bean);
+                } else if (annotatedElement instanceof Method) {
+                    Method m = (Method) annotatedElement;
+                    // This Method must NOT have a void return type...
+                    if (m.getReturnType().equals(Void.TYPE)) {
+                        final String msg = "Methods annotated with SoffitModelAttribute must not specify a void return type;  " + m.getName();
+                        throw new IllegalStateException(msg);
+                    }
+                    // Examine the parameters this Method declares and try to match them.
+                    final Class<?>[] parameterTypes = m.getParameterTypes();
+                    final Object[] parameters = new Object[parameterTypes.length];
+                    for (int i=0; i < parameters.length; i++) {
+                        final Class<?> pType = parameterTypes[i];
+                        // At present, these are the parameter types we support...
+                        if (HttpServletRequest.class.equals(pType)) {
+                            parameters[i] = req;
+                        } else if (HttpServletResponse.class.equals(pType)) {
+                            parameters[i] = res;
+                        } else if (PortalRequest.class.equals(pType)) {
+                            parameters[i] = portalRequest;
+                        } else if (Bearer.class.equals(pType)) {
+                            parameters[i] = bearer;
+                        } else if (Preferences.class.equals(pType)) {
+                            parameters[i] = preferences;
+                        } else if (Definition.class.equals(pType)) {
+                            parameters[i] = definition;
+                        } else {
+                            final String msg = "Unsupported parameter type for SoffitModelAttribute method:  " + pType;
+                            throw new UnsupportedOperationException(msg);
+                        }
+                    }
+                    try {
+                        final Object value = m.invoke(bean, parameters);
+                        rslt.put(modelAttributeName, value);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        final String msg = "Failed to evaluate the specified model attribute:  " + sma.value();
+                        throw new RuntimeException(msg);
+                    }
+                } else {
+                    final String msg = "Unsuppored AnnotatedElement type:  " + AnnotatedElement.class.getName();
+                    throw new UnsupportedOperationException(msg);
+                }
+            }
+        }
+
+        logger.debug("Calculated the following model attributes for viewName='{}':  {}", viewName, rslt);
+
+        return rslt;
+
+    }
+
+    private boolean attributeAppliesToView(SoffitModelAttribute attributeAnnotation, String viewName) {
+        final Pattern pattern = Pattern.compile(attributeAnnotation.viewRegex());
+        final Matcher matcher = pattern.matcher(viewName);
+        return matcher.matches();
+    }
+
+    private void configureCacheHeaders(final HttpServletResponse res, final String module) {
+
+        final String cacheScopeProperty = String.format(CACHE_SCOPE_PROPERTY_FORMAT, module);
+        final String cacheScopeValue = environment.getProperty(cacheScopeProperty);
+        logger.debug("Selecting cacheScopeValue='{}' for property '{}'", cacheScopeValue, cacheScopeProperty);
+
+        final String cacheMaxAgeProperty = String.format(CACHE_MAXAGE_PROPERTY_FORMAT, module);
+        final String cacheMaxAgeValue = environment.getProperty(cacheMaxAgeProperty);
+        logger.debug("Selecting cacheMaxAgeValue='{}' for property '{}'", cacheMaxAgeValue, cacheMaxAgeProperty);
+
+        // Both must be specified, else we just use the default...
+        final String cacheControl = (StringUtils.isNotEmpty(cacheScopeValue) && StringUtils.isNotEmpty(cacheMaxAgeValue))
+                ? cacheScopeValue + ", max-age=" + cacheMaxAgeValue
+                : CACHE_CONTROL_NOSTORE;
+        logger.debug("Setting cache-control='{}' for module '{}'", cacheControl, module);
+
+        // TODO: support validation caching
+
+        res.setHeader(Headers.CACHE_CONTROL.getName(), cacheControl);
 
     }
 

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -54,7 +54,6 @@ import org.springframework.web.servlet.ModelAndView;
  * convenience.
  *
  * @since 5.0
- * @author drewwills
  */
 @Controller
 @RequestMapping("/soffit")
@@ -257,12 +256,12 @@ public class SoffitRendererController {
         logger.debug("Selecting cacheScopeValue='{}' for property '{}'", cacheScopeValue, cacheScopeProperty);
 
         final String cacheMaxAgeProperty = String.format(CACHE_MAXAGE_PROPERTY_FORMAT, module);
-        final String cacheMaxAgeValue = environment.getProperty(cacheMaxAgeProperty);
-        logger.debug("Selecting cacheMaxAgeValue='{}' for property '{}'", cacheMaxAgeValue, cacheMaxAgeProperty);
+        final Integer cacheMaxAgeValueSeconds = environment.getProperty(cacheMaxAgeProperty, Integer.class);
+        logger.debug("Selecting cacheMaxAgeValueSeconds='{}' for property '{}'", cacheMaxAgeValueSeconds, cacheMaxAgeProperty);
 
         // Both must be specified, else we just use the default...
-        final String cacheControl = (StringUtils.isNotEmpty(cacheScopeValue) && StringUtils.isNotEmpty(cacheMaxAgeValue))
-                ? cacheScopeValue + ", max-age=" + cacheMaxAgeValue
+        final String cacheControl = (StringUtils.isNotEmpty(cacheScopeValue) && cacheMaxAgeValueSeconds != null)
+                ? cacheScopeValue + ", max-age=" + cacheMaxAgeValueSeconds
                 : CACHE_CONTROL_NOSTORE;
         logger.debug("Setting cache-control='{}' for module '{}'", cacheControl, module);
 

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -19,18 +19,11 @@
 
 package org.apereo.portal.soffit.renderer;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -47,10 +40,8 @@ import org.apereo.portal.soffit.service.PortalRequestService;
 import org.apereo.portal.soffit.service.PreferencesService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -107,9 +98,6 @@ public class SoffitRendererController {
     private static final String DEFAULT_WINDOW_STATE = "normal";
 
     @Autowired
-    private ApplicationContext applicationContext;
-
-    @Autowired
     private Environment environment;
 
     @Autowired
@@ -124,41 +112,14 @@ public class SoffitRendererController {
     @Autowired
     private DefinitionService definitionService;
 
+    @Autowired
+    private ModelAttributeService modelAttributeService;
+
     @Value("${soffit.renderer.viewsLocation:/WEB-INF/soffit/}")
     private String viewsLocation;
     private final Map<ViewTuple,String> availableViews = new HashMap<>();
 
-    private Map<AnnotatedElement,Object> modelAttributes;
-
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-
-    @PostConstruct
-    public void init() {
-        /*
-         * Gather classes & methods that reference @SoffitMoldelAttribute
-         */
-        final Map<AnnotatedElement,Object> map = new HashMap<>();
-        final String[] beanNames = applicationContext.getBeanDefinitionNames();
-        for (String name : beanNames) {
-            final Object bean = applicationContext.getBean(name);
-            final Class clazz = AopUtils.isAopProxy(bean)
-                    ? AopUtils.getTargetClass(bean)
-                    : bean.getClass();
-            if (clazz.isAnnotationPresent(SoffitModelAttribute.class)) {
-                // The bean itself is the model attribute
-                map.put(clazz, bean);
-            } else {
-                // Check the bean for annotated methods...
-                for (Method m : clazz.getMethods()) {
-                    if (m.isAnnotationPresent(SoffitModelAttribute.class)) {
-                        map.put(m, bean);
-                    }
-                }
-            }
-        }
-        logger.debug("Found {} beans and/or methods referencing @SoffitModelAttribute", map.size());
-        modelAttributes = Collections.unmodifiableMap(map);
-    }
 
     @RequestMapping(value="/{module}", method=RequestMethod.GET)
     public ModelAndView render(final HttpServletRequest req, final HttpServletResponse res, final @PathVariable String module) {
@@ -174,7 +135,7 @@ public class SoffitRendererController {
         // Select a view
         final String viewName = selectView(req, module, portalRequest);
 
-        final Map<String,Object> model = gatherModelAttributes(viewName, req, res, portalRequest, bearer, preferences, definition);
+        final Map<String,Object> model = modelAttributeService.gatherModelAttributes(viewName, req, res, portalRequest, bearer, preferences, definition);
         model.put(PORTAL_REQUEST_MODEL_NAME, portalRequest);
         model.put(BEARER_MODEL_NAME, bearer);
         model.put(PREFERENCES_MODEL_NAME, preferences);
@@ -183,7 +144,7 @@ public class SoffitRendererController {
         // Set up cache headers appropriately
         configureCacheHeaders(res, module);
 
-        return new ModelAndView(viewName.toString(), model);
+        return new ModelAndView(viewName, model);
 
     }
 
@@ -287,80 +248,6 @@ public class SoffitRendererController {
 
         return rslt.toString();
 
-    }
-
-    private Map<String,Object> gatherModelAttributes(String viewName, HttpServletRequest req, HttpServletResponse res,
-                        PortalRequest portalRequest, Bearer bearer, Preferences preferences, Definition definition) {
-
-        final Map<String,Object> rslt = new HashMap<>();
-
-        logger.debug("Processing model attributes for viewName='{}'", viewName);
-
-        for (Map.Entry<AnnotatedElement,Object> y : modelAttributes.entrySet()) {
-            final AnnotatedElement annotatedElement = y.getKey();
-            final Object bean = y.getValue();
-            final SoffitModelAttribute sma = annotatedElement.getAnnotation(SoffitModelAttribute.class);
-            if (attributeAppliesToView(sma, viewName)) {
-                logger.debug("The following  SoffitModelAttribute applies to viewName='{}':  {}", viewName, sma);
-                final String modelAttributeName = sma.value();
-                // Are we looking at a class or a method?
-                if (annotatedElement instanceof Class) {
-                    // The bean itself is the model attribute
-                    rslt.put(modelAttributeName, bean);
-                } else if (annotatedElement instanceof Method) {
-                    Method m = (Method) annotatedElement;
-                    // This Method must NOT have a void return type...
-                    if (m.getReturnType().equals(Void.TYPE)) {
-                        final String msg = "Methods annotated with SoffitModelAttribute must not specify a void return type;  " + m.getName();
-                        throw new IllegalStateException(msg);
-                    }
-                    // Examine the parameters this Method declares and try to match them.
-                    final Class<?>[] parameterTypes = m.getParameterTypes();
-                    final Object[] parameters = new Object[parameterTypes.length];
-                    for (int i=0; i < parameters.length; i++) {
-                        final Class<?> pType = parameterTypes[i];
-                        // At present, these are the parameter types we support...
-                        if (HttpServletRequest.class.equals(pType)) {
-                            parameters[i] = req;
-                        } else if (HttpServletResponse.class.equals(pType)) {
-                            parameters[i] = res;
-                        } else if (PortalRequest.class.equals(pType)) {
-                            parameters[i] = portalRequest;
-                        } else if (Bearer.class.equals(pType)) {
-                            parameters[i] = bearer;
-                        } else if (Preferences.class.equals(pType)) {
-                            parameters[i] = preferences;
-                        } else if (Definition.class.equals(pType)) {
-                            parameters[i] = definition;
-                        } else {
-                            final String msg = "Unsupported parameter type for SoffitModelAttribute method:  " + pType;
-                            throw new UnsupportedOperationException(msg);
-                        }
-                    }
-                    try {
-                        final Object value = m.invoke(bean, parameters);
-                        rslt.put(modelAttributeName, value);
-                    } catch (IllegalAccessException | InvocationTargetException e) {
-                        final String msg = "Failed to evaluate the specified model attribute:  " + sma.value();
-                        throw new RuntimeException(msg);
-                    }
-                } else {
-                    final String msg = "Unsuppored AnnotatedElement type:  " + AnnotatedElement.class.getName();
-                    throw new UnsupportedOperationException(msg);
-                }
-            }
-        }
-
-        logger.debug("Calculated the following model attributes for viewName='{}':  {}", viewName, rslt);
-
-        return rslt;
-
-    }
-
-    private boolean attributeAppliesToView(SoffitModelAttribute attributeAnnotation, String viewName) {
-        final Pattern pattern = Pattern.compile(attributeAnnotation.viewRegex());
-        final Matcher matcher = pattern.matcher(viewName);
-        return matcher.matches();
     }
 
     private void configureCacheHeaders(final HttpServletResponse res, final String module) {

--- a/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -58,6 +58,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
+/**
+ * <code>Controller</code> bean for remote soffits.  This class is provided as a
+ * convenience.
+ *
+ * @since 5.0
+ * @author drewwills
+ */
 @Controller
 @RequestMapping("/soffit")
 public class SoffitRendererController {

--- a/uPortal-soffit-renderer/src/test/java/org/apereo/portal/soffit/renderer/ModelAttributeServiceTest.java
+++ b/uPortal-soffit-renderer/src/test/java/org/apereo/portal/soffit/renderer/ModelAttributeServiceTest.java
@@ -35,9 +35,6 @@ import org.apereo.portal.soffit.model.v1_0.Preferences;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-/**
- * @author drewwills
- */
 public class ModelAttributeServiceTest extends ModelAttributeService {
 
     private final Object returnValue = new Object();

--- a/uPortal-soffit-renderer/src/test/java/org/apereo/portal/soffit/renderer/ModelAttributeServiceTest.java
+++ b/uPortal-soffit-renderer/src/test/java/org/apereo/portal/soffit/renderer/ModelAttributeServiceTest.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.soffit.renderer;
+
+import static org.junit.Assert.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apereo.portal.soffit.model.v1_0.Bearer;
+import org.apereo.portal.soffit.model.v1_0.Definition;
+import org.apereo.portal.soffit.model.v1_0.PortalRequest;
+import org.apereo.portal.soffit.model.v1_0.Preferences;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author drewwills
+ */
+public class ModelAttributeServiceTest extends ModelAttributeService {
+
+    private final Object returnValue = new Object();
+
+    @Test
+    public void testGetModelAttributeFromMethod() {
+
+        final ModelAttributeService modelAttributeService = new ModelAttributeService();
+
+        final Class[] parameterClasses = new Class[] { HttpServletRequest.class, PortalRequest.class, Bearer.class };
+        final Method method;
+        try {
+            method = getClass().getMethod("soffitModelAttributeMethod", parameterClasses);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Object Model
+        final HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+        final HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+        final PortalRequest portalRequest = Mockito.mock(PortalRequest.class);
+        final Bearer bearer = Mockito.mock(Bearer.class);
+        final Preferences preferences = Mockito.mock(Preferences.class);
+        final Definition definition = Mockito.mock(Definition.class);
+
+        final Object modelAttribute = modelAttributeService.getModelAttributeFromMethod(this,
+                            method, req, res, portalRequest, bearer, preferences, definition);
+
+        assertEquals("Incorrect modelAttribute", modelAttribute, returnValue);
+
+        final Method brokenMethod;
+        try {
+            brokenMethod = getClass().getMethod("brokenSoffitModelAttributeMethod", parameterClasses);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            modelAttributeService.getModelAttributeFromMethod(this,
+                    brokenMethod, req, res, portalRequest, bearer, preferences, definition);
+            fail("Expected IllegalStateException for void-declaring method");
+        } catch (IllegalStateException e) {
+            // Expected;  fall through...
+        }
+
+    }
+
+    @Test
+    public void testPrepareMethodParameters() {
+
+        final ModelAttributeService modelAttributeService = new ModelAttributeService();
+
+        final Class[] parameterClasses = new Class[] { HttpServletRequest.class, PortalRequest.class, Bearer.class };
+        final Method method;
+        try {
+            method = getClass().getMethod("soffitModelAttributeMethod", parameterClasses);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Object Model
+        final HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+        final HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+        final PortalRequest portalRequest = Mockito.mock(PortalRequest.class);
+        final Bearer bearer = Mockito.mock(Bearer.class);
+        final Preferences preferences = Mockito.mock(Preferences.class);
+        final Definition definition = Mockito.mock(Definition.class);
+
+        final Object[] parameters = modelAttributeService.prepareMethodParameters(method, req, res,
+                portalRequest, bearer, preferences, definition);
+
+        assertEquals("parameterClasses and parameters arrays must be the same length",
+                                                parameterClasses.length, parameters.length);
+
+        for (int i=0; i < parameters.length; i++) {
+            assertTrue("Mismatched parameter type", parameterClasses[i].isInstance(parameters[i]));
+        }
+
+    }
+
+    @Test
+    public void testAttributeAppliesToView() {
+
+        final ModelAttributeService modelAttributeService = new ModelAttributeService();
+
+        final SoffitModelAttribute unspecific = new BaseSoffitModelAttribute() {
+            @Override
+            public String value() {
+                return "unspecific";
+            }
+
+            @Override
+            public String viewRegex() {
+                return ".*";
+            }
+        };
+
+        final SoffitModelAttribute specific = new BaseSoffitModelAttribute() {
+            @Override
+            public String value() {
+                return "specific";
+            }
+
+            @Override
+            public String viewRegex() {
+                return "specific";
+            }
+        };
+
+        final String[] unspecificViewNames = new String[] {"apereo", "uPortal", "open source"};
+        for (String name : unspecificViewNames) {
+            // Each of these should match 'unspecific' but not 'specific'
+            assertTrue("View name '" + name + "' should apply to model attribute: " + unspecific,
+                    modelAttributeService.attributeAppliesToView(unspecific, name));
+            assertFalse("View name '" + name + "' should NOT apply to model attribute: " + specific,
+                    modelAttributeService.attributeAppliesToView(specific, name));
+        }
+
+        // But the name 'specific' should match...
+        final String specificName = "specific";
+        assertTrue("View name '" + specificName + "' should apply to model attribute: " + specific,
+                modelAttributeService.attributeAppliesToView(unspecific, specificName));
+
+    }
+
+    /**
+     * For use in some of the test cases via reflection.
+     */
+    public Object soffitModelAttributeMethod(HttpServletRequest req, PortalRequest portalRequest, Bearer bearer) {
+        return returnValue;
+    }
+
+    /**
+     * For use in some of the test cases via reflection.
+     */
+    public void brokenSoffitModelAttributeMethod(HttpServletRequest req, PortalRequest portalRequest, Bearer bearer) {
+        // do nothing...
+    }
+
+    private static abstract class BaseSoffitModelAttribute implements SoffitModelAttribute {
+        @Override
+        public boolean equals(Object obj) {
+            return false;
+        }
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .toString();
+        }
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return getClass();
+        }
+    };
+
+}

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/Headers.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/Headers.java
@@ -23,7 +23,6 @@ package org.apereo.portal.soffit;
  * Set of HTTP headers, both standard and custom, in use within Soffit.
  *
  * @since 5.0
- * @author drewwills
  */
 public enum Headers {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/Headers.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/Headers.java
@@ -22,6 +22,7 @@ package org.apereo.portal.soffit;
 /**
  * Set of HTTP headers, both standard and custom, in use within Soffit.
  *
+ * @since 5.0
  * @author drewwills
  */
 public enum Headers {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/ITokenizable.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/ITokenizable.java
@@ -23,6 +23,7 @@ package org.apereo.portal.soffit;
  * Model objects implement this interface, indicating they can be serialized
  * (and deserialized) as JSON Web Tokens (JWT).  https://jwt.io/
  *
+ * @since 5.0
  * @author drewwills
  */
 public interface ITokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/ITokenizable.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/ITokenizable.java
@@ -24,7 +24,6 @@ package org.apereo.portal.soffit;
  * (and deserialized) as JSON Web Tokens (JWT).  https://jwt.io/
  *
  * @since 5.0
- * @author drewwills
  */
 public interface ITokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/AbstractTokenizable.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/AbstractTokenizable.java
@@ -24,6 +24,7 @@ import org.apereo.portal.soffit.ITokenizable;
 /**
  * Base class for model objects that implement {@link ITokenizable}.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class AbstractTokenizable implements ITokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/AbstractTokenizable.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/AbstractTokenizable.java
@@ -25,7 +25,6 @@ import org.apereo.portal.soffit.ITokenizable;
  * Base class for model objects that implement {@link ITokenizable}.
  *
  * @since 5.0
- * @author drewwills
  */
 public class AbstractTokenizable implements ITokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 /**
  * Encapsulates username, user attributes, and group affiliations.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class Bearer extends AbstractTokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * Encapsulates username, user attributes, and group affiliations.
  *
  * @since 5.0
- * @author drewwills
  */
 public class Bearer extends AbstractTokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * Provides information about the publication record of the soffit within the
  * portal.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class Definition extends AbstractTokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * portal.
  *
  * @since 5.0
- * @author drewwills
  */
 public class Definition extends AbstractTokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * respond using output from the soffit.  This information is organized into
  * three collections:  properties, attributes, and parameters.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class PortalRequest extends AbstractTokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * three collections:  properties, attributes, and parameters.
  *
  * @since 5.0
- * @author drewwills
  */
 public class PortalRequest extends AbstractTokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * Collection of preferences for this Soffit and their values.  Preferences are
  * typically defined by administrators at publish time.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class Preferences extends AbstractTokenizable {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * typically defined by administrators at publish time.
  *
  * @since 5.0
- * @author drewwills
  */
 public class Preferences extends AbstractTokenizable {
 

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/AbstractJwtService.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/AbstractJwtService.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Value;
 /**
  * Base class for services that produce JASON Web Tokens.
  *
+ * @since 5.0
  * @author drewwills
  */
 public class AbstractJwtService {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/BearerService.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/BearerService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 /**
  * Responsible for issuing and parsing Bearer tokens.
  *
+ * @since 5.0
  * @author drewwills
  */
 @Service

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/DefinitionService.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/DefinitionService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 /**
  * Responsible for issuing and parsing Definition tokens.
  *
+ * @since 5.0
  * @author drewwills
  */
 @Service

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/JwtClaims.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/JwtClaims.java
@@ -22,6 +22,7 @@ package org.apereo.portal.soffit.service;
 /**
  * Set of all the JWT claims in use within Soffit.
  *
+ * @since 5.0
  * @author drewwills
  */
 public enum JwtClaims {

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/PortalRequestService.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/PortalRequestService.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service;
  * Responsible for issuing and parsing the {@link PortalRequest} provided by the
  * Soffit Connector.
  *
+ * @since 5.0
  * @author drewwills
  */
 @Service

--- a/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/PreferencesService.java
+++ b/uPortal-soffit/src/main/java/org/apereo/portal/soffit/service/PreferencesService.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service;
 /**
  * Responsible for issuing and parsing the collection of preferences.
  *
+ * @since 5.0
  * @author drewwills
  */
 @Service


### PR DESCRIPTION
…the SoffitRendererController to inject model attributes

https://issues.jasig.org/browse/UP-4792

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement] is signed
-   [x] commit message follows [commit guidelines]
-   [x] tests are included
-   [x] documentation is changed or added

### Description of change
<!-- Provide a description of the change below this comment. -->

This feature is inspired by the `ModelAttribute` annotation in Spring MVC:  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/bind/annotation/ModelAttribute.html

uPortal soffit support should provide a similar annotation (e.g. `SoffitModelAttribute`) that allows soffit developers to inject arbitrary beans and/or return values on bean methods into the EL context when a JSP is rendered via the SoffitRendererController.

### Code Examples

#### Bean class that uses `@SoffitModelAttribute`

```
@Component
public class SnooperModelAttributes {

    private final ObjectMapper mapper = new ObjectMapper();

    @SoffitModelAttribute(value="bearerJson",viewRegex=".*/snooper/.*")
    public String getBearerJson(Bearer bearer) {
        String rslt = null;
        try {
            rslt = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(bearer);
        } catch (JsonProcessingException e) {
            final String msg = "Unable to write the Bearer object to JSON";
            throw new RuntimeException(msg, e);
        }
        return rslt;
    }

    @SoffitModelAttribute(value="portalRequestJson",viewRegex=".*/snooper/.*")
    public String getPortalRequestJson(PortalRequest portalRequest) {
        String rslt = null;
        try {
            rslt = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(portalRequest);
        } catch (JsonProcessingException e) {
            final String msg = "Unable to write the PortalRequest object to JSON";
            throw new RuntimeException(msg, e);
        }
        return rslt;
    }

    @SoffitModelAttribute(value="preferencesJson",viewRegex=".*/snooper/.*")
    public String getPreferencesJson(Preferences preferences) {
        String rslt = null;
        try {
            rslt = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(preferences);
        } catch (JsonProcessingException e) {
            final String msg = "Unable to write the Preferences object to JSON";
            throw new RuntimeException(msg, e);
        }
        return rslt;
    }

    @SoffitModelAttribute(value="definitionJson",viewRegex=".*/snooper/.*")
    public String getDefinitionJson(Definition definition) {
        String rslt = null;
        try {
            rslt = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(definition);
        } catch (JsonProcessingException e) {
            final String msg = "Unable to write the Definition object to JSON";
            throw new RuntimeException(msg, e);
        }
        return rslt;
    }
}
```

#### JSP page that uses these model attributes

```
<%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
<jsp:directive.include file="/WEB-INF/soffit/include.jsp"/>

<c:set var="n" value="${portalRequest.attributes['namespace'][0]}" />

<div id="${n}">

    <h2 class="text-primary">Snooper</h2>
    <p>Here is an example of data elements available to a remote soffit endpoint.</p>

    <h3>Request Headers</h3>
    <ul>
        <c:forEach items="${header}" var="entry">
            <li><code><strong><c:out value="${entry.key}" />:</strong> <c:out value="${entry.value}" /></code></li>
        </c:forEach>
    </ul>

    <h3>Bearer:</h3>
    <pre>${bearerJson}</pre>

    <h3>Portal Request:</h3>
    <pre>${portalRequestJson}</pre>

    <h3>Preferences:</h3>
    <pre>${preferencesJson}</pre>

    <h3>Definition:</h3>
    <pre>${definitionJson}</pre>

</div>
```

<!-- Reference Links -->
[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
