### PR TITLE
NOJIRA: Remove type annotations in Search that can be implicitly determined

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/portlets/search/PortalSearchResults.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/search/PortalSearchResults.java
@@ -50,7 +50,7 @@ public class PortalSearchResults implements Serializable {
 
         this.results =
                 CacheBuilder.newBuilder()
-                        .<String, List<Tuple<SearchResult, String>>>build(
+                        .build(
                                 new CacheLoader<String, List<Tuple<SearchResult, String>>>() {
                                     @Override
                                     public List<Tuple<SearchResult, String>> load(String key)
@@ -70,7 +70,7 @@ public class PortalSearchResults implements Serializable {
         final Set<String> tabs = this.getTabs(result);
         for (final String tab : tabs) {
             final List<Tuple<SearchResult, String>> typeResults = this.results.getUnchecked(tab);
-            typeResults.add(new Tuple<SearchResult, String>(result, url));
+            typeResults.add(new Tuple<>(result, url));
         }
     }
 
@@ -82,7 +82,7 @@ public class PortalSearchResults implements Serializable {
             return this.defaultTab;
         }
 
-        final Set<String> tabs = new HashSet<String>();
+        final Set<String> tabs = new HashSet<>();
 
         //For each type the search result declares lookup the tab(s) mapped to that type
         for (final String type : types) {

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
@@ -124,8 +124,7 @@ public class SearchPortletController {
     private int maxAutocompleteSearchResults = 10;
     // Map of (search result type, priority) to prioritize search autocomplete results.  0 is default priority.
     // > 0 is higher priority, < 0 is lower priority.
-    private Map<String, Integer> autocompleteResultTypeToPriorityMap =
-            new HashMap<String, Integer>();
+    private Map<String, Integer> autocompleteResultTypeToPriorityMap = new HashMap<>();
 
     private IPortalSpELService spELService;
 
@@ -133,7 +132,7 @@ public class SearchPortletController {
     // search event listeners to voluntarily ignore the search event if they are one of the ignored types (and
     // again filtering here in case the search event listener doesn't respect the ignore set).
     // This requires changing the SearchEvent and unfortunately there is not time for that now.
-    private Set<String> autocompleteIgnoreResultTypes = new HashSet<String>();
+    private Set<String> autocompleteIgnoreResultTypes = new HashSet<>();
 
     @Resource(name = "searchServices")
     public void setPortalSearchServices(List<IPortalSearchService> searchServices) {
@@ -195,8 +194,8 @@ public class SearchPortletController {
     //Map of tab-key to string or collection<string> of search result types
     public void setSearchTabs(Map<String, Object> searchTabMappings) {
         final Map<String, Set<String>> resultTypeMappingsBuilder =
-                new LinkedHashMap<String, Set<String>>();
-        final List<String> tabKeysBuilder = new ArrayList<String>(searchTabMappings.size());
+                new LinkedHashMap<>();
+        final List<String> tabKeysBuilder = new ArrayList<>(searchTabMappings.size());
 
         for (final Map.Entry<String, Object> tabMapping : searchTabMappings.entrySet()) {
             final String tabKey = tabMapping.getKey();
@@ -223,7 +222,7 @@ public class SearchPortletController {
             final String resultType) {
         Set<String> tabKeys = resultTypeMappingsBuilder.get(resultType);
         if (tabKeys == null) {
-            tabKeys = new LinkedHashSet<String>();
+            tabKeys = new LinkedHashSet<>();
             resultTypeMappingsBuilder.put(resultType, tabKeys);
         }
         tabKeys.add(tabKey);
@@ -264,7 +263,7 @@ public class SearchPortletController {
                 searchCounterCache =
                         CacheBuilder.newBuilder()
                                 .expireAfterAccess(1, TimeUnit.MINUTES)
-                                .<String, Boolean>build();
+                                .build();
                 session.setAttribute(SEARCH_COUNTER_NAME, searchCounterCache);
             }
         }
@@ -314,7 +313,7 @@ public class SearchPortletController {
                         CacheBuilder.newBuilder()
                                 .maximumSize(20)
                                 .expireAfterAccess(5, TimeUnit.MINUTES)
-                                .<String, PortalSearchResults>build();
+                                .build();
                 session.setAttribute(SEARCH_RESULTS_CACHE_NAME, searchResultsCache);
             }
             // Save the last queryId for an ajax autocomplete search response.
@@ -509,7 +508,7 @@ public class SearchPortletController {
     /** Display a search form */
     @RequestMapping
     public ModelAndView showSearchForm(RenderRequest request, RenderResponse response) {
-        final Map<String, Object> model = new HashMap<String, Object>();
+        final Map<String, Object> model = new HashMap<>();
 
         // Determine if this portlet displays the search launch view or regular search view.
         PortletPreferences prefs = request.getPreferences();
@@ -570,7 +569,7 @@ public class SearchPortletController {
             @RequestParam(value = "query") String query,
             @RequestParam(value = "queryId") String queryId) {
 
-        final Map<String, Object> model = new HashMap<String, Object>();
+        final Map<String, Object> model = new HashMap<>();
         model.put("query", query);
 
         ConcurrentMap<String, List<Tuple<SearchResult, String>>> results =
@@ -597,7 +596,7 @@ public class SearchPortletController {
             @RequestParam(value = "query") String query,
             @RequestParam(value = "hitMaxQueries") boolean hitMaxQueries) {
 
-        final Map<String, Object> model = new HashMap<String, Object>();
+        final Map<String, Object> model = new HashMap<>();
         model.put("query", query);
         model.put("hitMaxQueries", hitMaxQueries);
 
@@ -615,8 +614,8 @@ public class SearchPortletController {
         int maxTextLength =
                 Integer.parseInt(prefs.getValue(AUTOCOMPLETE_MAX_TEXT_LENGTH_PREF_NAME, "180"));
 
-        final Map<String, Object> model = new HashMap<String, Object>();
-        List<AutocompleteResultsModel> results = new ArrayList<AutocompleteResultsModel>();
+        final Map<String, Object> model = new HashMap<>();
+        List<AutocompleteResultsModel> results = new ArrayList<>();
 
         final PortletSession session = request.getPortletSession();
         String queryId = (String) session.getAttribute(SEARCH_LAST_QUERY_ID);
@@ -662,7 +661,7 @@ public class SearchPortletController {
                 getCleanedAndSortedMapResults(resultsMap, maxTextLength);
 
         // Consolidate the results into a single, ordered list of max entries.
-        List<AutocompleteResultsModel> results = new ArrayList<AutocompleteResultsModel>();
+        List<AutocompleteResultsModel> results = new ArrayList<>();
         for (List<AutocompleteResultsModel> items : prioritizedResultsMap.values()) {
             results.addAll(items);
             if (results.size() >= maxAutocompleteSearchResults) {
@@ -729,8 +728,7 @@ public class SearchPortletController {
     }
 
     private SortedMap<Integer, List<AutocompleteResultsModel>> createAutocompletePriorityMap() {
-        SortedMap<Integer, List<AutocompleteResultsModel>> resultsMap =
-                new TreeMap<Integer, List<AutocompleteResultsModel>>();
+        SortedMap<Integer, List<AutocompleteResultsModel>> resultsMap = new TreeMap<>();
         for (Map.Entry<String, Integer> entry : autocompleteResultTypeToPriorityMap.entrySet()) {
             if (!resultsMap.containsKey(entry.getValue())) {
                 resultsMap.put(entry.getValue(), new ArrayList<AutocompleteResultsModel>());

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/search/google/GoogleCustomSearchService.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/search/google/GoogleCustomSearchService.java
@@ -94,7 +94,7 @@ public class GoogleCustomSearchService implements IPortalSearchService {
 
     @Override
     public SearchResults getSearchResults(PortletRequest request, SearchRequest query) {
-        final Map<String, Object> parameters = new LinkedHashMap<String, Object>();
+        final Map<String, Object> parameters = new LinkedHashMap<>();
 
         parameters.put(VERSION_PARAM, VERSION);
         parameters.put(RESULT_SIZE_PARAM, resultSize);

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/search/gsa/GsaSearchService.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/search/gsa/GsaSearchService.java
@@ -70,7 +70,7 @@ public class GsaSearchService implements IPortalSearchService {
 
     protected SearchResults search(String query) {
 
-        Map<String, String> vars = new HashMap<String, String>();
+        Map<String, String> vars = new HashMap<>();
         vars.put("query", query);
         vars.put("baseUrl", gsaBaseUrl);
         vars.put("site", gsaSite);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Cleans up the search portlet to remove type annotations on operators that can be determined from variable declarations and the operands.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
