### PR TITLE
UP-4833: Fix portlet preference name/value hibernate mapping for Post…

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/portlet/dao/jpa/PortletPreferenceImpl.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlet/dao/jpa/PortletPreferenceImpl.java
@@ -44,6 +44,7 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.IndexColumn;
+import org.hibernate.annotations.Type;
 
 /**
  * @author Eric Dalquist
@@ -79,6 +80,7 @@ public class PortletPreferenceImpl implements IPortletPreference, Cloneable {
     private final long entityVersion;
 
     @Column(name = "PREF_NAME", length = 100000)
+    @Type(type = "org.hibernate.type.TextType")
     @Lob
     private String name = null;
 
@@ -90,6 +92,7 @@ public class PortletPreferenceImpl implements IPortletPreference, Cloneable {
     @IndexColumn(name = "VALUE_ORDER")
     @Lob
     @Column(name = "PREF_VALUE", length = 100000)
+    @Type(type = "org.hibernate.type.TextType")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Fetch(FetchMode.JOIN)
     private List<String> values = new ArrayList<String>(0);


### PR DESCRIPTION
…gresql, so that these are stored as TEXT and not as large objects (which results in orphaned data).

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

UP-4833: Fix portlet preference name/value hibernate mapping for Postgresql, so that these are stored as TEXT and not as large objects (which results in orphaned data).  See:  https://issues.jasig.org/browse/UP-4833

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
