### PR TITLE
Acknowledge Apereo Welcoming policy.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+uPortal is an Apereo Foundation sponsored project.
+
+The [Apereo Foundation Welcoming Policy][] therefore applies.
+
+In addition to reporting mechanisms under that Policy, participants may at any time contact the uPortal Steering Committee ( `uportal-steering-committee@apereo.org` ) about any matter, and may designate their contact as confidential if they prefer. All contact will be acknowledged. Contacts regarding issues covered by the Welcoming Policy will be handled in a manner consistent with that policy.
+
+[Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ uPortal is an Apereo project.  Apereo requires that contributions be through Ind
 
 You can learn more about [Apereo licensing generally][], the [contributor licensing agreements specifically][], and get the actual [Individual Contributor License Agreement form][], as linked.
 
+## Apereo Welcoming Policy
+
+As an Apereo project, participation in uPortal is within the scope of the Apereo Welcoming Policy. cf. `CODE_OF_CONDUCT.md` at the root of this repository.
+
 ## Getting Started
 
 If you are just getting started with Git, GitHub and/or contributing to uPortal via GitHub there are a few pre-requisite steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ You can learn more about [Apereo licensing generally][], the [contributor licens
 
 ## Apereo Welcoming Policy
 
-As an Apereo project, participation in uPortal is within the scope of the Apereo Welcoming Policy. cf. `CODE_OF_CONDUCT.md` at the root of this repository.
+As an Apereo project, participation in uPortal is within the scope of the Apereo Welcoming Policy. cf. [`CODE_OF_CONDUCT.md`][] at the root of this repository.
 
 ## Getting Started
 
@@ -79,6 +79,8 @@ If your change is to a user-facing experience, it should not regress support for
 [contributor licensing agreements specifically]: http://www.apereo.org/licensing/agreements
 [Contributor License Agreement]: http://www.apereo.org/licensing/agreements
 [Individual Contributor License Agreement form]: https://www.apereo.org/licensing/agreements/icla
+
+[`CODE_OF_CONDUCT.md`]: CODE_OF_CONDUCT.md
 
 [uportal-dev@]: https://wiki.jasig.org/display/JSG/uportal-dev
 [uportal-user@]: https://wiki.jasig.org/display/JSG/uportal-user


### PR DESCRIPTION
Acknowledges that as a sponsored Apereo project, uPortal is in-scope for Apereo Welcoming Policy, as `CODE_OF_CONDUCT.md`.

Riffing on @ChristianMurphy 's #926 applying @jimhelwig suggestion of by-reference rather than by-value inclusion of Apereo policy.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] documentation is changed or added


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
