### PR TITLE
UP-4822: Ignore trivial code from Code Test Coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1538,6 +1538,7 @@
                         <!-- aggregated reports for multi-module projects -->
                         <aggregate>true</aggregate>
                         <instrumentation>
+                            <ignoreTrivial>true</ignoreTrivial>
                             <excludes>
                                 <!-- Exclude generated classes -->
                                 <exclude>**/*_.class</exclude>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://issues.jasig.org/browse/UP-4822

:notebook: This is the same as #846, PR is being opened to verify that this change will not break CI. :notebook: 

Ignore trivial code automatically, update cobertura and coveralls plugins to take advantage of latest features, ensure that `mvn test` is run only once to cut down on CI build time.

> [the] ignoreTrivial switch [...] tells Cobertura to ignore the 
  following in the coverage report: Getter methods that simply 
  read a class field; Setter methods that set a class field;
  Constructors that only set class fields and call a super 
  class constructor.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
