### PR TITLE
UP-4885: Ensure supported Java version is used to compile portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ description = "Apereo uPortal $version"
 apply plugin: 'com.gradle.build-scan'
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: me.champeau.gradle.buildscans.RecipesPlugin
-apply plugin: 'java'
 apply plugin: 'build-announcements'
 apply plugin: 'org.standardout.versioneye'
 
@@ -58,8 +57,11 @@ versioneye {
 }
 
 allprojects {
+    apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'nebula.lint'
+
+    sourceCompatibility = 1.8
 
     gradleLint.criticalRules = [
       'overridden-dependency-version',
@@ -78,7 +80,6 @@ subprojects {
     apply plugin: 'eclipse'
     apply plugin: 'findbugs'
     apply plugin: 'idea'
-    apply plugin: 'java'
     apply plugin: 'maven'
     apply plugin: 'signing'
     apply plugin: 'maven-publish'

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,10 +34,6 @@ projectLicenseDistribution=repo
 projectIssueSystem=JIRA
 projectIssueUrl=https://issues.jasig.org/browse/UP
 
-gradleVersion=3.4
-sourceCompatibility=1.8
-targetCompatibility=1.8
-
 servletApiDependency=javax.servlet:javax.servlet-api:3.0.1
 portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

<https://issues.jasig.org/browse/UP-4885>

Previously `sourceCompatility` set in `gradle.properties` was creating a dynamic property, which cannot be picked up by the `JavaCompile` task, so the version check was being ignored.

Same goes for `targetCompatibility`, however `targetCompatibility` can be removed since it defaults to `sourceCompatility`.

`gradleVersion` is competing against version set in `.gradle/gradle-wrapper.properties`

:white_check_mark: Example warning output:

```log
* What went wrong:
Execution failed for task ':uPortal-core:compileJava'.
> Could not target platform: 'Java SE 8' using tool chain: 'JDK 7 (1.7)'.
```

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
