### PR TITLE
UP-4904:  References to 'CATALINA_HOME' should be updated to 'catalin…

### DIFF
--- a/docs/installing/tomcat/index.md
+++ b/docs/installing/tomcat/index.md
@@ -1,6 +1,9 @@
 # Installing Tomcat
 
-Apache Tomcat is the recommended servlet container to use with uPortal. While uPortal requires a Servlet 3.0-compatible servlet container and another servlet container may be used, most uPortal implementers deploy to Apache Tomcat. Choosing Tomcat 8.x will likely allow uPortal adopters to get the best advice from the community.
+Apache Tomcat is the recommended servlet container to use with uPortal. While uPortal requires a
+Servlet 3.0-compatible servlet container and another servlet container may be used, most uPortal
+implementers deploy to Apache Tomcat. Choosing Tomcat 8.x will likely allow uPortal adopters to get
+the best advice from the community.
 
 See also
 
@@ -72,14 +75,13 @@ Unzip the download into a suitable directory. For example, you may unzip the fil
 
 ### 3. Set environment variables
 
-You will need to create two environment variables `CATALINA_HOME` and `JAVA_HOME`.
+You will need to define the `JAVA_HOME` environment variable.
 
 ```shell
-CATALINA_HOME : C:\apache-tomcat-8.x
 JAVA_HOME : C:\Program Files\Java\jdk1.x
 ```
 
-For Windows (different versions may vary) you can create these environment variables by doing the following: right-click 'My Computer' select properties and then the Advanced tab. Then click Environment Variables and under System variables click New. From here, you can enter the name and value for `CATALINA_HOME` and again for `JAVA_HOME` if it's not already created.
+For Windows (different versions may vary) you can create these environment variables by doing the following: right-click 'My Computer' select properties and then the Advanced tab. Then click Environment Variables and under System variables click New. From here, you can enter the name and value for `JAVA_HOME` if it's not already created.
 
 ### 4. Start Tomcat
 
@@ -135,7 +137,7 @@ uPortal requires a larger than standard `PermGen` space (Java 7 only) and more h
 -XX:MaxPermSize=384m (Java 7 only) -Xmx2048m
 ```
 
-To add these, create a file called either `setenv.sh` (Linux/Mac) or `setenv.bat` (Windows) in your `CATALINA_HOME/bin` directory and add the configuration as follows. Note for production settings you would typically want more heap space, at least 4GB. See Additional Tomcat Configuration below.
+To add these, create a file called either `setenv.sh` (Linux/Mac) or `setenv.bat` (Windows) in your Tomcat `bin` directory and add the configuration as follows. Note for production settings you would typically want more heap space, at least 4GB. See Additional Tomcat Configuration below.
 
 ```
 JAVA_OPTS="$JAVA_OPTS -XX:+PrintCommandLineFlags -XX:MaxPermSize=384m -Xms1024m -Xmx2048m -Djsse.enableSNIExtension=false"

--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -71,7 +71,7 @@
                |  Any property defined in the above files that is referenced in the Spring context 
                |  may be overridden in one (or both) of these files.
                |
-               |  The default location for overrides is ${CATALINA_HOME}/portal/overrides.properties;  
+               |  The default location for overrides is ${catalina.base}/portal/overrides.properties;
                |  you can use a custom location by specifying PORTAL_HOME as a JVM startup argument 
                |  or as an environment variable.
                |
@@ -80,9 +80,9 @@
                |  files also).  The latter two files (uPortal_overrides.properties) are for properties
                |  that are specific to uPortal (portlets should not read these files).
                +-->
-              <value>file:${CATALINA_HOME}/portal/overrides.properties</value>
+              <value>file:${catalina.base}/portal/overrides.properties</value>
               <value>file:${PORTAL_HOME}/overrides.properties</value>
-              <value>file:${CATALINA_HOME}/portal/uPortal_overrides.properties</value>
+              <value>file:${catalina.base}/portal/uPortal_overrides.properties</value>
               <value>file:${PORTAL_HOME}/uPortal_overrides.properties</value>
             </list>
         </property>

--- a/uPortal-webapp/src/main/resources/properties/portal.properties
+++ b/uPortal-webapp/src/main/resources/properties/portal.properties
@@ -525,10 +525,11 @@ org.apereo.portal.portlets.googleSearchAppliance.search.result.type=googleApplia
 org.apereo.portal.portlets.googleWebSearch.search.result.type=googleCustom
 
 ##
-## Encryption key for the String Encryption Service used for user password encryption. Should be set to different value
-## at least in prod, typically by using the Spring Property override files defined in CATALINA_HOME or
-## PORTAL_HOME (see applicationContext.xml).  This is used to encrypt the user's password stored in-memory in the
-## security context so malicious code or a hacker is less likely to obtain user's credentials.
+## Encryption key for the String Encryption Service used for user password encryption. Should be
+## set to different value at least in prod, typically by using the Spring Property override files
+## defined in ${catalina.base} or ${PORTAL_HOME} (see applicationContext.xml).  This is used to
+## encrypt the user's password stored in-memory in the security context so malicious code or a
+## hacker is less likely to obtain user's credentials.
 ##
 org.apereo.portal.portlets.passwordEncryptionKey=changeme
 


### PR DESCRIPTION
…a.base'

https://issues.jasig.org/browse/UP-4904

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Using the `${CATALINA_HOME}` variable works in many circumstances, but using the `${catalina.base}` variable works in all (afaik) circumstances.

Tomcat will (always) set the 'catalina.base' variable when it starts up, but the 'CATALINA_HOME' variable is only set if you set it. (And there are many common circumstances where you wouldn't need to set it.)

Also, if your 'catalina.home' and 'catalina.base' values are different – which is uncommon, but can happen – the value we would normally want (in Tomcat speak) is 'catalina.base'.

Reference:
  - https://stackoverflow.com/questions/3090398/tomcat-catalina-base-and-catalina-home-variables
  - https://tomcat.apache.org/tomcat-7.0-doc/introduction.html


[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
