### PR TITLE
UP-4896: Ensure portlet drag areas are visible and customize arrows work

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
@@ -236,7 +236,7 @@
        Namespace: region-customizeDrawer
        ========================================================================== */
     #region-customize {
-        position: absolute;
+        position: relative;
         z-index: 1;
 
         button {
@@ -267,11 +267,11 @@
             .border(@grayscale4);
         }
 
-        #customizeOptions.collapse + button i:after {
+        #customizeOptions + button i:after {
             content: "\f0d7";
         }
 
-        #customizeOptions + button i:after {
+        #customizeOptions.in + button i:after {
             content: "\f0d8";
         }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://issues.jasig.org/browse/UP-4896

* Arrow now updates when customize is opened and closed
* Customize drawer no longer partially covers drag and drop areas

Before:

![original_customize](https://user-images.githubusercontent.com/3107513/28292857-fac91ed2-6b05-11e7-9206-ca7c772a886c.gif)

After:

![updated_customize](https://user-images.githubusercontent.com/3107513/28292746-58c6b694-6b05-11e7-979c-5c3fe2bd89b8.gif)



<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
