### PR TITLE
UP-4865:  Once favorited, the Favorites portlet continues to list por…

### DIFF
--- a/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/favorites/FavoritesUtils.java
+++ b/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/favorites/FavoritesUtils.java
@@ -169,7 +169,7 @@ public final class FavoritesUtils {
 
         logger.trace("Extracting favorite portlets from layout [{}]", userLayout);
 
-        List<IUserLayoutNodeDescription> favorites = new LinkedList<IUserLayoutNodeDescription>();
+        List<IUserLayoutNodeDescription> favorites = new LinkedList<>();
 
         Enumeration<String> childrenOfRoot = userLayout.getChildIds(userLayout.getRootId());
 
@@ -180,10 +180,6 @@ public final class FavoritesUtils {
             try {
 
                 IUserLayoutNodeDescription nodeDescription = userLayout.getNodeDescription(nodeId);
-
-                String parentId = userLayout.getParentId(nodeId);
-                String nodeName = nodeDescription.getName();
-                IUserLayoutNodeDescription.LayoutNodeType nodeType = nodeDescription.getType();
 
                 if (FOLDER.equals(nodeDescription.getType())
                         && nodeDescription instanceof IUserLayoutFolderDescription) {
@@ -197,10 +193,10 @@ public final class FavoritesUtils {
 
                         //loop through columns to gather beloved portlets
                         while (columns.hasMoreElements()) {
-                            String column = (String) columns.nextElement();
+                            String column = columns.nextElement();
                             Enumeration<String> portlets = userLayout.getChildIds(column);
                             while (portlets.hasMoreElements()) {
-                                String portlet = (String) portlets.nextElement();
+                                String portlet = portlets.nextElement();
                                 IUserLayoutNodeDescription portletDescription =
                                         userLayout.getNodeDescription(portlet);
                                 favorites.add(portletDescription);

--- a/uPortal-core/src/main/java/org/apereo/portal/layout/node/IUserLayoutNodeDescription.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/layout/node/IUserLayoutNodeDescription.java
@@ -21,7 +21,7 @@ import org.w3c.dom.Element;
  * An interface describing common features of user layout nodes, that is channels and folders
  */
 public interface IUserLayoutNodeDescription {
-    public enum LayoutNodeType {
+    enum LayoutNodeType {
         PORTLET,
         FOLDER;
     }
@@ -31,38 +31,38 @@ public interface IUserLayoutNodeDescription {
      *
      * @return a <code>String</code> value
      */
-    public String getId();
+    String getId();
 
     /** Set a new node Id. The Id has to be unique in the entire user layout document. */
-    public void setId(String id);
+    void setId(String id);
 
     /**
      * Determine a name associated with this node.
      *
      * @return a folder/channel name.
      */
-    public String getName();
+    String getName();
 
     /**
      * Returns a type of the node, could be FOLDER or CHANNEL integer constant.
      *
      * @return a type
      */
-    public LayoutNodeType getType();
+    LayoutNodeType getType();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public boolean isUnremovable();
+    boolean isUnremovable();
 
-    public void setUnremovable(boolean setting);
+    void setUnremovable(boolean setting);
 
-    public boolean isImmutable();
+    boolean isImmutable();
 
-    public void setImmutable(boolean setting);
+    void setImmutable(boolean setting);
 
-    public boolean isHidden();
+    boolean isHidden();
 
-    public void setHidden(boolean setting);
+    void setHidden(boolean setting);
 
     /**
      * Creates a <code>org.w3c.dom.Element</code> representation of the current node.
@@ -70,43 +70,43 @@ public interface IUserLayoutNodeDescription {
      * @param root a <code>Document</code> for which the <code>Element</code> should be created.
      * @return a <code>Element</code> value
      */
-    public Element getXML(Document root);
+    Element getXML(Document root);
 
-    public void addNodeAttributes(Element node);
+    void addNodeAttributes(Element node);
 
     /** Returns true if child nodes can be added to the node. Added by SCT for DLM. */
-    public boolean isAddChildAllowed();
+    boolean isAddChildAllowed();
 
     /** Set whether or not child nodes can be added to this node. Added by SCT for DLM. */
-    public void setAddChildAllowed(boolean setting);
+    void setAddChildAllowed(boolean setting);
 
     /** Returns true if the node's attributes can be edited. Added by SCT for DLM. */
-    public boolean isEditAllowed();
+    boolean isEditAllowed();
 
     /** Set whether a node's attributes can be edited or not. Added by SCT for DLM. */
-    public void setEditAllowed(boolean setting);
+    void setEditAllowed(boolean setting);
 
     /**
      * Returns the precedence value for this node. The precedence is 0.0 for a user owned node and
      * the value of the node's owning fragment's precedence for a node incorporated from another
      * fragment. Added by SCT for DLM.
      */
-    public double getPrecedence();
+    double getPrecedence();
 
     /**
      * Set the precedence of a node. See getPrecedence for more information. Added by SCT for DLM.
      */
-    public void setPrecedence(double setting);
+    void setPrecedence(double setting);
 
     /** Returns true if the node can be moved. Added by SCT for DLM. */
-    public boolean isMoveAllowed();
+    boolean isMoveAllowed();
 
     /** Set whether a node can be moved or not. Added by SCT for DLM. */
-    public void setMoveAllowed(boolean setting);
+    void setMoveAllowed(boolean setting);
 
     /** Returns true if the node can be deleted. Added by SCT for DLM. */
-    public boolean isDeleteAllowed();
+    boolean isDeleteAllowed();
 
     /** Set whether a node can be deleted or not. Added by SCT for DLM. */
-    public void setDeleteAllowed(boolean setting);
+    void setDeleteAllowed(boolean setting);
 }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/node/IUserLayoutChannelDescription.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/node/IUserLayoutChannelDescription.java
@@ -30,168 +30,168 @@ public interface IUserLayoutChannelDescription extends IUserLayoutNodeDescriptio
      *
      * @return value of hasAbout.
      */
-    public boolean hasAbout();
+    boolean hasAbout();
 
     /**
      * Specify whether the channel supports "about" action.
      *
      * @param v Value to assign to hasAbout.
      */
-    public void setHasAbout(boolean v);
+    void setHasAbout(boolean v);
 
     /**
      * Determine if the channel supports "help" action.
      *
      * @return value of hasHelp.
      */
-    public boolean hasHelp();
+    boolean hasHelp();
 
     /**
      * Specify whether the channel supports "help" action.
      *
      * @param v Value to assign to hasHelp.
      */
-    public void setHasHelp(boolean v);
+    void setHasHelp(boolean v);
 
     /**
      * Determine if the channel is editable.
      *
      * @return value of editable.
      */
-    public boolean isEditable();
+    boolean isEditable();
 
     /**
      * Specify whether the channel is editable.
      *
      * @param v Value to assign to editable.
      */
-    public void setEditable(boolean v);
+    void setEditable(boolean v);
 
     /**
      * Get the value of channel timeout in milliseconds.
      *
      * @return value of timeout.
      */
-    public long getTimeout();
+    long getTimeout();
 
     /**
      * Set the value of channel timeout in milliseconds.
      *
      * @param v Value to assign to timeout.
      */
-    public void setTimeout(long v);
+    void setTimeout(long v);
 
     /**
      * Get the value of functionalName.
      *
      * @return value of functionalName.
      */
-    public String getFunctionalName();
+    String getFunctionalName();
 
     /**
      * Set the value of functionalName.
      *
      * @param v Value to assign to functionalName.
      */
-    public void setFunctionalName(String v);
+    void setFunctionalName(String v);
 
     /**
      * Get the value of channelSubscribeId.
      *
      * @return value of channelSubscribeId.
      */
-    public String getChannelSubscribeId();
+    String getChannelSubscribeId();
 
     /**
      * Set the value of channelSubscribeId.
      *
      * @param v Value to assign to channelSubscribeId.
      */
-    public void setChannelSubscribeId(String v);
+    void setChannelSubscribeId(String v);
 
     /**
      * Get the value of channelTypeId.
      *
      * @return value of channelTypeId.
      */
-    public String getChannelTypeId();
+    String getChannelTypeId();
 
     /**
      * Set the value of channelTypeId.
      *
      * @param v Value to assign to channelTypeId.
      */
-    public void setChannelTypeId(String v);
+    void setChannelTypeId(String v);
 
     /**
      * Get the value of channelPublishId for this channel.
      *
      * @return value of channelPublishId.
      */
-    public String getChannelPublishId();
+    String getChannelPublishId();
 
     /**
      * Set the value of channelPublishId for this channel.
      *
      * @param v Value to assign to channelPublishId.
      */
-    public void setChannelPublishId(String v);
+    void setChannelPublishId(String v);
 
     /**
      * Get the value of className implementing this channel.
      *
      * @return value of className.
      */
-    public String getClassName();
+    String getClassName();
 
     /**
      * Set the value of className implementing this channel.
      *
      * @param v Value to assign to className.
      */
-    public void setClassName(String v);
+    void setClassName(String v);
 
     /**
      * Get the value of title.
      *
      * @return value of title.
      */
-    public String getTitle();
+    String getTitle();
 
     /**
      * Set the value of title.
      *
      * @param v Value to assign to title.
      */
-    public void setTitle(String v);
+    void setTitle(String v);
 
     /**
      * Get the value of description.
      *
      * @return value of description.
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Set the value of description.
      *
      * @param v Value to assign to description.
      */
-    public void setDescription(String v);
+    void setDescription(String v);
 
     /**
      * Get the value of secure.
      *
      * @return value of secure.
      */
-    public boolean isSecure();
+    boolean isSecure();
 
     /**
      * Set the value of secure.
      *
      * @param v Value to assign to secure.
      */
-    public void setIsSecure(boolean v);
+    void setIsSecure(boolean v);
 
     /**
      * Return true if the described channel is a JSR-168 portlet, false otherwise.
@@ -200,7 +200,7 @@ public interface IUserLayoutChannelDescription extends IUserLayoutNodeDescriptio
      * @deprecated everything is a portlet now
      */
     @Deprecated
-    public boolean isPortlet();
+    boolean isPortlet();
 
     // channel parameter methods
 
@@ -211,7 +211,7 @@ public interface IUserLayoutChannelDescription extends IUserLayoutNodeDescriptio
      * @param parameterName a <code>String</code> value
      * @return a <code>String</code> value that was set.
      */
-    public String setParameterValue(String parameterName, String parameterValue);
+    String setParameterValue(String parameterName, String parameterValue);
 
     /**
      * Obtain a channel parameter value.
@@ -219,28 +219,28 @@ public interface IUserLayoutChannelDescription extends IUserLayoutNodeDescriptio
      * @param parameterName a <code>String</code> value
      * @return a <code>String</code> value
      */
-    public String getParameterValue(String parameterName);
+    String getParameterValue(String parameterName);
 
     /**
      * Obtain values of all existing channel parameters.
      *
      * @return a <code>Collection</code> of <code>String</code> parameter values.
      */
-    public Collection getParameterValues();
+    Collection getParameterValues();
 
     /**
      * Obtain a set of channel parameter names.
      *
      * @return a <code>Set</code> of <code>String</code> parameter names.
      */
-    public Enumeration getParameterNames();
+    Enumeration getParameterNames();
 
     /**
      * Returns an entire mapping of parameters.
      *
      * @return a <code>Map</code> of parameter names on parameter values.
      */
-    public Map getParameterMap();
+    Map getParameterMap();
 
     /**
      * Creates a <code>org.w3c.dom.Element</code> representation of the current channel.
@@ -248,5 +248,5 @@ public interface IUserLayoutChannelDescription extends IUserLayoutNodeDescriptio
      * @param root a <code>Document</code> for which the <code>Element</code> should be created.
      * @return a <code>Node</code> value
      */
-    public Element getXML(Document root);
+    Element getXML(Document root);
 };

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/favorites/FavoritesController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/favorites/FavoritesController.java
@@ -106,8 +106,11 @@ public class FavoritesController extends AbstractFavoritesController {
         final List<IUserLayoutNodeDescription> rawFavorites = FavoritesUtils.getFavoritePortlets(userLayout);
 
         /*
-         * Filter the collection by SUBSCRIBE permission.  (NOTE:  I wish this filtering were done
-         * by the Layout Manager, before now, but it isn't.)
+         * Filter the collection by SUBSCRIBE permission.
+         *
+         * NOTE:  In the "regular" (non-Favorites) layout, this permissions check is handled by
+         * the rendering engine.  It will refuse to spawn a worker for a portlet to which you
+         * cannot SUBSCRIBE.
          */
         final String username = req.getRemoteUser() != null ? req.getRemoteUser() : PersonFactory.GUEST_USERNAMES.get(0); // First item is the default
         final IAuthorizationPrincipal principal =

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/favorites/FavoritesController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/favorites/FavoritesController.java
@@ -14,13 +14,22 @@
  */
 package org.apereo.portal.portlets.favorites;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
 import org.apereo.portal.UserPreferencesManager;
 import org.apereo.portal.layout.IUserLayout;
 import org.apereo.portal.layout.IUserLayoutManager;
+import org.apereo.portal.layout.node.IUserLayoutChannelDescription;
 import org.apereo.portal.layout.node.IUserLayoutNodeDescription;
+import org.apereo.portal.security.IAuthorizationPrincipal;
+import org.apereo.portal.security.IAuthorizationService;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.PersonFactory;
 import org.apereo.portal.user.IUserInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -52,6 +61,9 @@ public class FavoritesController extends AbstractFavoritesController {
      */
     public static final String MAX_HEIGHT_PIXELS_PREFERENCE = "FavoritesController.maxHeightPixels";
 
+    @Autowired
+    private IAuthorizationService authorizationService;
+
     /**
      * Handles all Favorites portlet VIEW mode renders. Populates model with user's favorites and
      * selects a view to display those favorites.
@@ -72,13 +84,13 @@ public class FavoritesController extends AbstractFavoritesController {
      * @return jsp/Favorites/view[_zero]
      */
     @RenderMapping
-    public String initializeView(Model model) {
-        IUserInstance ui =
+    public String initializeView(PortletRequest req, Model model) {
+        final IUserInstance ui =
                 userInstanceManager.getUserInstance(portalRequestUtils.getCurrentPortalRequest());
-        UserPreferencesManager upm = (UserPreferencesManager) ui.getPreferencesManager();
-        IUserLayoutManager ulm = upm.getUserLayoutManager();
+        final UserPreferencesManager upm = (UserPreferencesManager) ui.getPreferencesManager();
+        final IUserLayoutManager ulm = upm.getUserLayoutManager();
 
-        IUserLayout userLayout = ulm.getUserLayout();
+        final IUserLayout userLayout = ulm.getUserLayout();
 
         // TODO: the portlet could predicate including a non-null marketplace portlet fname
         // on the accessing user having permission to render the portlet referenced by that fname
@@ -87,11 +99,32 @@ public class FavoritesController extends AbstractFavoritesController {
         // viable configured marketplace.  This complexity may not be worth it.  Anyway it is not yet implemented.
         model.addAttribute("marketplaceFname", this.marketplaceFName);
 
-        List<IUserLayoutNodeDescription> collections =
+        final List<IUserLayoutNodeDescription> collections =
                 FavoritesUtils.getFavoriteCollections(userLayout);
         model.addAttribute("collections", collections);
 
-        List<IUserLayoutNodeDescription> favorites = FavoritesUtils.getFavoritePortlets(userLayout);
+        final List<IUserLayoutNodeDescription> rawFavorites = FavoritesUtils.getFavoritePortlets(userLayout);
+
+        /*
+         * Filter the collection by SUBSCRIBE permission.  (NOTE:  I wish this filtering were done
+         * by the Layout Manager, before now, but it isn't.)
+         */
+        final String username = req.getRemoteUser() != null ? req.getRemoteUser() : PersonFactory.GUEST_USERNAMES.get(0); // First item is the default
+        final IAuthorizationPrincipal principal =
+                authorizationService.newPrincipal(username, IPerson.class);
+        final List<IUserLayoutNodeDescription> favorites = new ArrayList<>();
+        for (IUserLayoutNodeDescription nodeDescription : rawFavorites) {
+            if (nodeDescription instanceof IUserLayoutChannelDescription) {
+                final IUserLayoutChannelDescription channelDescription =
+                        (IUserLayoutChannelDescription) nodeDescription;
+                if (principal.canRender(channelDescription.getChannelPublishId())) {
+                    favorites.add(nodeDescription);
+                }
+
+            }
+
+        }
+
         model.addAttribute("favorites", favorites);
 
         // default to the regular old view
@@ -102,7 +135,7 @@ public class FavoritesController extends AbstractFavoritesController {
             viewName = "jsp/Favorites/view_zero";
         }
 
-        logger.trace(
+        logger.debug(
                 "Favorites Portlet VIEW mode render populated model [{}] for render by view {}.",
                 model,
                 viewName);
@@ -111,8 +144,9 @@ public class FavoritesController extends AbstractFavoritesController {
 
     @ModelAttribute("maxHeightPixels")
     public Integer getMaxHeightPixels(PortletPreferences prefs) {
-        String value = prefs.getValue(MAX_HEIGHT_PIXELS_PREFERENCE, null);
-        Integer rslt = value != null ? Integer.valueOf(value) : null;
+        final String value = prefs.getValue(MAX_HEIGHT_PIXELS_PREFERENCE, null);
+        final Integer rslt = value != null ? Integer.valueOf(value) : null;
         return rslt;
     }
+
 }


### PR DESCRIPTION
…tlets even when a user no longer has permission to view them

https://issues.jasig.org/browse/UP-4865

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Favorite Apps will remain in the list even when the user loses access to an app. Clicking on a favorite that the user lost access to will refresh the page and display the following message at the top of the page: “It looks like the page you were attempting to go to does not exist so we redirected you here.” It would be better if apps to which the user no longer has access are not displayed in the list.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
