### PR TITLE
Resolves marketplace entry feed almost always having a null url

### DIFF
--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -63,7 +63,7 @@ public class LayoutPortlet {
             title = portletDef.getTitle();
             description = portletDef.getDescription();
             fname = portletDef.getFName();
-            url = portletDef.getAlternativeMaximizedLink(); //todo get normal URL if alt is missing
+            url = portletDef.getAlternativeMaximizedLink();
             target = portletDef.getTarget();
             isAltMaxUrl = StringUtils.isNotBlank(url);
             IPortletDefinitionParameter iconParam = portletDef.getParameter("iconUrl");

--- a/uPortal-marketplace/src/main/java/org/apereo/portal/rest/layout/MarketplaceEntry.java
+++ b/uPortal-marketplace/src/main/java/org/apereo/portal/rest/layout/MarketplaceEntry.java
@@ -66,6 +66,9 @@ public class MarketplaceEntry implements Serializable {
         this.maxURL = pdef.getRenderUrl();
         this.user = user;
         this.layoutObject = new LayoutPortlet(pdef);
+        if (this.layoutObject.getUrl() == null) {
+            this.layoutObject.setUrl(this.maxURL);
+        }
     }
 
     public MarketplaceEntry(MarketplacePortletDefinition pdef, String maxURL, final IPerson user) {
@@ -73,6 +76,9 @@ public class MarketplaceEntry implements Serializable {
         this.maxURL = maxURL;
         this.user = user;
         this.layoutObject = new LayoutPortlet(pdef);
+        if (this.layoutObject.getUrl() == null) {
+            this.layoutObject.setUrl(this.maxURL);
+        }
     }
 
     public MarketplaceEntry(
@@ -84,6 +90,9 @@ public class MarketplaceEntry implements Serializable {
         this.generateRelatedPortlets = generateRelatedPortlets;
         this.user = user;
         this.layoutObject = new LayoutPortlet(pdef);
+        if (this.layoutObject.getUrl() == null) {
+            this.layoutObject.setUrl(this.maxURL);
+        }
     }
 
     public LayoutPortlet getLayoutObject() {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

The marketplace entry feed would almost always return an object with a null url (would return valid url if altmaxurl was set).  This creates a consistent url in the feed.

Doesn't resolve that three constructors are using more or less the same code.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
