### PR TITLE
UP-4863: Change JGroups pbcast.GMS join_timeout to 2 seconds and max_…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/jgroups.xml
+++ b/uPortal-webapp/src/main/resources/properties/jgroups.xml
@@ -79,8 +79,8 @@
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="4M"/>
     <!-- <AUTH auth_class="org.apereo.portal.jgroups.auth.HashedDaoAuthToken"/> -->
-    <pbcast.GMS print_local_addr="true" join_timeout="3000"
-
+    <pbcast.GMS print_local_addr="true" join_timeout="2000"
+                max_join_attempts="3"
                 view_bundling="true"/>
     <UFC max_credits="2M"
          min_threshold="0.4"/>


### PR DESCRIPTION
…join_attempts to 3.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Reduce time spent joining JGroups cluster.

<!-- Reference Links -->
https://issues.jasig.org/browse/UP-4863

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
