### PR TITLE
UP-4910:  Source external properties from '${portal.home}/global.prop…

### DIFF
--- a/docs/installing/configuring-a-deployment.md
+++ b/docs/installing/configuring-a-deployment.md
@@ -1,0 +1,41 @@
+# Configuring a uPortal Deployment
+
+Most simple uPortal settings can and should be managed outside the `uPortal.war` package itself
+because:
+
+  - Sensitive configuration information is best left out of your Git repository (and `uPortal.war`
+    is built from the sources in your repo)
+  - It's convenient to manage some common settings without a full build-and-deploy cycle
+  - It's advantageous to have build artifacts that are environment-independent and reusable
+
+This system is based on the [Spring Environment abstraction][]. Any setting defined in
+`portal.properties`, `rdbm.properties`, or `security.properties` can be managed in this way.
+
+Use one or more of the following options for defining deployment-specific settings:
+
+  - Special properties files in the `portal.home` directory (see below).
+  - Environment variables
+  - System properties (viz. JVM arguments)
+
+All of these approaches will override the default values for settings found in `uPortal.war`.
+This list is shown in ascending order of priority:  values defined in a manner later on this list
+will override those defined in a manner earlier on the list.
+
+## The `portal.home` Directory
+
+The Spring Environment inside uPortal will look for two files within a special directory called
+`portal.home`:
+
+  - `global.properties
+  - `uPortal.properties`
+
+Both files are 100% optional.
+
+The default location of `portal.home` is `${catalina.base}/portal`, but you can specify another
+location using a `PORTAL_HOME` environment variable.
+
+The `global.properties` file may be sourced by multiple modules in Tomcat (e.g. portlets);  but the
+`uPortal.properties` file should be sourced by uPortal exclusively.  If a setting is defined in
+both files, the value defined in `uPortal.properties` "wins."
+
+[Spring Environment abstraction]: https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-environment

--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -3,6 +3,7 @@
 + [Requirements](requirements.md)
 + [Installing Tomcat](./tomcat/)
 + [Downloading uPortal](downloading.md)
-+ [Using uPortal with a relational database](./database/)
++ [Using uPortal with a Relational Database](./database/)
 + [Building and Deploying uPortal](building-and-deploying.md)
 + [Web Contexts Included in uPortal](web-contexts-included.md)
++ [Configuring a uPortal Deployment](configuring-a-deployment.md)

--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -55,35 +55,34 @@
     <bean id="primaryPropertyPlaceholderConfigurer" class="org.springframework.context.support.PortalPropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>
-              <value>classpath:/properties/rdbm.properties</value>
-              <value>classpath:/properties/security.properties</value>
-              <value>classpath:/properties/portal.properties</value>
-              <!-- 
-               |  The following files optionally allow deployers to set or override many uPortal
-               |  configuration settings in a outside the control of the build/deploy cycle, SCM, 
-               |  and Tomcat.
-               |
-               |  Reasons for choosing that may include:
-               |    - Desire to keep sensitive information out of your Git repository
-               |    - Ability to change some common settings without a full build and deploy cycle
-               |    - Building a WAR/EAR that is environment-independent.
-               |
-               |  Any property defined in the above files that is referenced in the Spring context 
-               |  may be overridden in one (or both) of these files.
-               |
-               |  The default location for overrides is ${catalina.base}/portal/overrides.properties;
-               |  you can use a custom location by specifying PORTAL_HOME as a JVM startup argument 
-               |  or as an environment variable.
-               |
-               |  The first two files (overrides.properties) are intended to contain properties,
-               |  such as database secrets, that are shared with portlets (they read those property
-               |  files also).  The latter two files (uPortal_overrides.properties) are for properties
-               |  that are specific to uPortal (portlets should not read these files).
-               +-->
-              <value>file:${catalina.base}/portal/overrides.properties</value>
-              <value>file:${PORTAL_HOME}/overrides.properties</value>
-              <value>file:${catalina.base}/portal/uPortal_overrides.properties</value>
-              <value>file:${PORTAL_HOME}/uPortal_overrides.properties</value>
+                <value>classpath:/properties/rdbm.properties</value>
+                <value>classpath:/properties/security.properties</value>
+                <value>classpath:/properties/portal.properties</value>
+                <!--
+                 | The following optional files allow deployers to set or override most uPortal
+                 | configuration settings in a manner that is outside the footprint of the
+                 | build/deploy cycle and SCM.
+                 |
+                 | Reasons for choosing that may include:
+                 |   - Desire to keep sensitive information out of your Git repository
+                 |   - Ability to change some common settings without a full build and deploy cycle
+                 |   - Building a WAR/EAR that is environment-independent
+                 |
+                 | Any property defined in the above files that is referenced in the Spring context
+                 | may be overridden in one (or both) of these files.  Later files override earlier
+                 | files.
+                 |
+                 | The conventional location of ${portal.home} is ${catalina.base}/portal;  but you
+                 | can (typically) override that location using a PORTAL_HOME environment variable.
+                 | (Ultimately it depends on your setenv.sh or setenv.bat file.)
+                 |
+                 | The first file (global.properties) may contain properties that are shared with
+                 | other modules (e.g. portlets) in Tomcat.  Several Apereo portlets source
+                 | global.properties automatically.  The second file (uPortal.properties) is
+                 | (should be) sourced by uPortal exclusively.
+                 +-->
+                <value>file:${portal.home}/global.properties</value>
+                <value>file:${portal.home}/uPortal.properties</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
…erties' and '${portal.home}/uPortal.properties';  includes documentation

https://issues.jasig.org/browse/UP-4910

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR corresponds with [PR #29 in uPortal-start](https://github.com/Jasig/uPortal-start/pull/29).

This change removes the following external properties sources...

```
  <value>file:${catalina.base}/portal/overrides.properties</value>
  <value>file:${PORTAL_HOME}/overrides.properties</value>
  <value>file:${catalina.base}/portal/uPortal_overrides.properties</value>
  <value>file:${PORTAL_HOME}/uPortal_overrides.properties</value>
```

in favor of...

```
  <value>file:${portal.home}/global.properties</value>
  <value>file:${portal.home}/uPortal.properties</value>
```

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
