### PR TITLE
NOJIRA: Cache maven and gradle dependencies to reduce network time on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,9 @@ install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script: mvn clean test cobertura:cobertura coveralls:report -B -V
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Each build gradle and maven pull fresh versions of their dependencies down from maven central.
This PR adds configuration that allows Travis CI to cache known dependencies to an S3 bucket that is mounted at the start of each build.
Reducing the network time spent on dependency resolution.

:notebook: Appveyor already is leveraging a similar mechanism, appveyor build with caching takes 5 minutes, Travis CI without caching takes 7 minutes.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
