### PR TITLE
NOJIRA: Generate buildscans on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - mvn clean test cobertura:cobertura coveralls:report -B -V
-  - ./gradlew -u -i -S check
+  - ./gradlew -u -i -S --scan check
 
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ description = "Apereo uPortal $version"
 // Build Scans provide detailed information about many aspects of your
 // build right in your browser.  (https://scans.gradle.com/plugin)
 apply plugin: 'com.gradle.build-scan'
+apply plugin: me.champeau.gradle.buildscans.RecipesPlugin
 apply plugin: 'java'
 
 // Adds support for Node.js scripts
@@ -31,6 +32,7 @@ buildscript {
         classpath 'com.gradle:build-scan-plugin:1.0'
         classpath 'com.moowork.gradle:gradle-node-plugin:0.13'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6'
+        classpath 'me.champeau.gradle:buildscan-recipes-plugin:0.2.0'
     }
 }
 
@@ -42,6 +44,9 @@ node {
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
+}
+buildScanRecipes {
+    recipes 'travis-ci', 'git-commit'
 }
 
 subprojects {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Build scans offer additional insights into how the build ran ([reference](https://gradle.com/build-scans)).
These scans can be run by adding `--scan` to any call to `./gradlew` or `gradle.bat`.
This automatically creates and tags a buildscan for each build on continuous integration.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
