### PR TITLE
UP-4916: Handle text overflow in portlet title

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
@@ -310,6 +310,7 @@
         <!-- Reference anchor for page focus on refresh and link to focused view of channel. -->
         <xsl:element name="a">
           <xsl:attribute name="id"><xsl:value-of select="@ID"/></xsl:attribute>
+          <xsl:attribute name="title"><xsl:value-of select="@title"/></xsl:attribute>
           <xsl:choose>
             <xsl:when test="parameter[@name='alternativeMaximizedLink'] and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
               <xsl:attribute name="href"><xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value" /></xsl:attribute>

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -96,7 +96,7 @@
   & > a {
     display: block;
     width: 80%; // fallback for browsers that don't support calc
-    width: calc(~"100% - 85px"); // tilde is used to escape string, preventing less from mangeling math
+    width: calc(~"100% - 85px"); // tilde is used to escape string, preventing less from mangling math
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -91,6 +91,15 @@
 
 .portlet-title {
   .border-radiuses-top(5px);
+
+  /* title text */
+  & > a {
+    display: block;
+    width: 80%; // fallback for browsers that don't support calc
+    width: calc(~"100% - 85px"); // tilde is used to escape string, preventing less from mangeling math
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .portlet-content {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

When the portlet title includes long text, the text goes through the options dropdown, and can extend past the border of the portlet.
The title should be appropriately truncated before "Options" and should show full text on hover.

Before:

![selection_010](https://user-images.githubusercontent.com/3107513/28896122-0768a978-7790-11e7-9733-1fc21e3293ad.png)

After:

![selection_011](https://user-images.githubusercontent.com/3107513/28896127-0d48a80c-7790-11e7-8a7a-147c9843c092.png)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
