### PR TITLE
NOJIRA: Add status overview to uPortal 5 manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,141 @@
 # uPortal
 
-<table><tr>
-<td>
-
-[![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](#accessible)
-[![Issue Stats](http://issuestats.com/github/Jasig/uPortal/badge/pr)](http://issuestats.com/github/Jasig/uPortal)
-[![Google Code Style](https://img.shields.io/badge/code_style-Google-green.svg?style=flat)](https://google.github.io/styleguide/javaguide.html)
-
-| Version | Linux | Windows | Coverage |
-| - | - | - | - |
-| [uPortal 5](https://github.com/Jasig/uPortal/tree/master) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=master)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/master) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master)](https://coveralls.io/github/Jasig/uPortal?branch=master) |
-| [uPortal 4](https://github.com/Jasig/uPortal/tree/rel-4-3-patches) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches)](https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches) |
-
-</td>
-<td>
-
-| Get Involved | Outlet |
-| - | - |
-| Report an Issue | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
-| Request a feature | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
-| Contibute Code | [![Contributing Guide](https://img.shields.io/badge/contributing-guide-green.svg?style=flat)](CONTRIBUTING.md)
-| Join the Conversation | [![Gitter](https://badges.gitter.im/Jasig/uPortal.svg)](https://gitter.im/Jasig/uPortal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) <br> [![uPortal on IRC](https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat)](https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1) <br> [![Twitter Follow](https://img.shields.io/twitter/follow/uPortal.svg?style=social&label=Follow)](https://twitter.com/uPortal) |
-
-</td>
-</tr></table>
+<table border="0">
+  <tr>
+    <td>
+      <a href="https://www.w3.org/TR/WCAG20/">
+        <img src="https://www.w3.org/WAI/wcag2AA-blue-v.svg" alt="WCAG 2 AA Badge">
+      </a>
+      <a href="http://issuestats.com/github/Jasig/uPortal">
+        <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
+      </a>
+      <a href="https://google.github.io/styleguide/javaguide.html">
+        <img src="https://img.shields.io/badge/code_style-Google-green.svg?style=flat" alt="Google Code Style">
+      </a>
+      <br>
+      <table>
+        <tr>
+          <th>
+            Version
+          </th>
+          <th>
+            Linux
+          </th>
+          <th>
+            Windows
+          </th>
+          <th>
+            Coverage
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://github.com/Jasig/uPortal/tree/master">
+              uPortal 5
+            </a>
+          </td>
+          <td>
+            <a href="https://travis-ci.org/Jasig/uPortal">
+              <img src="https://travis-ci.org/Jasig/uPortal.svg?branch=master" alt="Linux Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://ci.appveyor.com/project/drewwills/uportal/branch/master">
+              <img src="https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true" alt="Windows Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://coveralls.io/github/Jasig/uPortal?branch=master">
+              <img src="https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master" alt="Coverage Status">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://github.com/Jasig/uPortal/tree/rel-4-3-patches">
+              uPortal 4
+            </a>
+          </td>
+          <td>
+            <a href="https://travis-ci.org/Jasig/uPortal">
+              <img src="https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches" alt="Linux Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches">
+              <img src="https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true" alt="Windows Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches">
+              <img src="https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches" alt="Coverage Status">
+            </a>
+          </td>
+        </tr>
+      </table>
+    </td>
+    <td>
+      <table>
+        <tr>
+          <th>
+            Get Involved
+          </th>
+          <th>
+            Outlet
+          </th>
+        </tr>
+        <tr>
+          <td>
+            Report an Issue
+          </td>
+          <td>
+            <a href="https://issues.jasig.org/browse/UP">
+              <img src="https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat" alt="Issue Tracker">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Request a feature
+          </td>
+          <td>
+            <a href="https://issues.jasig.org/browse/UP">
+              <img src="https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat" alt="Issue Tracker">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Contribute Code
+          </td>
+          <td>
+            <a href="CONTRIBUTING.md">
+              <img src="https://img.shields.io/badge/contributing-guide-green.svg?style=flat" alt="Contributing Guide">
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Join the Conversation
+          </td>
+          <td>
+            <a href="https://gitter.im/Jasig/uPortal?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge">
+              <img src="https://badges.gitter.im/Jasig/uPortal.svg" alt="Gitter">
+            </a>
+            <br>
+            <a href="https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1">
+              <img src="https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat" alt="uPortal on IRC">
+            </a>
+            <br>
+            <a href="https://twitter.com/uPortal">
+              <img src="https://img.shields.io/twitter/follow/uPortal.svg?style=social&amp;label=Follow" alt="Twitter Follow">
+            </a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
 
 ## About
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,31 @@ Documentation for earlier versions of uPortal is available in
 [Confluence](https://wiki.jasig.org).  See *Documentation for Previous Releases*
 below.
 
+<table><tr>
+<td>
+
+[![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](#accessible)
+[![Issue Stats](http://issuestats.com/github/Jasig/uPortal/badge/pr)](http://issuestats.com/github/Jasig/uPortal)
+[![Google Code Style](https://img.shields.io/badge/code_style-Google-green.svg?style=flat)](https://google.github.io/styleguide/javaguide.html)
+
+| Version | Linux | Windows | Coverage |
+| - | - | - | - |
+| [uPortal 5](https://github.com/Jasig/uPortal/tree/master) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=master)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/master) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master)](https://coveralls.io/github/Jasig/uPortal?branch=master) |
+| [uPortal 4](https://github.com/Jasig/uPortal/tree/rel-4-3-patches) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches)](https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches) |
+
+</td>
+<td>
+
+| Get Involved | Outlet |
+| - | - |
+| Report an Issue | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
+| Request a feature | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
+| Contibute Code | [![Contributing Guide](https://img.shields.io/badge/contributing-guide-green.svg?style=flat)](CONTRIBUTING.md)
+| Join the Conversation | [![Gitter](https://badges.gitter.im/Jasig/uPortal.svg)](https://gitter.im/Jasig/uPortal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) <br> [![uPortal on IRC](https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat)](https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1) <br> [![Twitter Follow](https://img.shields.io/twitter/follow/uPortal.svg?style=social&label=Follow)](https://twitter.com/uPortal) |
+
+</td>
+</tr></table>
+
 ## Sections
 
 * [Ant Help](antHelp.txt)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,15 @@ below.
 <table border="0">
   <tr>
     <td>
-      [![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](#accessible)
-      [![Issue Stats](http://issuestats.com/github/Jasig/uPortal/badge/pr)](http://issuestats.com/github/Jasig/uPortal)
-      [![Google Code Style](https://img.shields.io/badge/code_style-Google-green.svg?style=flat)](https://google.github.io/styleguide/javaguide.html)
+      <a href="https://www.w3.org/TR/WCAG20/">
+        <img src="https://www.w3.org/WAI/wcag2AA-blue-v.svg" alt="WCAG 2 AA Badge">
+      </a>
+      <a href="http://issuestats.com/github/Jasig/uPortal">
+        <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
+      </a>
+      <a href="https://google.github.io/styleguide/javaguide.html">
+        <img src="https://img.shields.io/badge/code_style-Google-green.svg?style=flat" alt="Google Code Style">
+      </a>
       <br>
       <table>
         <tr>
@@ -29,31 +35,47 @@ below.
           </th>
         </tr>
         <tr>
-          <th>
-            [uPortal 5](https://github.com/Jasig/uPortal/tree/master)
-          </th>
           <td>
-            [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=master)](https://travis-ci.org/Jasig/uPortal)
+            <a href="https://github.com/Jasig/uPortal/tree/master">
+              uPortal 5
+            </a>
           </td>
           <td>
-            [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/master)
+            <a href="https://travis-ci.org/Jasig/uPortal">
+              <img src="https://travis-ci.org/Jasig/uPortal.svg?branch=master" alt="Linux Build Status">
+            </a>
           </td>
           <td>
-            [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master)](https://coveralls.io/github/Jasig/uPortal?branch=master)
+            <a href="https://ci.appveyor.com/project/drewwills/uportal/branch/master">
+              <img src="https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true" alt="Windows Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://coveralls.io/github/Jasig/uPortal?branch=master">
+              <img src="https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master" alt="Coverage Status">
+            </a>
           </td>
         </tr>
         <tr>
-          <th>
-            [uPortal 4](https://github.com/Jasig/uPortal/tree/rel-4-3-patches)
-          </th>
           <td>
-            [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches)](https://travis-ci.org/Jasig/uPortal)
+            <a href="https://github.com/Jasig/uPortal/tree/rel-4-3-patches">
+              uPortal 4
+            </a>
           </td>
           <td>
-            [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches)
+            <a href="https://travis-ci.org/Jasig/uPortal">
+              <img src="https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches" alt="Linux Build Status">
+            </a>
           </td>
           <td>
-            [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches)](https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches)
+            <a href="https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches">
+              <img src="https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true" alt="Windows Build Status">
+            </a>
+          </td>
+          <td>
+            <a href="https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches">
+              <img src="https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches" alt="Coverage Status">
+            </a>
           </td>
         </tr>
       </table>
@@ -73,38 +95,47 @@ below.
             Report an Issue
           </td>
           <td>
-            [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP)
+            <a href="https://issues.jasig.org/browse/UP">
+              <img src="https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat" alt="Issue Tracker">
+            </a>
           </td>
         </tr>
-
         <tr>
           <td>
             Request a feature
           </td>
           <td>
-            [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP)
+            <a href="https://issues.jasig.org/browse/UP">
+              <img src="https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat" alt="Issue Tracker">
+            </a>
           </td>
         </tr>
-
         <tr>
           <td>
             Contribute Code
           </td>
           <td>
-            [![Contributing Guide](https://img.shields.io/badge/contributing-guide-green.svg?style=flat)](CONTRIBUTING.md)
+            <a href="CONTRIBUTING.md">
+              <img src="https://img.shields.io/badge/contributing-guide-green.svg?style=flat" alt="Contributing Guide">
+            </a>
           </td>
         </tr>
-
         <tr>
           <td>
             Join the Conversation
           </td>
           <td>
-            [![Gitter](https://badges.gitter.im/Jasig/uPortal.svg)](https://gitter.im/Jasig/uPortal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+            <a href="https://gitter.im/Jasig/uPortal?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge">
+              <img src="https://badges.gitter.im/Jasig/uPortal.svg" alt="Gitter">
+            </a>
             <br>
-            [![uPortal on IRC](https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat)](https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1)
+            <a href="https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1">
+              <img src="https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat" alt="uPortal on IRC">
+            </a>
             <br>
-            [![Twitter Follow](https://img.shields.io/twitter/follow/uPortal.svg?style=social&label=Follow)](https://twitter.com/uPortal)
+            <a href="https://twitter.com/uPortal">
+              <img src="https://img.shields.io/twitter/follow/uPortal.svg?style=social&amp;label=Follow" alt="Twitter Follow">
+            </a>
           </td>
         </tr>
       </table>

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,30 +6,111 @@ Documentation for earlier versions of uPortal is available in
 [Confluence](https://wiki.jasig.org).  See *Documentation for Previous Releases*
 below.
 
-<table><tr>
-<td>
+<table border="0">
+  <tr>
+    <td>
+      [![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](#accessible)
+      [![Issue Stats](http://issuestats.com/github/Jasig/uPortal/badge/pr)](http://issuestats.com/github/Jasig/uPortal)
+      [![Google Code Style](https://img.shields.io/badge/code_style-Google-green.svg?style=flat)](https://google.github.io/styleguide/javaguide.html)
+      <br>
+      <table>
+        <tr>
+          <th>
+            Version
+          </th>
+          <th>
+            Linux
+          </th>
+          <th>
+            Windows
+          </th>
+          <th>
+            Coverage
+          </th>
+        </tr>
+        <tr>
+          <th>
+            [uPortal 5](https://github.com/Jasig/uPortal/tree/master)
+          </th>
+          <td>
+            [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=master)](https://travis-ci.org/Jasig/uPortal)
+          </td>
+          <td>
+            [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/master)
+          </td>
+          <td>
+            [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master)](https://coveralls.io/github/Jasig/uPortal?branch=master)
+          </td>
+        </tr>
+        <tr>
+          <th>
+            [uPortal 4](https://github.com/Jasig/uPortal/tree/rel-4-3-patches)
+          </th>
+          <td>
+            [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches)](https://travis-ci.org/Jasig/uPortal)
+          </td>
+          <td>
+            [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches)
+          </td>
+          <td>
+            [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches)](https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches)
+          </td>
+        </tr>
+      </table>
+    </td>
+    <td>
+      <table>
+        <tr>
+          <th>
+            Get Involved
+          </th>
+          <th>
+            Outlet
+          </th>
+        </tr>
+        <tr>
+          <td>
+            Report an Issue
+          </td>
+          <td>
+            [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP)
+          </td>
+        </tr>
 
-[![WCAG 2 AA Badge](https://www.w3.org/WAI/wcag2AA-blue-v.svg)](#accessible)
-[![Issue Stats](http://issuestats.com/github/Jasig/uPortal/badge/pr)](http://issuestats.com/github/Jasig/uPortal)
-[![Google Code Style](https://img.shields.io/badge/code_style-Google-green.svg?style=flat)](https://google.github.io/styleguide/javaguide.html)
+        <tr>
+          <td>
+            Request a feature
+          </td>
+          <td>
+            [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP)
+          </td>
+        </tr>
 
-| Version | Linux | Windows | Coverage |
-| - | - | - | - |
-| [uPortal 5](https://github.com/Jasig/uPortal/tree/master) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=master)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/master?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/master) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=master)](https://coveralls.io/github/Jasig/uPortal?branch=master) |
-| [uPortal 4](https://github.com/Jasig/uPortal/tree/rel-4-3-patches) | [![Linux Build Status](https://travis-ci.org/Jasig/uPortal.svg?branch=rel-4-3-patches)](https://travis-ci.org/Jasig/uPortal) | [![Windows Build Status](https://ci.appveyor.com/api/projects/status/8t95sjt090mf62dh/branch/rel-4-3-patches?svg=true)](https://ci.appveyor.com/project/drewwills/uportal/branch/rel-4-3-patches) | [![Coverage Status](https://coveralls.io/repos/github/Jasig/uPortal/badge.svg?branch=rel-4-3-patches)](https://coveralls.io/github/Jasig/uPortal?branch=rel-4-3-patches) |
+        <tr>
+          <td>
+            Contribute Code
+          </td>
+          <td>
+            [![Contributing Guide](https://img.shields.io/badge/contributing-guide-green.svg?style=flat)](CONTRIBUTING.md)
+          </td>
+        </tr>
 
-</td>
-<td>
-
-| Get Involved | Outlet |
-| - | - |
-| Report an Issue | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
-| Request a feature | [![Issue Tracker](https://img.shields.io/badge/issue_tacker-Jira-green.svg?style=flat)](https://issues.jasig.org/browse/UP) |
-| Contibute Code | [![Contributing Guide](https://img.shields.io/badge/contributing-guide-green.svg?style=flat)](CONTRIBUTING.md)
-| Join the Conversation | [![Gitter](https://badges.gitter.im/Jasig/uPortal.svg)](https://gitter.im/Jasig/uPortal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) <br> [![uPortal on IRC](https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat)](https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1) <br> [![Twitter Follow](https://img.shields.io/twitter/follow/uPortal.svg?style=social&label=Follow)](https://twitter.com/uPortal) |
-
-</td>
-</tr></table>
+        <tr>
+          <td>
+            Join the Conversation
+          </td>
+          <td>
+            [![Gitter](https://badges.gitter.im/Jasig/uPortal.svg)](https://gitter.im/Jasig/uPortal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+            <br>
+            [![uPortal on IRC](https://img.shields.io/badge/IRC-%23jasig--uportal-1e72ff.svg?style=flat)](https://www.irccloud.com/invite?channel=%23jasig-uportal&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1)
+            <br>
+            [![Twitter Follow](https://img.shields.io/twitter/follow/uPortal.svg?style=social&label=Follow)](https://twitter.com/uPortal)
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
 
 ## Sections
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][
-   [x] documentation is changed or added
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds overview to homepage of uPortal 5 manual.

![screencapture-christianmurphy-github-io-uportal-1493844666130](https://cloud.githubusercontent.com/assets/3107513/25681028/b828ab94-3007-11e7-97f9-75b863d878fe.png)


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
