### PR TITLE
UP-4835 - removed the running groovy in interactive mode code 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1048,7 +1048,8 @@
     </target>
 
     <!-- Internal use -->
-    <target name="up-shell" description="Run a uPortal Groovy Shell. Interactive or scripted using -Dscript=">
+	<!-- Following target run a uPortal Groovy Shell. Scripted using -Dscript=" -->
+    <target name="up-shell">
         <if>
             <not>
                 <istrue value="${skip-up-shell-execution}" />
@@ -1074,17 +1075,7 @@
                                 <arg value="${arg2}"/>
                             </java>
                         </then>
-                        <else>
-                            <echo>Interactive Mode</echo>
-
-                            <java fork="true" failonerror="true" dir="${basedir}" classname="org.apereo.portal.shell.PortalShell">
-                                <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
-                                <sysproperty key="java.awt.headless" value="true"/>
-                                <classpath refid="uportal-war-full.classpath" />
-                            </java>
-                        </else>
                     </if>
-
                 </uportal-war-macro>
             </then>
         </if>

--- a/uportal-war/src/main/java/org/apereo/portal/shell/PortalShell.java
+++ b/uportal-war/src/main/java/org/apereo/portal/shell/PortalShell.java
@@ -29,8 +29,6 @@ import org.apache.commons.cli.PosixParser;
 import org.apache.tools.ant.util.FileUtils;
 import org.apereo.portal.utils.PortalApplicationContextLocator;
 import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.tools.shell.Groovysh;
-import org.codehaus.groovy.tools.shell.IO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -76,9 +74,6 @@ public class PortalShell {
                         new CompilerConfiguration(System.getProperties());
                 final GroovyShell shell = new GroovyShell(binding, conf);
                 shell.run(scriptFile, args);
-            } else {
-                final Groovysh shell = new Groovysh(binding, new IO());
-                shell.run();
             }
         } finally {
             if (applicationContext instanceof DisposableBean) {


### PR DESCRIPTION
Removed the running the groovy in interactive mode code from up-shell ant target and PortelShell.java
Issue  link - https://issues.jasig.org/browse/UP-4835
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]


##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
