### PR TITLE
UP-4922: Add Gradle Release plugin to automatically generate tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ subprojects {
             }
         }
     }
+    afterReleaseBuild.dependsOn uploadArchives
 }
 
 /*
@@ -208,7 +209,7 @@ release {
         requireBranch = ''
     }
 }
-afterReleaseBuild.dependsOn uploadArchives
+
 
 task jacocoAggregateReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = allprojects.test

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'com.moowork.node' version '1.2.0'
     id 'me.champeau.buildscan-recipes' version '0.2.0'
     id 'org.standardout.versioneye' version '1.5.0'
+    id 'net.researchgate.release' version '2.4.0'
 
     // Sub project plugins
     id 'com.github.sherter.google-java-format' version '0.6' apply false
@@ -198,6 +199,8 @@ subprojects {
         }
     }
 }
+
+afterReleaseBuild.dependsOn uploadArchives
 
 task jacocoAggregateReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = allprojects.test

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,14 @@ subprojects {
     }
 }
 
+/*
+ * Configuration for the 'gradle-release' plugin (https://github.com/researchgate/gradle-release)
+ */
+release {
+    git {
+        requireBranch = ''
+    }
+}
 afterReleaseBuild.dependsOn uploadArchives
 
 task jacocoAggregateReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {

--- a/docs/developer/other/RELEASE.md
+++ b/docs/developer/other/RELEASE.md
@@ -17,8 +17,12 @@ signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
 
 ## Running a release
 
-Run
+Run the following commands:
 
 ```sh
-./gradlew clean uploadArtifacts
+./gradlew clean release
+git push origin --tags
 ```
+
+:warning: During the `release` task, you will be prompted for a release version (e.g. `5.0.3`) and a
+new version number for the branch (e.g. `5.0.4-SNAPSHOT`)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.0.0-test
+version=5.0.0-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.0.0-SNAPSHOT
+version=5.0.0-test2
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.0.0-test2
+version=5.0.0-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.0.0-SNAPSHOT
+version=5.0.0-test
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://issues.jasig.org/browse/UP-4922

Plugin is attached to `./gradlew release`

When a release is started the plugin will automatically check that:

1. ~~master branch is being used~~ :memo:  *edit* disabled
2. all changes on branch have been committed
3. all changes on branch have been pushed to remote
4. current branch is up-to-date with remote
5. project is not dependent on any SNAPSHOT releases

Then generates a git tag commit

**:notebook: NOTE**: in the future it could be good to add the git `signTag` option.
Ensuring all releases have been signed by a committer.

gradle release plugin reference: https://github.com/researchgate/gradle-release

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
