### PR TITLE
UP-4864:  Hyperlinks in the Favorites portlet fail to honor the alter…

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Favorites/view.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Favorites/view.jsp
@@ -60,10 +60,16 @@
                 <c:forEach var="favorite" items="${favorites}">
                     <li class="list-group-item">
                         <span class="glyphicon glyphicon-star pull-right"></span>
-                        <a href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP">
+                        <c:set var="favoriteAnchorContent">
+                            <c:choose>
+                                <c:when test="${not empty favorite.parameterMap['alternativeMaximizedLink']}">href="${favorite.parameterMap['alternativeMaximizedLink']}" target="_blank" rel="noopener noreferrer"</c:when>
+                                <c:otherwise>href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP"</c:otherwise>
+                            </c:choose>
+                        </c:set>
+                        <a ${favoriteAnchorContent}>
                             <span class="favorites-icon">
                                 <c:choose>
-                                    <c:when test="${favorite.parameterMap['iconUrl'] ne null}">
+                                    <c:when test="${not empty favorite.parameterMap['iconUrl']}">
                                         <img src="${favorite.parameterMap['iconUrl']}" class="img-responsive" alt="Icon for ${favorite.name}" aria-hidden="true" />
                                     </c:when>
                                     <c:otherwise>


### PR DESCRIPTION
…nativeMaximizedLink paramter when configured

https://issues.jasig.org/browse/UP-4864

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Clicking on an item in the Favorites portlet always brings the portlet up in MAXIMIZED window state;  if an 'alternativeMaximizedLink' setting is provided for the portlet, it is not honored.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
