### PR TITLE
NOJIRA:  Fixed fresh install build issue with nodejs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 node {
-    version = '8.1.4'
+    version = "${nodejsVersion}"
     download = true
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -88,6 +88,7 @@ junitVersion=4.12
 lesscssVersion=1.3.3
 logbackVersion=1.1.2
 mockitoVersion=2.7.6
+nodejsVersion=8.1.4
 oauthVersion=20100527
 orgJsonVersion=20090211
 personDirectoryVersion=1.7.1

--- a/uPortal-webapp/build.gradle
+++ b/uPortal-webapp/build.gradle
@@ -83,7 +83,8 @@ dependencies {
 }
 
 node {
-    workDir = file("${rootDir}/.gradle/nodejs")
+    version = "${nodejsVersion}"
+    download = true
 }
 
 processResources {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
Signed, but Apereo hasn't approved it yet.
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included
N/A
-   [x] documentation is changed or added
N/A
-   [x] [message properties][] have been updated with new phrases
N/A
-   [x] view conforms with [WCAG 2.0 AA][]
No view changes.

##### Description of change
<!-- Provide a description of the change below this comment. -->
On a fresh build of uPortal (5), _./gradlew install_ would fail with a message about not being able to find npm.  After changing the uPortal-webapps node to a discrete version, the build succeeded.  I parameterized the nodejs version for the root level, and the the uPortal-webapp level. 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
