### PR TITLE
UP-4854: Setup jacoco test coverage and coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - mvn clean test -B -V
-  - ./gradlew -u -i -S check jacocoRootReport coveralls
+  - ./gradlew -u -i -S check jacocoAggregateReport coveralls
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - mvn clean test cobertura:cobertura coveralls:report -B -V
-  - ./gradlew -u -i -S check
+  - ./gradlew -u -i -S check jacocoRootReport coveralls
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script:
-  - mvn clean test cobertura:cobertura coveralls:report -B -V
+  - mvn clean test -B -V
   - ./gradlew -u -i -S check jacocoRootReport coveralls
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - mvn clean test -B -V
-  - ./gradlew -u -i -S check jacocoAggregateReport coveralls
+  - ./gradlew -u -i -w -S check jacocoAggregateReport coveralls
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,10 @@ language: java
 jdk: oraclejdk8
 sudo: false
 
-before_install:
-  - unset GEM_PATH
+install: ./gradlew install
 
-# ./gradlew assemble (default install command) won't cut it
-install:
-  - ./gradlew install
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-
-script:
-  - mvn clean test -B -V
-  - ./gradlew -u -i -w -S check jacocoAggregateReport coveralls
+script: ./gradlew -u -i -q -S check jacocoAggregateReport coveralls
 
 cache:
   directories:
-    - $HOME/.m2
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    - $HOME/.gradle/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,9 @@ environment:
 os: Visual Studio 2017 # Windows Server 2016
 install:
   - java -version
-  - mvn --version
   - gradlew.bat --version
-build_script:
-  - gradlew.bat -u -i install
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-test_script:
-  - mvn clean test
-  - gradlew.bat -u -i -S check
+build_script: gradlew.bat -u -i install
+test_script: gradlew.bat -u -i -S check
 cache:
   - .gradle
   - C:\Users\appveyor\.gradle
-  - C:\Users\appveyor\.m2\ -> pom.xml

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,6 @@ task jacocoAggregateReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
 }
 
 coveralls {
-    sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
     jacocoReportPath = "${buildDir}/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml"
+    sourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs).files.absolutePath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
     }
 }
 
-task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+task jacocoAggregateReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = subprojects.test
     additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
     sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
@@ -137,4 +137,9 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
             it.exists()
         })
     }
+}
+
+coveralls {
+    sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
+    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ description = "Apereo uPortal $version"
 // Build Scans provide detailed information about many aspects of your
 // build right in your browser.  (https://scans.gradle.com/plugin)
 apply plugin: 'com.gradle.build-scan'
+apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'java'
 
 // Adds support for Node.js scripts
@@ -31,6 +32,7 @@ buildscript {
         classpath 'com.gradle:build-scan-plugin:1.0'
         classpath 'com.moowork.gradle:gradle-node-plugin:0.13'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
     }
 }
 
@@ -42,6 +44,10 @@ node {
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
+}
+
+allprojects {
+    apply plugin: 'jacoco'
 }
 
 subprojects {
@@ -110,5 +116,25 @@ subprojects {
                 }
             }
         }
+    }
+}
+
+task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+    dependsOn = subprojects.test
+    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(subprojects.sourceSets.main.output)
+    executionData = files(subprojects.jacocoTestReport.executionData)
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+    onlyIf = {
+        true
+    }
+    doFirst {
+        executionData = files(executionData.findAll {
+            it.exists()
+        })
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://issues.jasig.org/browse/UP-4854

:notebook: Jacoco can correctly handle Java 8 code, however it will skip subprojects that do not have any tests.

:warning: Coveralls Gradle logs the entire tests results to console. This can causes Travis CI to fail because the log size exceeds 4Mb. Log occurs at `INFO` level, this PR moves logging to quiet to prevent `INFO` and `WARN` level messages from appearing.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
