### PR TITLE
UP-4850: Add "Skip to page content" button in the portal header

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -384,4 +384,14 @@
   <!-- =================================================== -->
 
 
+  <!-- ========== TEMPLATE: SKIPNAV ========== -->
+  <!-- =================================================== -->
+  <!--
+   | This template renders the "Skip to page content" button at th top of the page.
+  -->
+  <xsl:template name="skipnav">
+    <a role="button" class="portal-header-skip-nav btn" href="#portalPageBody"><xsl:value-of select="upMsg:getMessage('skip.to.page.content', $USER_LANG)"/></a>
+  </xsl:template>
+  <!-- =================================================== -->
+
 </xsl:stylesheet>

--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -107,6 +107,7 @@
     -->
     <xsl:template name="region.pre-header">
         <xsl:if test="//region[@name='pre-header']/channel">
+            <a role="button" class="portal-header-skip-nav btn" href="#portalPageBody"><xsl:value-of select="upMsg:getMessage('skip.to.page.content', $USER_LANG)"/></a>
             <div id="region-pre-header" class="portal-user">
                 <xsl:for-each select="//region[@name='pre-header']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />

--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -107,7 +107,6 @@
     -->
     <xsl:template name="region.pre-header">
         <xsl:if test="//region[@name='pre-header']/channel">
-            <a role="button" class="portal-header-skip-nav btn" href="#portalPageBody"><xsl:value-of select="upMsg:getMessage('skip.to.page.content', $USER_LANG)"/></a>
             <div id="region-pre-header" class="portal-user">
                 <xsl:for-each select="//region[@name='pre-header']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -718,6 +718,7 @@
             <script src="/uPortal/scripts/respond-1.4.2.min.js" type="text/javascript"></script>
         </head>
         <body class="up dashboard portal fl-theme-mist">
+          <xsl:call-template name="skipnav" />
           <div class="row-offcanvas">
             <div id="up-notification"></div>
             <div id="wrapper">
@@ -862,6 +863,7 @@
         <script src="/uPortal/scripts/respond-1.4.2.min.js" type="text/javascript"></script>
     </head>
     <body class="up dashboard portal fl-theme-mist detachedHeader">
+        <xsl:call-template name="skipnav" />
         <div id="wrapper">
             <xsl:call-template name="region.hidden-top" />
             <xsl:call-template name="region.page-top" />

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -17,6 +17,27 @@
  * under the License.
  */
 
+/* Hide the "Skip to page content" button offscreen until it's brought into focus */
+.portal-header-skip-nav {
+    position: absolute;
+    top: -1000px;
+    left: -1000px;
+    height: 1px;
+    width: 1px;
+    text-align: left;
+    color: @header-link-color;
+    overflow: hidden;
+
+    &:active, &:focus, &:hover {
+        left: 0;
+        top: .5rem;
+        z-index: 1;
+        width: auto;
+        height: auto;
+        overflow: visible;
+   }
+}
+
 .portal-header {
     background: @header-background-color;
     color: @header-text-color;
@@ -51,25 +72,6 @@
         /* Need for the offcanvas open effect */
         position: relative;
         z-index: 10;
-    }
-
-    /* Hide the "Skip to page content" button offscreen until it's brought into focus */
-    .portal-header-skip-nav {
-        position: absolute;
-        top: -1000px;
-        left: -1000px;
-        height: 1px;
-        width: 1px;
-        text-align: left;
-        overflow: hidden;
-
-        &:active, &:focus, &:hover {
-            left: 0;
-            top: 0;
-            width: auto;
-            height: auto;
-            overflow: visible;
-       }
     }
 
     .portal-nav {

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -53,6 +53,25 @@
         z-index: 10;
     }
 
+    /* Hide the "Skip to page content" button offscreen until it's brought into focus */
+    .portal-header-skip-nav {
+        position: absolute;
+        top: -1000px;
+        left: -1000px;
+        height: 1px;
+        width: 1px;
+        text-align: left;
+        overflow: hidden;
+
+        &:active, &:focus, &:hover {
+            left: 0;
+            top: 0;
+            width: auto;
+            height: auto;
+            overflow: visible;
+       }
+    }
+
     .portal-nav {
         .container {
             padding: 0;


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4850
(Indirectly related to https://issues.jasig.org/browse/UP-2599)

##### Checklist
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
This button will allow easier access to uPortal's content when using screen reading software.
This was a feature way back in 2010 with Universality - this brings the button into Respondr.

<!-- Reference Links -->
[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
