### PR TITLE
UP-4838:  Provide a new permission governing access to one's own user…

### DIFF
--- a/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
+++ b/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
@@ -32,7 +32,7 @@
     <activity>
         <name>View own attribute</name>
         <fname>VIEW_OWN_USER_ATTRIBUTE</fname>
-        <desc>View the value(s) of one's own user attribute</desc>
+        <desc>View one's own value(s) for the specified user attribute.  This permission is cumulative with VIEW_USER_ATTRIBUTE</desc>
         <targetProvider>userAttributesTargetProvider</targetProvider>
     </activity>
     <activity>

--- a/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
+++ b/uportal-war/src/main/data/default_entities/permission_owner/UP_USERS.permission-owner.xml
@@ -30,6 +30,12 @@
         <targetProvider>userAttributesTargetProvider</targetProvider>
     </activity>
     <activity>
+        <name>View own attribute</name>
+        <fname>VIEW_OWN_USER_ATTRIBUTE</fname>
+        <desc>View the value(s) of one's own user attribute</desc>
+        <targetProvider>userAttributesTargetProvider</targetProvider>
+    </activity>
+    <activity>
         <name>View user</name>
         <fname>VIEW_USER</fname>
         <desc>View a user.</desc>

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImpl.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImpl.java
@@ -420,8 +420,9 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
     }
 
     /**
-     * Filter the provided set of user attribute names to contain only those the specified principal
-     * has permissions to view.
+     * Filter the specified set of user attribute names to contain only those that the specified
+     * principal may perform <code>IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY</code>.  These are
+     * user attributes the user has general permission to view, for all visible users.
      *
      * @param principal
      * @param attributeNames
@@ -440,12 +441,15 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
     }
 
     /**
-     * Filter the provided set of user attribute names to contain only those the specified principal
-     * has permissions to view.
+     * Provide a complete set of user attribute names that the specified principal may view within
+     * his or her own collection.  These will be attributes for which the user has <em>either</em>
+     * <code>IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY</code> or
+     * <code>IPermission.VIEW_OWN_USER_ATTRIBUTE_ACTIVITY</code>.
      *
-     * @param principal
-     * @param generallyPermittedAttributes
-     * @return
+     * @param principal Represents a portal user who wishes to view user attributes
+     * @param generallyPermittedAttributes The collection of user attribute name this user may view
+     *                                     for any visible user
+     * @since 5.0
      */
     protected Set<String> getPermittedOwnAttributes(
             final IAuthorizationPrincipal principal, final Set<String> generallyPermittedAttributes) {

--- a/uportal-war/src/main/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImpl.java
+++ b/uportal-war/src/main/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImpl.java
@@ -202,11 +202,11 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
 
         // build a set of all possible user attributes the current user has
         // permission to view
-        final Set<String> permittedAttributes = getAvailableAttributes(principal);
+        final Set<String> permittedAttributes = getPermittedAttributes(principal);
 
         // remove any query attributes that the user does not have permission
         // to view
-        final Map<String, Object> inUseQuery = new HashMap<String, Object>();
+        final Map<String, Object> inUseQuery = new HashMap<>();
         for (Map.Entry<String, Object> queryEntry : query.entrySet()) {
             final String attr = queryEntry.getKey();
             if (permittedAttributes.contains(attr)) {
@@ -293,7 +293,7 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
         // For each person in the list, check to see if the current user has permission to view this user
         for (IPersonAttributes person : peopleList) {
             Callable<IPersonAttributes> worker =
-                    new GetVisiblePerson(principal, person, permittedAttributes, requestAttributes);
+                    new FetchVisiblePersonCallable(principal, person, permittedAttributes, requestAttributes);
             Future<IPersonAttributes> task = executor.submit(worker);
             futures.add(task);
         }
@@ -323,13 +323,13 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
      * Utility class for executor framework for search persons processing. Ugly - person directory
      * needs the requestAttributes in the RequestContextHolder set for each thread from the caller.
      */
-    private class GetVisiblePerson implements Callable<IPersonAttributes> {
+    private class FetchVisiblePersonCallable implements Callable<IPersonAttributes> {
         private IAuthorizationPrincipal principal;
         private IPersonAttributes person;
         private Set<String> permittedAttributes;
         private RequestAttributes requestAttributes;
 
-        public GetVisiblePerson(
+        public FetchVisiblePersonCallable(
                 IAuthorizationPrincipal principal,
                 IPersonAttributes person,
                 Set<String> permittedAttributes,
@@ -380,7 +380,7 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
 
         // build a set of all possible user attributes the current user has
         // permission to view
-        final Set<String> permittedAttributes = getAvailableAttributes(principal);
+        final Set<String> permittedAttributes = getPermittedAttributes(principal);
 
         // get the set of people matching the search query
         final IPersonAttributes person = this.personAttributeDao.getPerson(username);
@@ -414,9 +414,9 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
      * @param principal
      * @return
      */
-    protected Set<String> getAvailableAttributes(final IAuthorizationPrincipal principal) {
-        final Set<String> attributeNames = this.personAttributeDao.getPossibleUserAttributeNames();
-        return getAvailableAttributes(principal, attributeNames);
+    protected Set<String> getPermittedAttributes(final IAuthorizationPrincipal principal) {
+        final Set<String> attributeNames = personAttributeDao.getPossibleUserAttributeNames();
+        return getPermittedAttributes(principal, attributeNames);
     }
 
     /**
@@ -427,9 +427,9 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
      * @param attributeNames
      * @return
      */
-    protected Set<String> getAvailableAttributes(
+    protected Set<String> getPermittedAttributes(
             final IAuthorizationPrincipal principal, final Set<String> attributeNames) {
-        final Set<String> permittedAttributes = new HashSet<String>();
+        final Set<String> permittedAttributes = new HashSet<>();
         for (String attr : attributeNames) {
             if (principal.hasPermission(
                     IPermission.PORTAL_USERS, IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY, attr)) {
@@ -440,19 +440,44 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
     }
 
     /**
+     * Filter the provided set of user attribute names to contain only those the specified principal
+     * has permissions to view.
+     *
+     * @param principal
+     * @param generallyPermittedAttributes
+     * @return
+     */
+    protected Set<String> getPermittedOwnAttributes(
+            final IAuthorizationPrincipal principal, final Set<String> generallyPermittedAttributes) {
+
+        // The permttedOwnAttributes collection includes all the generallyPermittedAttributes
+        final Set<String> rslt = new HashSet<>(generallyPermittedAttributes);
+
+        for (String attr : personAttributeDao.getPossibleUserAttributeNames()) {
+            if (principal.hasPermission(
+                    IPermission.PORTAL_USERS, IPermission.VIEW_OWN_USER_ATTRIBUTE_ACTIVITY, attr)) {
+                rslt.add(attr);
+            }
+        }
+
+        return rslt;
+
+    }
+
+    /**
      * Filter an IPersonAttributes for a specified viewing principal. The returned person will
      * contain only the attributes provided in the permitted attributes list. <code>null</code> if
      * the principal does not have permission to view the user.
      *
      * @param principal
      * @param person
-     * @param permittedAttributes
+     * @param generallyPermittedAttributes
      * @return
      */
     protected IPersonAttributes getVisiblePerson(
             final IAuthorizationPrincipal principal,
             final IPersonAttributes person,
-            final Set<String> permittedAttributes) {
+            final Set<String> generallyPermittedAttributes) {
 
         // first check to see if the principal has permission to view this person.  Unfortunately for
         // non-admin users, this will result in a call to PersonDirectory (which may go out to LDAP or
@@ -464,9 +489,14 @@ public class PersonLookupHelperImpl implements IPersonLookupHelper {
                         IPermission.VIEW_USER_ACTIVITY,
                         person.getName())) {
 
-            // if the user has permission, filter the person attributes according
-            // to the specified permitted attributes
-            final Map<String, List<Object>> visibleAttributes = new HashMap<String, List<Object>>();
+            // If the user has permission, filter the person attributes according
+            // to the specified permitted attributes;  the collection of permitted
+            // attributes can be different based on whether the user is trying to
+            // access information about him/herself.
+            final Set<String> permittedAttributes = person.getName().equals(principal.getKey())
+                    ? getPermittedOwnAttributes(principal, generallyPermittedAttributes)
+                    : generallyPermittedAttributes;
+            final Map<String, List<Object>> visibleAttributes = new HashMap<>();
             for (String attr : person.getAttributes().keySet()) {
                 if (permittedAttributes.contains(attr)) {
                     visibleAttributes.put(attr, person.getAttributeValues(attr));

--- a/uportal-war/src/main/java/org/apereo/portal/rest/PeopleRESTControllerV50.java
+++ b/uportal-war/src/main/java/org/apereo/portal/rest/PeopleRESTControllerV50.java
@@ -115,14 +115,14 @@ public final class PeopleRESTControllerV50 {
         final IPerson me = personManager.getPerson(request);
 
         if (me == null) {
-            //If null, this person is not logged in.
+            //If null, this person does not have a proper portal session.
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return null;
         }
 
         final IPersonAttributes person = lookupHelper.findPerson(me, me.getUserName());
         if (person == null) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }
 

--- a/uportal-war/src/main/java/org/apereo/portal/rest/PeopleRESTControllerV50.java
+++ b/uportal-war/src/main/java/org/apereo/portal/rest/PeopleRESTControllerV50.java
@@ -116,10 +116,18 @@ public final class PeopleRESTControllerV50 {
 
         if (me == null) {
             //If null, this person is not logged in.
-            response.setStatus(401);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return null;
         }
 
-        return new ModelAndView("json", me.getAttributeMap());
+        final IPersonAttributes person = lookupHelper.findPerson(me, me.getUserName());
+        if (person == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }
+
+        return new ModelAndView("json", person.getAttributes());
+
     }
+
 }

--- a/uportal-war/src/main/java/org/apereo/portal/security/IAuthorizationPrincipal.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/IAuthorizationPrincipal.java
@@ -43,7 +43,7 @@ public interface IAuthorizationPrincipal {
      * @exception AuthorizationException thrown when authorization information could not be
      *     retrieved.
      */
-    public boolean canManage(PortletLifecycleState state, String categoryId)
+    boolean canManage(PortletLifecycleState state, String categoryId)
             throws AuthorizationException;
     /**
      * Answers if this <code>IAuthorizationPrincipal</code> has permission to use the CONFIG
@@ -53,7 +53,7 @@ public interface IAuthorizationPrincipal {
      * @return
      * @throws AuthorizationException
      */
-    public boolean canConfigure(String channelPublishId) throws AuthorizationException;
+    boolean canConfigure(String channelPublishId) throws AuthorizationException;
     /**
      * Answers if this <code>IAuthoriztionPrincipal</code> has permission to render this channel.
      *
@@ -80,7 +80,7 @@ public interface IAuthorizationPrincipal {
      * @return org.apereo.portal.security.IPermission[]
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public IPermission[] getAllPermissions() throws AuthorizationException;
+    IPermission[] getAllPermissions() throws AuthorizationException;
     /**
      * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code> for the
      * specified <code>owner</code>, <code>activity</code> and <code>target</code>. This includes
@@ -94,7 +94,7 @@ public interface IAuthorizationPrincipal {
      * @param target java.lang.String
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public IPermission[] getAllPermissions(String owner, String activity, String target)
+    IPermission[] getAllPermissions(String owner, String activity, String target)
             throws AuthorizationException;
     /**
      * Return a Vector of IChannels.
@@ -102,20 +102,20 @@ public interface IAuthorizationPrincipal {
      * @return a <code>java.util.Vector</code> of IChannels
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public Vector getAuthorizedChannels() throws AuthorizationException;
+    Vector getAuthorizedChannels() throws AuthorizationException;
     /**
-     * Returns the key of the underlying entity.
+     * Returns the key of the underlying entity.  For users, the key will be the username.
      *
      * @return java.lang.String
      */
-    public String getKey();
+    String getKey();
     /**
      * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code>.
      *
      * @return org.apereo.portal.security.IPermission[]
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public IPermission[] getPermissions() throws AuthorizationException;
+    IPermission[] getPermissions() throws AuthorizationException;
     /**
      * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code> for the
      * specified <code>owner</code>, <code>activity</code> and <code>target</code>. Null parameters
@@ -128,16 +128,16 @@ public interface IAuthorizationPrincipal {
      * @param target java.lang.String
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public IPermission[] getPermissions(String owner, String activity, String target)
+    IPermission[] getPermissions(String owner, String activity, String target)
             throws AuthorizationException;
     /** @return java.lang.String */
-    public String getPrincipalString();
+    String getPrincipalString();
     /**
      * Return the Type of the underlying entity.
      *
      * @return java.lang.Class
      */
-    public Class getType();
+    Class getType();
 
     /**
      * Indicates whether the entity represented by this principal is a group (branch node) or user
@@ -158,7 +158,7 @@ public interface IAuthorizationPrincipal {
      * @param target java.lang.String
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public boolean hasPermission(String owner, String activity, String target)
+    boolean hasPermission(String owner, String activity, String target)
             throws AuthorizationException;
 
     /**
@@ -173,7 +173,7 @@ public interface IAuthorizationPrincipal {
      * @param policy org.apereo.portal.security.IPermissionPolicy
      * @exception AuthorizationException indicates authorization information could not be retrieved.
      */
-    public boolean hasPermission(
+    boolean hasPermission(
             String owner, String activity, String target, IPermissionPolicy policy)
             throws AuthorizationException;
 }

--- a/uportal-war/src/main/java/org/apereo/portal/security/IPermission.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/IPermission.java
@@ -31,41 +31,41 @@ public interface IPermission {
      * Allows the user to view or add to his or her layout a portlet that is in the <code>CREATED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_SUBSCRIBER_CREATED_ACTIVITY = "SUBSCRIBE_CREATED";
+    String PORTLET_SUBSCRIBER_CREATED_ACTIVITY = "SUBSCRIBE_CREATED";
     /**
      * Allows the user to view or add to his or her layout a portlet that is in the <code>APPROVED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_SUBSCRIBER_APPROVED_ACTIVITY = "SUBSCRIBE_APPROVED";
+    String PORTLET_SUBSCRIBER_APPROVED_ACTIVITY = "SUBSCRIBE_APPROVED";
     /**
      * The standard <code>SUBSCRIBE</code> activity. Allows the user to view or add to his or her
      * layout a portlet that is in the <code>PUBLISHED</code> lifecycle state.
      */
-    public static final String PORTLET_SUBSCRIBER_ACTIVITY = "SUBSCRIBE";
+    String PORTLET_SUBSCRIBER_ACTIVITY = "SUBSCRIBE";
     /**
      * Allows the user to view or add to his or her layout a portlet that is in the <code>EXPIRED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_SUBSCRIBER_EXPIRED_ACTIVITY = "SUBSCRIBE_EXPIRED";
+    String PORTLET_SUBSCRIBER_EXPIRED_ACTIVITY = "SUBSCRIBE_EXPIRED";
 
     /**
      * Portlet subscribe permission to view ("browse") marketplace entry.
      *
      * @since uPortal 4.1
      */
-    public static final String PORTLET_BROWSE_ACTIVITY = "BROWSE";
+    String PORTLET_BROWSE_ACTIVITY = "BROWSE";
 
     /**
      * Permission to favorite/star a portlet.
      *
      * @since uPortal 5.0
      */
-    public static final String PORTLET_FAVORITE_ACTIVITY = "FAVORITE";
+    String PORTLET_FAVORITE_ACTIVITY = "FAVORITE";
 
     /*
      * Portlet management permissions by portlet type.
      */
-    public static final String PORTLET_MANAGER_SELECT_PORTLET_TYPE = "SELECT_PORTLET_TYPE";
+    String PORTLET_MANAGER_SELECT_PORTLET_TYPE = "SELECT_PORTLET_TYPE";
 
     /*
      * Portlet management permissions listed
@@ -76,33 +76,33 @@ public interface IPermission {
      * Allows the user to edit the publication metadata of a portlet that is in the <code>CREATED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_MANAGER_CREATED_ACTIVITY = "MANAGE_CREATED";
+    String PORTLET_MANAGER_CREATED_ACTIVITY = "MANAGE_CREATED";
     /**
      * Allows the user to edit the publication metadata of a portlet that is in the <code>APPROVED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_MANAGER_APPROVED_ACTIVITY = "MANAGE_APPROVED";
+    String PORTLET_MANAGER_APPROVED_ACTIVITY = "MANAGE_APPROVED";
     /**
      * The standard <code>MANAGE</code> activity. Allows the user to edit the publication metadata
      * of a portlet that is in the <code>PUBLISHED</code> lifecycle state.
      */
-    public static final String PORTLET_MANAGER_ACTIVITY = "MANAGE";
+    String PORTLET_MANAGER_ACTIVITY = "MANAGE";
     /**
      * Allows the user to edit the publication metadata of a portlet that is in the <code>EXPIRED
      * </code> lifecycle state.
      */
-    public static final String PORTLET_MANAGER_EXPIRED_ACTIVITY = "MANAGE_EXPIRED";
+    String PORTLET_MANAGER_EXPIRED_ACTIVITY = "MANAGE_EXPIRED";
     /**
      * Allows the user to edit the publication metadata of a portlet that is in the <code>
      * MAINTENANCE</code> lifecycle state.
      *
      * @since 4.2
      */
-    public static final String PORTLET_MANAGER_MAINTENANCE_ACTIVITY = "MANAGE_MAINTENANCE";
+    String PORTLET_MANAGER_MAINTENANCE_ACTIVITY = "MANAGE_MAINTENANCE";
 
     /** All management permissions in one handy array. Used within the edit-portlet flow. */
     @SuppressWarnings("ucd")
-    public static final String[] PORTLET_MANAGER_MANAGE_ACTIVITIES =
+    String[] PORTLET_MANAGER_MANAGE_ACTIVITIES =
             new String[] {
                 PORTLET_MANAGER_CREATED_ACTIVITY, PORTLET_MANAGER_APPROVED_ACTIVITY,
                 PORTLET_MANAGER_ACTIVITY, PORTLET_MANAGER_EXPIRED_ACTIVITY,
@@ -112,42 +112,59 @@ public interface IPermission {
     /*
      * PortletMode permissions
      */
-    public static final String PORTLET_MODE_CONFIG = "PORTLET_MODE_CONFIG";
+    String PORTLET_MODE_CONFIG = "PORTLET_MODE_CONFIG";
 
     /*
      * UP_GROUP (GaP) Permissions
      */
 
-    public static final String VIEW_GROUP_ACTIVITY = "VIEW_GROUP";
-    public static final String CREATE_GROUP_ACTIVITY = "CREATE_GROUP";
-    public static final String DELETE_GROUP_ACTIVITY = "DELETE_GROUP";
-    public static final String EDIT_GROUP_ACTIVITY = "EDIT_GROUP";
+    String VIEW_GROUP_ACTIVITY = "VIEW_GROUP";
+    String CREATE_GROUP_ACTIVITY = "CREATE_GROUP";
+    String DELETE_GROUP_ACTIVITY = "DELETE_GROUP";
+    String EDIT_GROUP_ACTIVITY = "EDIT_GROUP";
 
     /** Activity string for adding a tab to your personal layout */
-    public static final String ADD_TAB_ACTIVITY = "ADD_TAB";
+    String ADD_TAB_ACTIVITY = "ADD_TAB";
 
     /** Non-owner-specific view activity (used by ERROR_PORTLET) */
-    public static final String VIEW_ACTIVITY = "VIEW";
+    String VIEW_ACTIVITY = "VIEW";
 
-    public static final String VIEW_USER_ACTIVITY = "VIEW_USER";
-    public static final String VIEW_USER_ATTRIBUTE_ACTIVITY = "VIEW_USER_ATTRIBUTE";
-    public static final String IMPERSONATE_USER_ACTIVITY = "IMPERSONATE";
+    /**
+     * Determines whether a user is visible within the portal.
+     */
+    String VIEW_USER_ACTIVITY = "VIEW_USER";
 
-    public static final String VIEW_PERMISSIONS_ACTIVITY = "VIEW_PERMISSIONS";
-    public static final String EDIT_PERMISSIONS_ACTIVITY = "EDIT_PERMISSIONS";
+    /**
+     * Governs which user attributes are visible within the portal, applies
+     * to attributes of others as well as one's own attributes.
+     */
+    String VIEW_USER_ATTRIBUTE_ACTIVITY = "VIEW_USER_ATTRIBUTE";
+
+    /**
+     * Governs the visibility of one's own user attributes.
+     */
+    String VIEW_OWN_USER_ATTRIBUTE_ACTIVITY = "VIEW_OWN_USER_ATTRIBUTE";
+
+    /**
+     * Governs the ability to become another user through the User Manager.
+     */
+    String IMPERSONATE_USER_ACTIVITY = "IMPERSONATE";
+
+    String VIEW_PERMISSIONS_ACTIVITY = "VIEW_PERMISSIONS";
+    String EDIT_PERMISSIONS_ACTIVITY = "EDIT_PERMISSIONS";
 
     /*
      * These two are used in the ImportExportPortlet;  the command-line tool does
      * not check permissions.
      */
-    public static final String EXPORT_ACTIVITY = "EXPORT_ENTITY";
-    public static final String DELETE_ACTIVITY = "DELETE_ENTITY";
+    String EXPORT_ACTIVITY = "EXPORT_ENTITY";
+    String DELETE_ACTIVITY = "DELETE_ENTITY";
 
     /*
       Permission types.  At present only 2, but that could change.
     */
-    public static final String PERMISSION_TYPE_GRANT = "GRANT";
-    public static final String PERMISSION_TYPE_DENY = "DENY";
+    String PERMISSION_TYPE_GRANT = "GRANT";
+    String PERMISSION_TYPE_DENY = "DENY";
 
     /*
      * Permission Owner Strings
@@ -157,20 +174,20 @@ public interface IPermission {
      * A String representing the uPortal framework, used, for example, for Permission.owner when the
      * framework grants a Permission.
      */
-    public static final String PORTAL_SYSTEM = "UP_SYSTEM";
+    String PORTAL_SYSTEM = "UP_SYSTEM";
 
     /** Represents the GaP subsystem as a permissions owner */
-    public static final String PORTAL_GROUPS = "UP_GROUPS";
+    String PORTAL_GROUPS = "UP_GROUPS";
 
-    public static final String PORTAL_PUBLISH = "UP_PORTLET_PUBLISH";
+    String PORTAL_PUBLISH = "UP_PORTLET_PUBLISH";
 
-    public static final String PORTAL_SUBSCRIBE = "UP_PORTLET_SUBSCRIBE";
+    String PORTAL_SUBSCRIBE = "UP_PORTLET_SUBSCRIBE";
 
-    public static final String PORTAL_USERS = "UP_USERS";
+    String PORTAL_USERS = "UP_USERS";
 
-    public static final String PORTAL_PERMISSIONS = "UP_PERMISSIONS";
+    String PORTAL_PERMISSIONS = "UP_PERMISSIONS";
 
-    public static final String ERROR_PORTLET = "UP_ERROR_CHAN";
+    String ERROR_PORTLET = "UP_ERROR_CHAN";
 
     /*
       A String which, when concatentated with a portlet id, represents a portal
@@ -178,95 +195,95 @@ public interface IPermission {
       grants a Permission to perform some activity on a portlet.
       See PermissionHelper for a convenience method for correctly using this.
     */
-    public static final String PORTLET_PREFIX = "PORTLET_ID.";
+    String PORTLET_PREFIX = "PORTLET_ID.";
 
-    public static final String ALL_PORTLET_TYPES = "ALL_PORTLET_TYPES";
+    String ALL_PORTLET_TYPES = "ALL_PORTLET_TYPES";
 
-    public static final String ALL_PORTLETS_TARGET = "ALL_PORTLETS";
+    String ALL_PORTLETS_TARGET = "ALL_PORTLETS";
 
-    public static final String ALL_GROUPS_TARGET = "ALL_GROUPS";
+    String ALL_GROUPS_TARGET = "ALL_GROUPS";
 
-    public static final String ALL_CATEGORIES_TARGET = "ALL_CATEGORIES";
+    String ALL_CATEGORIES_TARGET = "ALL_CATEGORIES";
 
-    public static final String ALL_PERMISSIONS_ACTIVITY = "ALL_PERMISSIONS";
+    String ALL_PERMISSIONS_ACTIVITY = "ALL_PERMISSIONS";
 
-    public static final String ALL_TARGET = "ALL";
+    String ALL_TARGET = "ALL";
 
     /** Non-owner-specific details target string (used by ERROR_PORTLET) */
-    public static final String DETAILS_TARGET = "DETAILS";
+    String DETAILS_TARGET = "DETAILS";
 
     /**
      * Gets the activity associated with this <code>IPermission</code>.
      *
      * @return String
      */
-    public String getActivity();
+    String getActivity();
 
     /**
      * Gets that date that this <code>IPermission</code> should become effective on.
      *
      * @return date that this <code>IPermission</code> should become effective on
      */
-    public Date getEffective();
+    Date getEffective();
 
     /**
      * Gets the date that this <code>IPermission</code> should expire on.
      *
      * @return date that this <code>IPermission</code> should expire on
      */
-    public Date getExpires();
+    Date getExpires();
 
     /**
      * Returns the owner of this <code>IPermission</code>.
      *
      * @return owner of this <code>IPermission</code>
      */
-    public String getOwner();
+    String getOwner();
 
     /**
      * Gets the target associated with this <code>IPermission</code>.
      *
      * @return target associated with this <code>IPermission</code>
      */
-    public String getTarget();
+    String getTarget();
 
     /** Returns the <code>Permission</code> type. */
-    public String getType();
+    String getType();
 
     /**
      * Sets the activity associated with this <code>IPermission</code>.
      *
      * @param activity String
      */
-    public void setActivity(String activity);
+    void setActivity(String activity);
 
     /**
      * Sets the date that this <code>IPermission</code> should become effective on.
      *
      * @param effective java.util.Date
      */
-    public void setEffective(Date effective);
+    void setEffective(Date effective);
 
     /**
      * Sets the date that this <code>IPermission</code> should expire on.
      *
      * @param expires java.util.Date
      */
-    public void setExpires(Date expires);
+    void setExpires(Date expires);
 
     /**
      * Sets the target associated with this <code>IPermission</code>.
      *
      * @param target
      */
-    public void setTarget(String target);
+    void setTarget(String target);
 
     /**
      * Sets the <code>IPermission</code> type.
      *
      * @param type String
      */
-    public abstract void setType(String type);
+    void setType(String type);
 
     /**
      * Returns a String representing the <code>IAuthorizationPrincipal</code> associated with this
@@ -274,7 +291,7 @@ public interface IPermission {
      *
      * @return IAuthorizationPrincipal associated with this IPermission
      */
-    public String getPrincipal();
+    String getPrincipal();
 
     /**
      * Sets the principal String representing the <code>IAuthorizationPrincipal</code> associated
@@ -282,5 +299,6 @@ public interface IPermission {
      *
      * @param newPrincipal String
      */
-    public void setPrincipal(String newPrincipal);
+    void setPrincipal(String newPrincipal);
+
 }

--- a/uportal-war/src/main/java/org/apereo/portal/security/IPermission.java
+++ b/uportal-war/src/main/java/org/apereo/portal/security/IPermission.java
@@ -141,7 +141,12 @@ public interface IPermission {
     String VIEW_USER_ATTRIBUTE_ACTIVITY = "VIEW_USER_ATTRIBUTE";
 
     /**
-     * Governs the visibility of one's own user attributes.
+     * Governs additional visibility of one's own user attributes.  When it comes to their own
+     * attributes, users may view those for which they have either
+     * <code>VIEW_USER_ATTRIBUTE_ACTIVITY</code> or <code>VIEW_OWN_USER_ATTRIBUTE_ACTIVITY</code>
+     * permission.
+     *
+     * @since 5.0
      */
     String VIEW_OWN_USER_ATTRIBUTE_ACTIVITY = "VIEW_OWN_USER_ATTRIBUTE";
 

--- a/uportal-war/src/test/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImplTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/portlets/lookup/PersonLookupHelperImplTest.java
@@ -1,0 +1,109 @@
+package org.apereo.portal.portlets.lookup;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apereo.portal.security.IAuthorizationPrincipal;
+import org.apereo.portal.security.IPermission;
+import org.jasig.services.persondir.IPersonAttributeDao;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PersonLookupHelperImpl}.
+ *
+ * @since 5.0
+ */
+public class PersonLookupHelperImplTest extends PersonLookupHelperImpl {
+
+    private static final String GENERALLY_PERMITTED_ATTRIBUTE = "generally.permitted.attribute";
+    private static final String PERMITTED_OWN_ATTRIBUTE = "permitted.own.attribute";
+    private static final String NEVER_PERMITTED_ATTRIBUTE = "never.permitted.attribute";
+
+    private static final Set<String> ALL_ATTRIBUTES = Collections.unmodifiableSet(
+            new HashSet<>(
+                    Arrays.asList(
+                            new String[] {
+                                    GENERALLY_PERMITTED_ATTRIBUTE,
+                                    PERMITTED_OWN_ATTRIBUTE,
+                                    NEVER_PERMITTED_ATTRIBUTE
+                            }
+                    )
+            ));
+
+    private IAuthorizationPrincipal principal;
+
+    @Before
+    public void init() {
+
+        // Must make the superclass use our collection of attribute names
+        IPersonAttributeDao personAttributeDao = mock(IPersonAttributeDao.class);
+        when(personAttributeDao.getPossibleUserAttributeNames()).thenReturn(ALL_ATTRIBUTES);
+        setPersonAttributeDao(personAttributeDao);
+
+        principal = mock(IAuthorizationPrincipal.class);
+
+        // Generally permitted
+        when(principal.hasPermission(
+                IPermission.PORTAL_USERS,
+                IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY,
+                GENERALLY_PERMITTED_ATTRIBUTE)
+        ).thenReturn(true);
+        when(principal.hasPermission(
+                IPermission.PORTAL_USERS,
+                IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY,
+                PERMITTED_OWN_ATTRIBUTE)
+        ).thenReturn(false);
+        when(principal.hasPermission(
+                IPermission.PORTAL_USERS,
+                IPermission.VIEW_USER_ATTRIBUTE_ACTIVITY,
+                NEVER_PERMITTED_ATTRIBUTE)
+        ).thenReturn(false);
+
+        // Own attributes
+        when(principal.hasPermission(
+                IPermission.PORTAL_USERS,
+                IPermission.VIEW_OWN_USER_ATTRIBUTE_ACTIVITY,
+                GENERALLY_PERMITTED_ATTRIBUTE)
+        ).thenReturn(true);
+        when(principal.hasPermission(
+                IPermission.PORTAL_USERS,
+                IPermission.VIEW_OWN_USER_ATTRIBUTE_ACTIVITY,
+                PERMITTED_OWN_ATTRIBUTE)
+        ).thenReturn(true);
+        when(principal.hasPermission(IPermission.PORTAL_USERS,
+                IPermission.VIEW_OWN_USER_ATTRIBUTE_ACTIVITY,
+                NEVER_PERMITTED_ATTRIBUTE)
+        ).thenReturn(false);
+
+    }
+
+    @Test
+    public void testGetPermittedAttributes() {
+
+        final Set<String> permittedAttributes = getPermittedAttributes(principal, ALL_ATTRIBUTES);
+
+        assertTrue(permittedAttributes.contains(GENERALLY_PERMITTED_ATTRIBUTE));
+        assertFalse(permittedAttributes.contains(PERMITTED_OWN_ATTRIBUTE));
+        assertFalse(permittedAttributes.contains(NEVER_PERMITTED_ATTRIBUTE));
+
+    }
+
+    @Test
+    public void testGetPermittedOwnAttributes() {
+
+        final Set<String> permittedAttributes = getPermittedAttributes(principal, ALL_ATTRIBUTES);
+        final Set<String> permittedOwnAttributes = getPermittedOwnAttributes(principal, permittedAttributes);
+
+        assertTrue(permittedOwnAttributes.contains(GENERALLY_PERMITTED_ATTRIBUTE));
+        assertTrue(permittedOwnAttributes.contains(PERMITTED_OWN_ATTRIBUTE));
+        assertFalse(permittedOwnAttributes.contains(NEVER_PERMITTED_ATTRIBUTE));
+
+    }
+
+}


### PR DESCRIPTION
… attributes

https://issues.jasig.org/browse/UP-4838

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR introduces a the VIEW_OWN_USER_ATTRIBUTE permission.  It allows you to see more of your own attributes than the attributes you can generally see for users visible (to you) in the portal.

Using this new permission is optional -- having the (original) "VIEW_USER_ATTRIBUTE" permission still gives you access to information about yourself.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
