### PR TITLE
UP-4802: Add alt text attribute to Background Preference portlet thumbnails

### DIFF
--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/background-preference.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/background-preference.portlet-definition.xml
@@ -71,6 +71,12 @@
         <name>showChrome</name>
         <value>false</value>
     </parameter>
+    <portlet-preference>
+        <name>backgroundImageCaptions</name>
+        <value>Galaxy</value>
+        <value>Mountain</value>
+        <value>Nebula</value>
+    </portlet-preference>
     <!--
      | Beginning with uPortal 5.0, image paths in this portlet-definition
      | support ${portalContext} as a replacement token for the context path of

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/BackgroundSetSelectionStrategy.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/BackgroundSetSelectionStrategy.java
@@ -33,6 +33,9 @@ public interface BackgroundSetSelectionStrategy {
 
     String[] getImageThumbnailSet(PortletRequest req);
 
+    /**
+     * @since 4.3.2
+     */
     String[] getImageCaptions(PortletRequest req);
 
     String getSelectedImage(PortletRequest req);

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/BackgroundSetSelectionStrategy.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/BackgroundSetSelectionStrategy.java
@@ -33,6 +33,8 @@ public interface BackgroundSetSelectionStrategy {
 
     String[] getImageThumbnailSet(PortletRequest req);
 
+    String[] getImageCaptions(PortletRequest req);
+
     String getSelectedImage(PortletRequest req);
 
     String getBackgroundContainerSelector(PortletRequest req);

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/RoleBasedBackgroundSetSelectionStrategy.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/RoleBasedBackgroundSetSelectionStrategy.java
@@ -78,6 +78,10 @@ public class RoleBasedBackgroundSetSelectionStrategy implements BackgroundSetSel
         public String getBackgroundContainerSelectorPreferenceName() {
             return prefix + "BackgroundContainerSelector";
         }
+
+        public String getImageCaptionsName() {
+            return "backgroundImageCaptions";
+        }
     }
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
@@ -116,6 +120,13 @@ public class RoleBasedBackgroundSetSelectionStrategy implements BackgroundSetSel
             images[i] = evaluateImagePath(images[i]);
         }
         return images;
+    }
+
+    @Override
+    public String[] getImageCaptions(PortletRequest req) {
+        PreferenceNames names = PreferenceNames.getInstance(req);
+        PortletPreferences prefs = req.getPreferences();
+        return prefs.getValues(names.getImageCaptionsName(), null);
     }
 
     @Override

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/RoleBasedBackgroundSetSelectionStrategy.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/RoleBasedBackgroundSetSelectionStrategy.java
@@ -57,6 +57,7 @@ public class RoleBasedBackgroundSetSelectionStrategy implements BackgroundSetSel
         public static PreferenceNames getInstance(PortletRequest req) {
             return req.isUserInRole(MOBILE_DEVICE_ROLE_NAME) ? MOBILE : DEFAULT;
         }
+
         private final String prefix;
 
         private PreferenceNames(String prefix) {
@@ -79,9 +80,11 @@ public class RoleBasedBackgroundSetSelectionStrategy implements BackgroundSetSel
             return prefix + "BackgroundContainerSelector";
         }
 
-        public String getImageCaptionsName() {
-            return "backgroundImageCaptions";
-        }
+        /**
+         * The portlet-preference containing the image captions.
+         * This preference name will not change.
+         */
+        public static final String IMAGE_CAPTIONS_PREFERENCE_NAME = "backgroundImageCaptions";
     }
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
@@ -126,7 +129,7 @@ public class RoleBasedBackgroundSetSelectionStrategy implements BackgroundSetSel
     public String[] getImageCaptions(PortletRequest req) {
         PreferenceNames names = PreferenceNames.getInstance(req);
         PortletPreferences prefs = req.getPreferences();
-        return prefs.getValues(names.getImageCaptionsName(), null);
+        return prefs.getValues(names.IMAGE_CAPTIONS_PREFERENCE_NAME, null);
     }
 
     @Override

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/ViewBackgroundPreferenceController.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/backgroundpreference/ViewBackgroundPreferenceController.java
@@ -54,7 +54,10 @@ public class ViewBackgroundPreferenceController {
 
         final String[] thumbnailImages = imageSetSelectionStrategy.getImageThumbnailSet(req);
         model.addAttribute("thumbnailImages", thumbnailImages);
-
+        
+        final String[] imageCaptions = imageSetSelectionStrategy.getImageCaptions(req);
+        model.addAttribute("imageCaptions", imageCaptions);
+        
         final String preferredBackgroundImage = imageSetSelectionStrategy.getSelectedImage(req);
         model.addAttribute("backgroundImage", preferredBackgroundImage);
 

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
@@ -139,8 +139,8 @@
         </a>
         <c:forEach var="image" items="${thumbnailImages}" varStatus="status">
             <a href="#">
-                <img src="${image}" />
-                <span class="caption">Background ${status.index + 1}</span>
+                <img src="${image}" alt=${imageCaptions[status.index]}/>
+                <span class="caption">${imageCaptions[status.index]}</span>
             </a>
         </c:forEach>
     </div>

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
@@ -139,7 +139,7 @@
         </a>
         <c:forEach var="image" items="${thumbnailImages}" varStatus="status">
             <a href="#">
-                <img src="${image}" alt=""/>
+                <img src="${image}" alt="" role="presentation"/>
                 <span class="caption">${imageCaptions[status.index]}</span>
             </a>
         </c:forEach>

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
@@ -139,7 +139,7 @@
         </a>
         <c:forEach var="image" items="${thumbnailImages}" varStatus="status">
             <a href="#">
-                <img src="${image}" alt=${imageCaptions[status.index]}/>
+                <img src="${image}" alt=""/>
                 <span class="caption">${imageCaptions[status.index]}</span>
             </a>
         </c:forEach>


### PR DESCRIPTION
##### Checklist
-   [x] the [individual contributor license agreement](https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement) is signed
-   [x] commit message follows [commit guidelines](https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit)

##### Description of change

https://issues.jasig.org/browse/UP-4802

Images in the Background Preference portlet currently have no alt text, which isn't ADA compliant. This can be fixed by adding a new portlet-preference containing an alt-text string for each image.
