### PR TITLE
UP-4822: Improve Code Test Coverage Metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ install:
   - ./gradlew install
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
-after_success:
-  - mvn clean test cobertura:cobertura coveralls:cobertura
+script: mvn clean test cobertura:cobertura coveralls:report -B -V

--- a/pom.xml
+++ b/pom.xml
@@ -1542,6 +1542,7 @@
                         <!-- aggregated reports for multi-module projects -->
                         <aggregate>true</aggregate>
                         <instrumentation>
+                            <ignoreTrivial>true</ignoreTrivial>
                             <excludes>
                                 <!-- Exclude generated classes -->
                                 <exclude>**/*_.class</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <casclient.version>3.4.1</casclient.version>
         <ccpp.version>1.0</ccpp.version>
         <cernunnos.version>1.2.2</cernunnos.version>
-        <cobertura-maven-plugin.version>2.6</cobertura-maven-plugin.version>
+        <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <commons-cli.version>1.2</commons-cli.version>
         <commons-codec.version>1.9</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -163,7 +163,7 @@
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <commons-pool.version>1.6</commons-pool.version>
         <commons-math3.version>3.2</commons-math3.version>
-        <coveralls-maven-plugin.version>2.2.0</coveralls-maven-plugin.version>
+        <coveralls-maven-plugin.version>4.2.0</coveralls-maven-plugin.version>
         <dom4j.version>1.6.1</dom4j.version>
         <easymock.version>3.2</easymock.version>
         <ejb3-persistence.version>1.0.1.GA</ejb3-persistence.version>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://issues.jasig.org/browse/UP-4822

Ignore trivial code automatically, update cobertura and coveralls plugins to take advantage of latest features, ensure that `mvn test` is run only once to cut down on CI build time.

> [the] ignoreTrivial switch [...] tells Cobertura to ignore the 
  following in the coverage report: Getter methods that simply 
  read a class field; Setter methods that set a class field;
  Constructors that only set class fields and call a super 
  class constructor.

:notebook: These changes would be safe to backport to 4.3 patches

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
