### PR TITLE
NOJIRA: Move help and support higher in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,23 @@ has access to all releases of the uPortal software with absolutely no costs. We
 welcome [contributions from our community](https://github.com/Jasig/uPortal/graphs/contributors)
 of all types and sizes.
 
-## Manual
+### Accessibility
+
+uPortal strives to conform with Web Content Accessibility Guidelines Version 2.0 Level AA.
+The most recent accessibility audit results can be seen in [UP-4735](https://issues.jasig.org/browse/UP-4735).
+
+[![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](https://www.w3.org/TR/WCAG20/)
+
+## Help and Support
+
+The [uportal-user@apereo.org](https://wiki.jasig.org/display/JSG/uportal-user)
+email address is the best place to go with questions related to configuring or
+deploying uPortal.
+
+The [uPortal manual](#manual) is a collaborative resource which has more detailed documentation for
+each uPortal release.
+
+### Manual
 
 Additional information about uPortal is available in the Manual.
 
@@ -38,16 +54,6 @@ Additional information about uPortal is available in the Manual.
 *   [uPortal 3.2 Manual](https://wiki.jasig.org/display/UPM32/Home)
 *   [uPortal 3.1 Manual](https://wiki.jasig.org/display/UPM31/Home)
 *   [uPortal 3.0 Manual](https://wiki.jasig.org/display/UPM30/Home)
-
-## Continuous Integration
-
-uPortal uses Travis CI and AppVeyor for lightweight continuous integration.  You can see build statuses at <https://travis-ci.org/Jasig/uPortal> and <https://ci.appveyor.com/project/drewwills/uportal>.
-
-## Accessibility
-
-uPortal strives to conform with Web Content Accessibility Guidelines Version 2.0 Level AA. The most recent accessility audit results can be seen in [UP-4735](https://issues.jasig.org/browse/UP-4735).
-
-[![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](https://www.w3.org/TR/WCAG20/)
 
 ## Requirements
 
@@ -85,15 +91,6 @@ This is the required process to deploy any portlet to a uPortal instance.
 ``` shell
 ant deployPortletApp -DportletApp=/path/to/portlet.war
 ```
-
-## Help and Support
-
-The [uportal-user@apereo.org](https://wiki.jasig.org/display/JSG/uportal-user)
-email address is the best place to go with questions related to configuring or
-deploying uPortal.
-
-The uPortal manual is a collaborative document on the wiki which has more
-detailed documentation: <https://wiki.jasig.org/display/UPM42>
 
 ## Other Notes
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Arrangment is now:
1. Build statuses
2. About uPortal
3. Help and Support
4. Build Instructions

Continuous integration section has been removed.
Build status and environments is now described by the table at the top of
the page.

Help and support now links to the Manual section to give options for
which version of uPortal manual a person wants to see.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
