### PR TITLE
UP-4866:  Passed arguments in the correct order to PortalPermissionEv…

### DIFF
--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/PrincipalsRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/PrincipalsRESTController.java
@@ -51,7 +51,7 @@ public class PrincipalsRESTController {
      * @throws Exception
      */
     @PreAuthorize(
-            "hasPermission('string', 'REST', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping(value = "/permissions/principals.json", method = RequestMethod.GET)
     public ModelAndView getPrincipals(
             @RequestParam(value = "q") String query,

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/permissions/PermissionsRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/permissions/PermissionsRESTController.java
@@ -102,7 +102,7 @@ public class PermissionsRESTController {
      * @throws Exception
      */
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping(value = "/permissions/owners.json", method = RequestMethod.GET)
     public ModelAndView getOwners(HttpServletRequest req, HttpServletResponse response)
             throws Exception {
@@ -128,7 +128,7 @@ public class PermissionsRESTController {
      * @throws Exception
      */
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping(value = "/permissions/owners/{owner}.json", method = RequestMethod.GET)
     public ModelAndView getOwners(
             @PathVariable("owner") String ownerParam,
@@ -171,7 +171,7 @@ public class PermissionsRESTController {
      * @throws Exception
      */
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping(value = "/permissions/activities.json", method = RequestMethod.GET)
     public ModelAndView getActivities(
             @RequestParam(value = "q", required = false) String query,
@@ -214,7 +214,7 @@ public class PermissionsRESTController {
      * @throws Exception
      */
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping(value = "/permissions/{activity}/targets.json", method = RequestMethod.GET)
     public ModelAndView getTargets(
             @PathVariable("activity") Long activityId,
@@ -246,7 +246,7 @@ public class PermissionsRESTController {
     }
 
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping("/assignments/principal/{principal}.json")
     public ModelAndView getAssignmentsForPrincipal(
             @PathVariable("principal") String principal,
@@ -265,7 +265,7 @@ public class PermissionsRESTController {
     }
 
     @PreAuthorize(
-            "(#entityType == 'person' and #id == authentication.name) or hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "(#entityType == 'person' and #id == authentication.name) or hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping("/assignments/{entityType}/{id}.json")
     public ModelAndView getAssignmentsForEntity(
             @PathVariable("entityType") String entityType,
@@ -285,7 +285,7 @@ public class PermissionsRESTController {
     }
 
     @PreAuthorize(
-            "hasPermission('string', 'ALL', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
+            "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
     @RequestMapping("/assignments/target/{target}.json")
     public ModelAndView getAssignmentsOnTarget(
             @PathVariable("target") String target,

--- a/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/permission/target/IPermissionTargetProvider.java
+++ b/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/permission/target/IPermissionTargetProvider.java
@@ -30,7 +30,7 @@ public interface IPermissionTargetProvider {
      * @param key
      * @return
      */
-    public IPermissionTarget getTarget(String key);
+    IPermissionTarget getTarget(String key);
 
     /**
      * Search this provider for a particular target using a single string search term. Each target
@@ -39,5 +39,5 @@ public interface IPermissionTargetProvider {
      * @param term search term
      * @return collection of matching targets
      */
-    public Collection<IPermissionTarget> searchTargets(String term);
+    Collection<IPermissionTarget> searchTargets(String term);
 }

--- a/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
+++ b/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/security/provider/AnyUnblockedGrantPermissionPolicy.java
@@ -102,11 +102,7 @@ public class AnyUnblockedGrantPermissionPolicy implements IPermissionPolicy {
                             + "should not be possible.  This is indicative of a potentially serious bug in the permissions "
                             + "and authorization infrastructure;  service='{}', principal='{}', owner='{}', activity='{}', "
                             + "target='{}'",
-                    service,
-                    principal,
-                    owner,
-                    activity,
-                    target);
+                    service, principal, owner, activity, target, new AuthorizationException("Null argument"));
             // fail closed
             return false;
         }


### PR DESCRIPTION
…aluator.hasPermission() within PermissionsRESTController and PrincipalsRESTController

https://issues.jasig.org/browse/UP-4866

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

It's probably been incorrect from the beginning.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
