### PR TITLE
NOJIRA: Test uPortal on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 matrix:
+  fast_finish: true
   include:
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: java
 
+sudo: false
+
 matrix:
   fast_finish: true
   include:
     - os: linux
       dist: trusty
-      sudo: false
       jdk: oraclejdk8
     - os: osx
       osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
-jdk: oraclejdk8
-sudo: false
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode8.3
 
 # The 'build' task runs most things, including test, check, & static analysis
 install: true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds OS X 10.12 to the Travis CI build matrix, ensures linux build is running on Ubuntu Trusty.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
