### PR TITLE
UP-4842:  Add a lock icon ('fa fa-lock') to the portlet chrome of por…

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -392,6 +392,16 @@
       </xsl:variable>
 
       <div class="portlet-controls">
+        <!-- Locked indicator for portlets that are not movable -->
+        <xsl:if test="$PORTLET_LOCKED='locked'">
+          <div class="locked-icon">
+              <i class="fa fa-lock"></i>
+              <span class="sr-only">
+                  <xsl:value-of select="upMsg:getMessage('this.portlet.locked', $USER_LANG)"/>
+              </span>
+          </div>
+        </xsl:if>
+
         <!-- The 'grab-handle' class must be present on every portlet else fluid
              will error when it encounters a portlet without the class.  Grab
              handles for locked portlets will remain hidden. -->

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -395,7 +395,7 @@
         <!-- Locked indicator for portlets that are not movable -->
         <xsl:if test="$PORTLET_LOCKED='locked'">
           <div class="locked-icon">
-              <i class="fa fa-lock"></i>
+              <i class="fa fa-lock" aria-hidden="true"></i>
               <span class="sr-only">
                   <xsl:value-of select="upMsg:getMessage('this.portlet.locked', $USER_LANG)"/>
               </span>

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -703,6 +703,7 @@ tenant.manager.update.attributes=<i class="fa fa-pencil-square-o"></i> Update At
 tenant.manager.update.attributes.confirm=Are you sure update the attributes of tenant {0}?
 tenant.manager.welcome=Welcome to the tenant manager.  This portlet allows the portal administrator to create new tenancies within the portal.
 tenant.updated.successfully=Tenant {0} updated successfully
+this.portlet.locked=This portlet may not be moved
 this.portlet.supports.rich.config.message=This portlet supports rich configuration, you will be prompted to perform this configuration at the end of the publishing workflow.
 this.table.lists.portlet.configurations=This table is a list of the portlet''s configurations.
 this.table.lists.portlet.parameters=This table lists a portlet''s parameter settings.

--- a/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages_fr.properties
@@ -707,6 +707,7 @@ tenant.manager.update.attributes=<i class="fa fa-pencil-square-o"></i> Mettre \u
 tenant.manager.update.attributes.confirm=\u00CAtes-vous s\u00FBr de vouloir mettre \u00E0 jour les propri\u00E9t\u00E9s du tenant {0} ?
 tenant.manager.welcome=Bienvenue dans le gestionnaire de tenant.  Cette portlet permet \u00E0 l''administrateur du portail de cr\u00E9er des tenants.
 tenant.updated.successfully=Tenant {0} mis \u00E0 jour
+this.portlet.locked=Ce portlet ne peut être déplacé
 this.portlet.supports.rich.config.message=Cette portlet supporte la "configuration avanc\u00E9e", vous serez invit\u00E9 \u00E0 effectuer cette configuration \u00E0 la fin de l''\u00E9tape de publication.
 this.table.lists.portlet.configurations=Ce tableau est une liste des configurations de la portlet.
 this.table.lists.portlet.parameters=Ce tableau liste les param\u00E8tres d''une portlet.

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -183,6 +183,11 @@ section h4 {
       }
     }
 
+    .locked-icon {
+      display: inline-block;
+      font-size: 1.75rem;
+    }
+
     .grab-handle {
       display: inline-block;
       position: relative;


### PR DESCRIPTION
…tlets that mey not be moved due to DLM restrictions

https://issues.jasig.org/browse/UP-4842

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

![lock-icon](https://cloud.githubusercontent.com/assets/1127174/25706101/4b3b11ba-3094-11e7-9cdd-41e11a5c3280.png)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
