### PR TITLE
UP-4823: Change CAS validate filter from CAS protocol 3 back to 2.

### DIFF
--- a/docs/Cas5ClearPass.md
+++ b/docs/Cas5ClearPass.md
@@ -19,6 +19,16 @@ openssl pkcs8 -topk8 -inform PER -outform DER -nocrypt -in private.key -out priv
 
 Save `private.p8` in a well-known location.
 
+## Change CAS Validate Filter to use CAS Protocol 3
+
+uPortal uses an older version for it's CAS embedded service. To use this ClearPass feature,
+the validation filter needs to be switched from CAS Protocol 2 to 3. This is simply done
+by editing the classname of the filter in web.xml:
+
+```xml
+        <filter-class>org.jasig.cas.client.validation.Cas30ProxyReceivingTicketValidationFilter</filter-class>
+```
+
 ## Configuring uPortal for accepting encrypted passwords
 
 uPortal setup for this feature is straight-forward. The hardest part is configuring the location of the private key.

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -87,7 +87,7 @@
     
     <filter>
         <filter-name>CAS Validate Filter</filter-name>
-        <filter-class>org.jasig.cas.client.validation.Cas30ProxyReceivingTicketValidationFilter</filter-class>
+        <filter-class>org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter</filter-class>
         <init-param>
           <param-name>casServerUrlPrefix</param-name>
           <param-value>${environment.build.cas.protocol}://${environment.build.cas.server}${environment.build.cas.context}</param-value>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Revert change to fix embedded CAS service.

https://issues.jasig.org/browse/UP-4823
<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
