### PR TITLE
UP-4921:  Restore the LoginPortletHelper bean, which was overlooked w…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -36,6 +36,7 @@
         <context:include-filter type="assignable" expression="org.apereo.portal.portlets.PortletPreferencesJsonDao" />
         <context:include-filter type="assignable" expression="org.apereo.portal.portlets.account.UserAccountHelper" />
         <context:include-filter type="assignable" expression="org.apereo.portal.portlets.account.IPasswordResetNotification"/>
+        <context:include-filter type="assignable" expression="org.apereo.portal.portlets.login.LoginPortletHelper"/>
         <context:include-filter type="assignable" expression="org.apereo.portal.portlets.portletadmin.xmlsupport.IChannelPublishingDefinitionDao"/>
     </context:component-scan>
     <context:component-scan base-package="org.apereo.portal" use-default-filters="false">


### PR DESCRIPTION
…hen context:component-scan was refactored

https://issues.jasig.org/browse/UP-4921

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

The @Service bean defined by the class org.apereo.portal.portlets.login.LoginPortletHelper in (currently) not instantiated in either the parent or child (portlet) the application context.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
