### PR TITLE
Backport UP-4835 Remove Groovy Interactive Shell to rel-4-3-patches

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -27,7 +27,7 @@
 <project name="uPortal" default="help" basedir="." xmlns:up="urn:up-util-ant" xmlns:artifact="urn:maven-artifact-ant">
 
     <!--
-     | Determine if a named environment has been specified in the command.  
+     | Determine if a named environment has been specified in the command.
      | Examples:  dev, test, prod, local, etc.
      +-->
     <condition property="environment.token" value="${env}">
@@ -195,7 +195,7 @@
                 </not>
             </condition>
         </fail>
-    	
+
         <antcall target="db-hibernate-gen-update-script">
             <param name="outputDir" value="${outputDir}"/>
         </antcall>
@@ -859,7 +859,7 @@
         	logger.info("");
         	logger.info("");
         	logger.info("Update Database " + '${databaseQualifier}');
-        	
+
         	//hibernateUpdate(String target, String databaseQualifier, boolean export, String outputFile)
             portalShellBuildHelper.hibernateUpdate("db-hibernate-update",
         	    '${databaseQualifier}',
@@ -884,7 +884,7 @@
 	            logger.info("");
 	            logger.info("");
 	            logger.info("Generate Update Script for Database " + '${databaseQualifier}');
-	            
+
 	            //hibernateGenerateScript(String target, String databaseQualifier, String outputFile);
 	            portalShellBuildHelper.hibernateGenerateScript(
 	        	    "db-hibernate-update",
@@ -1050,7 +1050,8 @@
     </target>
 
     <!-- Internal use -->
-    <target name="up-shell" description="Run a uPortal Groovy Shell. Interactive or scripted using -Dscript=">
+	<!-- Following target run a uPortal Groovy Shell. Scripted using -Dscript=" -->
+    <target name="up-shell">
         <if>
             <not>
                 <istrue value="${skip-up-shell-execution}" />
@@ -1076,17 +1077,7 @@
                                 <arg value="${arg2}"/>
                             </java>
                         </then>
-                        <else>
-                            <echo>Interactive Mode</echo>
-
-                            <java fork="true" failonerror="true" dir="${basedir}" classname="org.jasig.portal.shell.PortalShell">
-                                <sysproperty key="logback.configurationFile" value="command-line.logback.xml" />
-                                <sysproperty key="java.awt.headless" value="true"/>
-                                <classpath refid="uportal-war-full.classpath" />
-                            </java>
-                        </else>
                     </if>
-
                 </uportal-war-macro>
             </then>
         </if>
@@ -1356,7 +1347,7 @@ IMPORTANT: The '-Dpattern=' property is no longer a regular expression and is a 
             <!--
              | Called via the <ant> task so the install happens in a different classloader. This
              | is required so an initial install which is missing jasig-parent doesn't cause problems
-             | later due to the failed load of jasig-parent being cached.  
+             | later due to the failed load of jasig-parent being cached.
              +-->
             <if>
                 <not>
@@ -1505,7 +1496,7 @@ IMPORTANT: The '-Dpattern=' property is no longer a regular expression and is a 
             </uportal-parent-macro>
         </sequential>
     </macrodef>
-	
+
     <!--
      | The task ensures the uportal-platform-api JAR exists and is up to date.
      |

--- a/uportal-war/src/main/java/org/jasig/portal/shell/PortalShell.java
+++ b/uportal-war/src/main/java/org/jasig/portal/shell/PortalShell.java
@@ -34,8 +34,6 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.tools.ant.util.FileUtils;
 import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.tools.shell.Groovysh;
-import org.codehaus.groovy.tools.shell.IO;
 import org.jasig.portal.spring.PortalApplicationContextLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +46,7 @@ import org.springframework.context.ApplicationContext;
  */
 public class PortalShell {
     static final Logger LOGGER = LoggerFactory.getLogger(PortalShell.class);
-    
+
     protected static Options getOptions() {
         final Options options = new Options();
 
@@ -56,10 +54,10 @@ public class PortalShell {
 
         return options;
     }
-    
+
     public static void main(String[] args) throws Exception {
         final Options options = getOptions();
-        
+
         final CommandLineParser parser = new PosixParser();
         final CommandLine commandLine;
         try {
@@ -70,23 +68,19 @@ public class PortalShell {
             printHelp(options);
             return;
         }
-        
+
         final ApplicationContext applicationContext = PortalApplicationContextLocator.getApplicationContext();
         try {
 	        final Binding binding = new SpringBinding(applicationContext);
 	        binding.setVariable("logger", LOGGER);
-	        
+
 	        if (commandLine.hasOption("script")) {
 	            final String scriptName = commandLine.getOptionValue("script");
 	            final File scriptFile = getAbsoluteFile(scriptName);
-	            
+
 	            final CompilerConfiguration conf = new CompilerConfiguration(System.getProperties());
 	            final GroovyShell shell = new GroovyShell(binding, conf);
 	            shell.run(scriptFile, args);
-	        }
-	        else {
-	            final Groovysh shell = new Groovysh(binding, new IO());
-	            shell.run();
 	        }
         }
         finally {
@@ -95,7 +89,7 @@ public class PortalShell {
         	}
         }
     }
-    
+
     protected static void printHelp(final Options options) {
         final HelpFormatter formatter = new HelpFormatter();
         final PrintWriter pw = new PrintWriter(System.err);
@@ -113,7 +107,7 @@ public class PortalShell {
         else {
             file = new File(new File(System.getProperty("user.dir")), filePath);
         }
-        
+
         try {
             return file.getCanonicalFile();
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Removed the running the groovy in interactive mode code from up-shell ant target and PortelShell.java
Issue link - https://issues.jasig.org/browse/UP-4835

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
