### PR TITLE
Fail fast when JVM < 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1266,7 +1266,7 @@
                                 <version>2.2</version>
                               </requireMavenVersion>
                               <requireJavaVersion>
-                                <version>1.6</version>
+                                <version>1.8</version>
                               </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@
          +-->
         <mobile.user.agent.regex>(.*iPhone.*)|(.*Android.*)|(.*IEMobile.*)|(.*Safari.*Pre.*)|(.*Nokia.*AppleWebKit.*)|(.*Black[Bb]erry.*)|(.*Opera Mobile.*)|(.*Windows Phone.*)|(.*Fennec.*)|(.*Minimo.*)</mobile.user.agent.regex>
 
-        <project.build.sourceVersion>1.7</project.build.sourceVersion>
-        <project.build.targetVersion>1.7</project.build.targetVersion>
+        <project.build.sourceVersion>1.8</project.build.sourceVersion>
+        <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1266,7 +1266,7 @@
                                 <version>2.2</version>
                               </requireMavenVersion>
                               <requireJavaVersion>
-                                <version>1.8</version>
+                                <version>${project.build.targetVersion}</version>
                               </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Modern uPortal build requires Java 8 or better. Tell Maven this so it can fail faster and more expressively when in a lesser Java environment.

Setting `JAVA_HOME` seems to be in practice pretty difficult. Help a developer out when they haven't yet set it emphatically enough.

##### Checklist
-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (Deal with this on squash merge.)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit