### PR TITLE
NOJIRA: Update ant constraint and documentation to require Java 8

### DIFF
--- a/assembly/quickstart/README.txt
+++ b/assembly/quickstart/README.txt
@@ -37,7 +37,7 @@ Contents
 
 System requirements
 --------------------------------------------------------------------------------
-- JDK 1.7 or later
+- JDK 1.8 or later
 - JDK must include tools.jar.
 - JAVA_HOME environment variable must be set to a path that does not contain
   spaces.
@@ -57,7 +57,7 @@ UNIX:    ant.sh
   (That is, under a UNIX-style operating system this is `ant.sh start` ,
    and under a Windows operating system this is `ant.bat` ).
 
-'ant stop' - Stops Tomcat then stops HSQL. 
+'ant stop' - Stops Tomcat then stops HSQL.
   (That is, under a UNIX-style operating system this is `ant.sh stop` ,
    and under a Windows operating system this is `ant.bat stop` ).
 
@@ -115,5 +115,3 @@ Please report bugs and suggestions:
 uPortal website:
 
  http://www.apereo.org/uportal
-
-

--- a/bootstrap/build_includes.xml
+++ b/bootstrap/build_includes.xml
@@ -20,7 +20,7 @@
 -->
 <project name="uPortal_Includes" basedir="." xmlns:artifact="urn:maven-artifact-ant">
     <dirname property="imported.basedir" file="${ant.file.uPortal_Includes}"/>
-    
+
     <fail message="Ant 1.8.2 or 1.9.3+ is required, version ${ant.version} is not supported">
         <condition>
             <not>
@@ -31,13 +31,10 @@
             </not>
         </condition>
     </fail>
-    <fail message="Unsupported Java version: ${java.version}. Make sure that the version of the Java compiler is 1.7 (7.0) or greater.">
+    <fail message="Unsupported Java version: ${java.version}. Make sure that the version of the Java compiler is 1.8 (8.0) or greater.">
         <condition>
             <not>
-                <or>
-                    <contains string="${java.version}" substring="1.7" casesensitive="false" />
-                    <contains string="${java.version}" substring="1.8" casesensitive="false" />
-                </or>
+                <contains string="${java.version}" substring="1.8" casesensitive="false" />
             </not>
         </condition>
     </fail>
@@ -79,7 +76,7 @@
             <echo>${@{filesetref}.echopath}</echo>
         </sequential>
     </macrodef>
-	
+
 	<target name="test-macros" description="Test macrodefs defined in this file">
 		<path id="testpath">
 			<pathelement location="hsqldb"/>

--- a/releaseNotes.html
+++ b/releaseNotes.html
@@ -25,16 +25,16 @@
 <body>
 
 <p>This is a file for notes specific to
-<a href="https://wiki.jasig.org/display/UPC/${project.version}">uPortal ${project.version} Release</a>.  
+<a href="https://wiki.jasig.org/display/UPC/${project.version}">uPortal ${project.version} Release</a>.
 What is known up front and could have been included in these release notes
 will be less than what is discovered about the release over time.</p>
 <p>Therefore, please see <a href="https://wiki.jasig.org/display/UPC/${project.version}">this release's wiki page</a> for more information.</p>
 <h2>Requirements:</h2>
 <ul>
-<li>JDK 1.7 or later</li>
+<li>JDK 1.8 or later</li>
 <li>Tomcat 7.x or later is required.  (Servlet 3.0 is required.) Other servlet containers may work.
     YMMV.</li>
-<li>Database (Oracle, Postgres, MySQL are commonly used in production; 
+<li>Database (Oracle, Postgres, MySQL are commonly used in production;
 these and HSQLDB are commonly used in development; specific vendors and
 versions are supported via declaration in the rdbm.properties file)</li>
 </ul>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Update docs and ant constraint to reflect that uPortal 5 requires Java 8 or above.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
