### PR TITLE
UP-4797 Adds lifecycle to json layout feed

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/rendering/PortletDefinitionAttributeSource.java
+++ b/uportal-war/src/main/java/org/apereo/portal/rendering/PortletDefinitionAttributeSource.java
@@ -57,6 +57,7 @@ public class PortletDefinitionAttributeSource implements AttributeSource, BeanNa
     public static final String WEBAPP_NAME_ATTRIBUTE = "webAppName";
     public static final String PORTLET_NAME_ATTRIBUTE = "portletName";
     public static final String FRAMEWORK_PORTLET_ATTRIBUTE = "frameworkPortlet";
+    public static final String PORTLET_LIFECYCLE_ATTRIBUTE = "lifecycleState";
 
     private final XMLEventFactory xmlEventFactory = XMLEventFactory.newFactory();
     private IPortletDefinitionDao portletDefinitionDao;
@@ -101,6 +102,7 @@ public class PortletDefinitionAttributeSource implements AttributeSource, BeanNa
             } else {
                 IPortletDescriptorKey descriptorKey = def.getPortletDescriptorKey();
                 attributes.add(xmlEventFactory.createAttribute(PORTLET_NAME_ATTRIBUTE, descriptorKey.getPortletName()));
+                attributes.add(xmlEventFactory.createAttribute(PORTLET_LIFECYCLE_ATTRIBUTE, def.getLifecycleState().toString()));
                 if (descriptorKey.isFrameworkPortlet()) {
                     attributes.add(xmlEventFactory.createAttribute(FRAMEWORK_PORTLET_ATTRIBUTE, "true"));
                 } else {

--- a/uportal-war/src/test/groovy/org/apereo/portal/rendering/PortletDefinitionAttributeSourceTest.groovy
+++ b/uportal-war/src/test/groovy/org/apereo/portal/rendering/PortletDefinitionAttributeSourceTest.groovy
@@ -21,6 +21,7 @@ package org.apereo.portal.rendering
 import org.apereo.portal.portlet.dao.IPortletDefinitionDao
 import org.apereo.portal.portlet.dao.jpa.PortletDefinitionImpl
 import org.apereo.portal.portlet.dao.jpa.PortletTypeImpl
+import org.apereo.portal.portlet.om.PortletLifecycleState
 import org.apereo.portal.rendering.PortletDefinitionAttributeSource
 
 import javax.xml.stream.XMLEventFactory
@@ -50,9 +51,10 @@ class PortletDefinitionAttributeSourceTest extends GroovyTestCase {
             def attrItem = attrIterator.next()
             attributeMap[attrItem.getName().getLocalPart()] = attrItem.getValue()
         }
-        assert attributeMap.size() == 2
+        assert attributeMap.size() == 3
         assert attributeMap[PortletDefinitionAttributeSource.PORTLET_NAME_ATTRIBUTE] == 'portletName'
         assert attributeMap[PortletDefinitionAttributeSource.WEBAPP_NAME_ATTRIBUTE] == 'webappName'
+        assert attributeMap[PortletDefinitionAttributeSource.PORTLET_LIFECYCLE_ATTRIBUTE] == PortletLifecycleState.CREATED.toString()
     }
 
     void testGetAdditionalAttributesFrameworkPortlet() {
@@ -73,7 +75,7 @@ class PortletDefinitionAttributeSourceTest extends GroovyTestCase {
             def attrItem = attrIterator.next()
             attributeMap[attrItem.getName().getLocalPart()] = attrItem.getValue()
         }
-        assert attributeMap.size() == 2
+        assert attributeMap.size() == 3
         assert attributeMap[PortletDefinitionAttributeSource.PORTLET_NAME_ATTRIBUTE] == 'portletName'
         assert attributeMap[PortletDefinitionAttributeSource.FRAMEWORK_PORTLET_ATTRIBUTE] == 'true'
     }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement] is signed
-   [x] commit message follows [commit guidelines]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds lifecycle to JSON layout feed.  Useful for those not using the rendering pipeline.  For example, AngularJS would like to render a 'Maintenance mode' widget for items in maintenance mode.


Example:
"content": [
{
"_objectType": "portlet",
"url": "/uPortal/api/v4-3/portlet/what-is-uportal.html",
"iconUrl": "/uPortal/media/skins/icons/mobile/feedback.png",
"ID": "u26l1n1110",
"chanID": "53",
"description": "Description of uPortal.",
"fragment": "0",
"precedence": "80.0",
"fname": "what-is-uportal",
"locale": "en_US",
"name": "Welcome to uPortal",
"timeout": "10000",
"title": "Welcome to uPortal",
"typeID": "3",
"deleteAllowed": "false",
"moveAllowed": "false",
"windowState": "normal",
"portletMode": "view",
"portletName": "cms",
#### "lifecycleState": "PUBLISHED",
"webAppName": "/SimpleContentPortlet",
"parameters": {
"disableDynamicTitle": "true",
"configurable": "true",
"iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
"mobileIconUrl": "/uPortal/media/skins/icons/mobile/feedback.png"
}
},
