### PR TITLE
UP-4892:  (rel-4-3-patches) AnyUnblockedGrantPermissionPolicy does not properly leverage the UsernameTaggedCacheEntryPurger...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/security/IAuthorizationPrincipal.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/IAuthorizationPrincipal.java
@@ -43,14 +43,14 @@ public interface IAuthorizationPrincipal {
  * @return boolean
  * @exception AuthorizationException thrown when authorization information could not be retrieved.
  */
-    public boolean canManage(PortletLifecycleState state, String categoryId) throws AuthorizationException;
+    boolean canManage(PortletLifecycleState state, String categoryId) throws AuthorizationException;
 /**
  * Answers if this <code>IAuthorizationPrincipal</code> has permission to use the CONFIG PortletMode on the specified channel
  * @param channelPublishId
  * @return
  * @throws AuthorizationException
  */
-    public boolean canConfigure(String channelPublishId) throws AuthorizationException;
+    boolean canConfigure(String channelPublishId) throws AuthorizationException;
 /**
  * Answers if this <code>IAuthoriztionPrincipal</code> has permission to render this channel.
  * @return boolean
@@ -73,7 +73,7 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public IPermission[] getAllPermissions() throws AuthorizationException;
+    IPermission[] getAllPermissions() throws AuthorizationException;
 /**
  * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code> for the
  * specified <code>owner</code>, <code>activity</code> and <code>target</code>.  This includes
@@ -88,19 +88,19 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public IPermission[] getAllPermissions(String owner, String activity, String target)
+    IPermission[] getAllPermissions(String owner, String activity, String target)
     throws AuthorizationException;
 /**
  * Return a Vector of IChannels.
  * @return a <code>java.util.Vector</code> of IChannels
  * @exception AuthorizationException indicates authorization information could not be retrieved.
  */
-    public Vector getAuthorizedChannels() throws AuthorizationException;
+    Vector getAuthorizedChannels() throws AuthorizationException;
 /**
- * Returns the key of the underlying entity.
- * @return java.lang.String
+ * Returns the key of the underlying entity.  In the case of a user, the value will be the
+ * username.
  */
-    public String getKey();
+    String getKey();
 /**
  * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code>.
  *
@@ -108,7 +108,7 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public IPermission[] getPermissions() throws AuthorizationException;
+    IPermission[] getPermissions() throws AuthorizationException;
 /**
  * Returns the <code>IPermissions</code> for this <code>IAuthorizationPrincipal</code> for the
  * specified <code>owner</code>, <code>activity</code> and <code>target</code>.  Null parameters
@@ -122,17 +122,17 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public IPermission[] getPermissions(String owner, String activity, String target)
+    IPermission[] getPermissions(String owner, String activity, String target)
     throws AuthorizationException;
 /**
  * @return java.lang.String
  */
-    public String getPrincipalString();
+    String getPrincipalString();
 /**
  * Return the Type of the underlying entity.
  * @return java.lang.Class
  */
-    public Class getType();
+    Class getType();
 
     /**
      * Indicates whether the entity represented by this principal is a group
@@ -155,7 +155,7 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public boolean hasPermission(String owner, String activity, String target) throws
+    boolean hasPermission(String owner, String activity, String target) throws
     AuthorizationException;
 
 /**
@@ -172,6 +172,6 @@ public interface IAuthorizationPrincipal {
  * @exception AuthorizationException indicates authorization information could not
  * be retrieved.
  */
-    public boolean hasPermission(String owner, String activity, String target, IPermissionPolicy policy) 
+    boolean hasPermission(String owner, String activity, String target, IPermissionPolicy policy)
     throws AuthorizationException;
 }

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/AuthorizationPrincipalImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/AuthorizationPrincipalImpl.java
@@ -28,7 +28,6 @@ import org.jasig.portal.security.IPermissionPolicy;
 
 /**
  * @author Dan Ellentuck
- * @version $Revision$
  */
 public class AuthorizationPrincipalImpl implements IAuthorizationPrincipal {
     private final String key;


### PR DESCRIPTION
... to clear permissions evaluations when a user re-authenticates

https://issues.jasig.org/browse/UP-4892

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

The cache 'org.jasig.portal.security.provider.AnyUnblockedGrantPermissionPolicy.HAS_UNBLOCKED_GRANT' declares the tagTrackingCacheEventListener, but it doesn't do any of the necessary things to benefit from its features.

We need to implement username tracking of cache keys in this cache so that a user's cached permissions evaluations will be leared when s/he re-authenticates.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
