### PR TITLE
Theme the GitHub Page website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ npm-debug.log
 target/
 uportal-impl
 uportal-portlets-overlay/*/overlays
+docs/_site
+.ruby-version
+Gemfile.lock

--- a/docs/GEMFILE
+++ b/docs/GEMFILE
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-default-layout'
+gem 'jekyll-optional-front-matter'
+gem 'jekyll-readme-index'
+gem 'jekyll-titles-from-headings'

--- a/docs/USING_ANGULAR.md
+++ b/docs/USING_ANGULAR.md
@@ -109,7 +109,8 @@ $controllerProvider, $provide) {
 
 
 #### Inline script
-```jsp
+
+```html
 <%@ page contentType="text/html" isELIgnored="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -179,7 +180,8 @@ $controllerProvider, $provide) {
 ```
 
 ### External scripts
-```jsp
+
+```html
 <%@ page contentType="text/html" isELIgnored="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/docs/USING_ANGULAR.md
+++ b/docs/USING_ANGULAR.md
@@ -1,4 +1,5 @@
 # Strategy for employing Angular.js in portal skins and/or portlets.
+
 ## Definitions
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+gems:
+  - github-pages
+  - jekyll-default-layout
+  - jekyll-optional-front-matter
+  - jekyll-readme-index
+  - jekyll-titles-from-headings

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,5 @@ gems:
   - jekyll-optional-front-matter
   - jekyll-readme-index
   - jekyll-titles-from-headings
+
+theme: jekyll-theme-dinky


### PR DESCRIPTION
*Checklist*

-   [x] the individual contributor license agreement is signed
-   [x] documentation is changed or added

# Description of change

(Preview [this change as deployed to apetro's fork](http://apetro.github.io/uPortal/).)

**Adds Jekyll configuration files** supporting running Jekyll to locally build the documentation, using the plugins and assumptions in place in GitHub Pages.

```shell_session
bundle exec jekyll serve
```

**Selects the  GitHub Pages theme named "dinky"**. There are several available such themes to choose among, or uPortal could develop its own theme, or Apereo could develop its own theme, or there's oodles of themes out on The Internet, but as an achievable next step this "dinky" theme looks better than the default minimalist theme.

**Edits Markdown files** to work a little better as rendered on GitHub Pages. Adding a little whitespace helps a lot; GitHub Pages uses the Rouge syntax highlighter which only supports some specific language lexers, `jsp` not among them, so mark those code blocks as `html` instead.
