### PR TITLE
UP-4851: Add nodes first-feasible rather than last when order unspecified.

### DIFF
--- a/uportal-war/src/main/java/org/apereo/portal/layout/IUserLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/IUserLayoutManager.java
@@ -98,6 +98,21 @@ public interface IUserLayoutManager {
             throws PortalException;
 
     /**
+     * Add a node under a parent without specifying in what order it ought to be placed among
+     * siblings. Use addNode(node, parentId, nextSiblingId) to express exactly where among
+     * current children of the parent node the new node ought to be placed. Use this method to
+     * leave sibling order to the discretion of the underlying layout manager.
+     *
+     * @param nodeToAdd non-null node to add to the layout
+     * @param parentId non-null ID of parent under which to add the node
+     * @return new description of the added node, now with a new or updated ID,
+     * or null if not added.
+     * @since 5.0.0
+     */
+    IUserLayoutNodeDescription addNodeInAnyOrder(
+        IUserLayoutNodeDescription nodeToAdd, String parentId);
+
+    /**
      * Move a node (channel or folder) from one location to another.
      *
      * @param nodeId a <code>String</code> value of a node Id.

--- a/uportal-war/src/main/java/org/apereo/portal/layout/TransientUserLayoutManagerWrapper.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/TransientUserLayoutManagerWrapper.java
@@ -147,6 +147,12 @@ public class TransientUserLayoutManagerWrapper implements IUserLayoutManager {
         return man.addNode(node, parentId, nextSiblingId);
     }
 
+    @Override
+    public IUserLayoutNodeDescription addNodeInAnyOrder(
+        final IUserLayoutNodeDescription nodeToAdd, final String parentId) {
+        return man.addNodeInAnyOrder(nodeToAdd, parentId);
+    }
+
     public boolean moveNode(String nodeId, String parentId, String nextSiblingId)
             throws PortalException {
         // allow all moves, except for those related to the transient channels and folders

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -929,6 +929,8 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
             final String nextSiblingId)
             throws PortalException {
 
+        if ( isFragmentOwner ) return false;
+
         if (node == null) { // cannot add a null node
             return false;
         }
@@ -970,8 +972,6 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         // todo if isFragmentOwner should probably verify both node and parent are part of the
         // same layout fragment as the fragment owner to insure a misbehaving front-end doesn't
         // do an improper operation.
-
-        if ( isFragmentOwner ) return false;
 
         if (parent instanceof IUserLayoutFolderDescription
                 && !(((IUserLayoutFolderDescription) parent).isAddChildAllowed())

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -929,6 +929,10 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
             final String nextSiblingId)
             throws PortalException {
 
+        if (node == null) { // cannot add a null node
+            return false;
+        }
+
         if (parent == null) { // cannot add a node without a parent to add it under
             return false;
         }

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -937,6 +937,10 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
             return false;
         }
 
+        if ( !(node.isMoveAllowed()) ) { // cannot add a node one cannot move
+            return false;
+        }
+
         // make sure sibling exists and is a child of nodeId
         if ( StringUtils.isNotBlank(nextSiblingId) ) {
             IUserLayoutNodeDescription sibling = getNode(nextSiblingId);
@@ -967,7 +971,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         // same layout fragment as the fragment owner to insure a misbehaving front-end doesn't
         // do an improper operation.
 
-        if ( !(node.isMoveAllowed() || isFragmentOwner)) return false;
+        if ( isFragmentOwner ) return false;
 
         if (parent instanceof IUserLayoutFolderDescription
                 && !(((IUserLayoutFolderDescription) parent).isAddChildAllowed())

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -927,6 +927,11 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
             final IUserLayoutNodeDescription parent,
             final String nextSiblingId)
             throws PortalException {
+
+        if (parent == null) { // cannot add a node without a parent to add it under
+            return false;
+        }
+
         // make sure sibling exists and is a child of nodeId
         if (nextSiblingId != null && !nextSiblingId.equals("")) {
             IUserLayoutNodeDescription sibling = getNode(nextSiblingId);
@@ -957,7 +962,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         // same layout fragment as the fragment owner to insure a misbehaving front-end doesn't
         // do an improper operation.
 
-        if (parent == null || !(node.isMoveAllowed() || isFragmentOwner)) return false;
+        if ( !(node.isMoveAllowed() || isFragmentOwner)) return false;
 
         if (parent instanceof IUserLayoutFolderDescription
                 && !(((IUserLayoutFolderDescription) parent).isAddChildAllowed())

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -923,9 +923,9 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
     }
 
     protected boolean canAddNode(
-            IUserLayoutNodeDescription node,
-            IUserLayoutNodeDescription parent,
-            String nextSiblingId)
+            final IUserLayoutNodeDescription node,
+            final IUserLayoutNodeDescription parent,
+            final String nextSiblingId)
             throws PortalException {
         // make sure sibling exists and is a child of nodeId
         if (nextSiblingId != null && !nextSiblingId.equals("")) {

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -908,6 +908,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         }
     }
 
+    @Override
     public boolean canAddNode(
             IUserLayoutNodeDescription node, String parentId, String nextSiblingId)
             throws PortalException {

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -452,6 +452,13 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
 
             return node;
         }
+
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Attempted to add node in impermissible location "
+                    + "with parent " + parentId + " and next sibling " + nextSiblingId
+                    + ". Made no layout change.");
+        }
+
         return null;
     }
 

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -977,7 +977,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
                 && !(((IUserLayoutFolderDescription) parent).isAddChildAllowed())
                 && !isFragmentOwner) return false;
 
-        if (nextSiblingId == null || nextSiblingId.equals("")) // end of list targeted
+        if ( StringUtils.isBlank(nextSiblingId) ) // end of list targeted
         return true;
 
         // so lets see if we can place it at the end of the sibling list and

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -33,6 +33,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.xpath.XPathConstants;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apereo.portal.IUserIdentityStore;
@@ -933,7 +934,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         }
 
         // make sure sibling exists and is a child of nodeId
-        if (nextSiblingId != null && !nextSiblingId.equals("")) {
+        if ( StringUtils.isNotBlank(nextSiblingId) ) {
             IUserLayoutNodeDescription sibling = getNode(nextSiblingId);
             if (sibling == null) {
                 throw new PortalException(

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
@@ -1000,7 +1000,6 @@ public class UpdatePreferencesServlet {
      * Update the user's preferred skin.
      *
      * @param request HTTP Request
-     * @param response HTTP Response
      * @param skinName name of the Skin
      * @throws IOException
      * @throws PortalException

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
@@ -915,11 +915,20 @@ public class UpdatePreferencesServlet {
                         Collections.singletonMap("error", "Cannot insert into portlet element"));
             }
 
-            String siblingId = isInsert ? destinationId : null;
-            String target = isInsert ? ulm.getParentId(destinationId) : destinationId;
+            if (isInsert) {
+                final String siblingId = isInsert ? destinationId : null;
+                final String target = isInsert ? ulm.getParentId(destinationId) : destinationId;
 
-            // move the channel into the column
-            node = ulm.addNode(channel, target, siblingId);
+                // move the channel into the column
+                node = ulm.addNode(channel, target, siblingId);
+            } else {
+                // request did not specify in what order to insert,
+                // so add anywhere in target folder.
+
+                node = ulm.addNodeInAnyOrder(channel, destinationId);
+            }
+
+
         }
 
         if (node == null) {

--- a/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
+++ b/uportal-war/src/main/java/org/apereo/portal/layout/dlm/remoting/UpdatePreferencesServlet.java
@@ -961,7 +961,8 @@ public class UpdatePreferencesServlet {
         if (columns.hasMoreElements()) {
             while (columns.hasMoreElements()) {
                 // attempt to add this channel to the column
-                node = ulm.addNode(channel, columns.nextElement(), null);
+                node = ulm.addNodeInAnyOrder(channel, columns.nextElement());
+
                 // if it couldn't be added to this column, go on and try the next
                 // one.  otherwise, we're set.
                 if (node != null) break;

--- a/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
@@ -34,6 +34,25 @@ import static org.mockito.Mockito.*;
  */
 public class DistributedLayoutManagerTest {
 
+
+    /**
+     * One cannot add a null node to a layout.
+     */
+    @Test
+    public void cannotAddNullNode() {
+
+        final IPerson person = new PersonImpl();
+        final IUserProfile profile = new UserProfile();
+
+        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+
+        final IUserLayoutNodeDescription nullNode = null;
+        final IUserLayoutNodeDescription parent =  mock(IUserLayoutNodeDescription.class);
+        final String noNextSiblingId = "";
+
+        assertFalse(dlm.canAddNode(nullNode, parent, noNextSiblingId));
+    }
+
     /**
      * Adding a node to a null parent makes no sense and is disallowed.
      */

--- a/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apereo.portal.layout.dlm;
+
+import org.apereo.portal.IUserProfile;
+import org.apereo.portal.UserProfile;
+import org.apereo.portal.layout.node.IUserLayoutNodeDescription;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.provider.PersonImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for DLM.
+ */
+public class DistributedLayoutManagerTest {
+
+    /**
+     * Adding a node to a null parent makes no sense and is disallowed.
+     */
+    @Test
+    public void cannotAddNodeToNullParent() {
+
+        final IPerson person = new PersonImpl();
+        final IUserProfile profile = new UserProfile();
+
+        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+
+        final IUserLayoutNodeDescription nodeToAdd = mock(IUserLayoutNodeDescription.class);
+        final IUserLayoutNodeDescription nullParent = null;
+        final String noNextSiblingId = "";
+
+        assertFalse(dlm.canAddNode(nodeToAdd, nullParent, noNextSiblingId));
+    }
+
+}

--- a/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
@@ -21,6 +21,7 @@ package org.apereo.portal.layout.dlm;
 
 import org.apereo.portal.IUserProfile;
 import org.apereo.portal.UserProfile;
+import org.apereo.portal.layout.node.IUserLayoutFolderDescription;
 import org.apereo.portal.layout.node.IUserLayoutNodeDescription;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.provider.PersonImpl;
@@ -81,6 +82,28 @@ public class DistributedLayoutManagerTest {
 
         assertFalse(dlm.canAddNode(nodeToAdd, parent, noNextSiblingId));
 
+    }
+
+    /**
+     * You cannot add a node to a parent that disallows adding children,
+     * when you are not a fragment owner.
+     */
+    @Test
+    public void nonFragmentOwnersCannotAddToParentThatDisallowsChildren() {
+
+        final DistributedLayoutManager dlm = newBasicDlm();
+
+        // bad news: hard to unit test DLM under fragment owner case
+        // good news: default is the not-fragment-owner case, and that is this case.
+
+        final IUserLayoutNodeDescription nodeToAdd = mock(IUserLayoutNodeDescription.class);
+
+        final IUserLayoutFolderDescription parent = mock(IUserLayoutFolderDescription.class);
+        when (parent.isAddChildAllowed()).thenReturn(Boolean.FALSE);
+
+        final String noNextSiblingId = "";
+
+        assertFalse(dlm.canAddNode(nodeToAdd, parent, noNextSiblingId));
     }
 
     /**

--- a/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
@@ -34,17 +34,13 @@ import static org.mockito.Mockito.*;
  */
 public class DistributedLayoutManagerTest {
 
-
     /**
      * One cannot add a null node to a layout.
      */
     @Test
     public void cannotAddNullNode() {
 
-        final IPerson person = new PersonImpl();
-        final IUserProfile profile = new UserProfile();
-
-        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+        final DistributedLayoutManager dlm = newBasicDlm();
 
         final IUserLayoutNodeDescription nullNode = null;
         final IUserLayoutNodeDescription parent =  mock(IUserLayoutNodeDescription.class);
@@ -59,10 +55,7 @@ public class DistributedLayoutManagerTest {
     @Test
     public void cannotAddNodeToNullParent() {
 
-        final IPerson person = new PersonImpl();
-        final IUserProfile profile = new UserProfile();
-
-        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+        final DistributedLayoutManager dlm = newBasicDlm();
 
         final IUserLayoutNodeDescription nodeToAdd = mock(IUserLayoutNodeDescription.class);
         final IUserLayoutNodeDescription nullParent = null;
@@ -77,10 +70,7 @@ public class DistributedLayoutManagerTest {
     @Test
     public void cannotAddAnImmovableNode() {
 
-        final IPerson person = new PersonImpl();
-        final IUserProfile profile = new UserProfile();
-
-        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+        final DistributedLayoutManager dlm = newBasicDlm();
 
         final IUserLayoutNodeDescription nodeToAdd = mock(IUserLayoutNodeDescription.class);
 
@@ -91,6 +81,19 @@ public class DistributedLayoutManagerTest {
 
         assertFalse(dlm.canAddNode(nodeToAdd, parent, noNextSiblingId));
 
+    }
+
+    /**
+     * Utility method for instantiating a DLM to test.
+     * @return a simple DLM instance.
+     */
+    public static DistributedLayoutManager newBasicDlm() {
+        final IPerson person = new PersonImpl();
+        final IUserProfile profile = new UserProfile();
+
+        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+
+        return dlm;
     }
 
 }

--- a/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
+++ b/uportal-war/src/test/java/org/apereo/portal/layout/dlm/DistributedLayoutManagerTest.java
@@ -52,4 +52,26 @@ public class DistributedLayoutManagerTest {
         assertFalse(dlm.canAddNode(nodeToAdd, nullParent, noNextSiblingId));
     }
 
+    /**
+     * If you can't move a node, you can't add that node.
+     */
+    @Test
+    public void cannotAddAnImmovableNode() {
+
+        final IPerson person = new PersonImpl();
+        final IUserProfile profile = new UserProfile();
+
+        final DistributedLayoutManager dlm = new DistributedLayoutManager(person, profile);
+
+        final IUserLayoutNodeDescription nodeToAdd = mock(IUserLayoutNodeDescription.class);
+
+        final IUserLayoutNodeDescription parent = mock(IUserLayoutNodeDescription.class);
+        when(parent.isMoveAllowed()).thenReturn(Boolean.FALSE);
+
+        final String noNextSiblingId = "";
+
+        assertFalse(dlm.canAddNode(nodeToAdd, parent, noNextSiblingId));
+
+    }
+
 }


### PR DESCRIPTION
Supersedes #883 .

See also [uportal-dev@ thread](https://groups.google.com/a/apereo.org/d/topic/uportal-dev/aspMtOThps8/discussion).

What this does:

+ Adds a layout manager API method for adding a node with the sibling order left unspecified, an implementation detail for the layout manager.
+ Implements the method in DLM with a policy of adding the node to the first sibling position consistent with applicable DLM restrictions.
+ Changes user preferences servlet to use the new less-specific layout manager API add method when the request has not specified the order in which a node should be added.

Why?

Often user layout modifying UIs will want to add an item with that item landing in some kind of "default" order rather than specifying that the item add last. This "often" is evidenced by [Respondr preferences adding portlets into first position](https://groups.google.com/a/apereo.org/d/msg/uportal-dev/aspMtOThps8/gWu0m1UhAQAJ) and by `uPortal-home` wanting to make its "Add to home" UI control add an item to the first rather than last position on the home.

So this change adds an API method for adding in a default order, implements this in DLM with an add-to-first-feasible position policy, and uses this method in the user preferences servlet methods when the add order wasn't otherwise explicitly communicated. This should make it easier to implement uPortal UIs achieving this "just-add-it-to-a-default-spot-under-this-parent" effect, since those UIs won't themselves have to compute the desired (and permissible) add position, they can leave it unspecified and let the layout manager figure it out.

To the extent that the default ordering ought to differ across uPortal implementations, the default ordering is an implementation detail of the layout manager so DLM could evolve or a successor layout manager could be implemented that chooses a different default behavior or makes it configurable.


##### Checklist

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (get this right on the squash commit)
-   [ ] tests are included (partial. tests supporting refactoring and understanding neighboring code included.)
-   [x] documentation is changed or added (JavaDoc)

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit