### PR TITLE
UP-4924:  Include Bootstrap sources in the uPortal.war package

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ antVersion=1.8.4
 awsVersion=1.10.65
 apereoPortletUtilsVersion=1.1.0
 aspectjVersion=1.7.4
+bootstrapVersion=3.3.7
 casClientVersion=3.4.1
 casServerVersion=3.5.2.1
 ccppVersion=1.0

--- a/uPortal-webapp/build.gradle
+++ b/uPortal-webapp/build.gradle
@@ -22,8 +22,9 @@ description = "Apereo uPortal Webapp (WAR)"
  * TODO:  Groovy-based tests (in src/test/groovy) are not currently run by the Gradle build.
  */
 
-// Support for filtering properties files
-import org.apache.tools.ant.filters.ReplaceTokens
+configurations {
+    webjars
+}
 
 dependencies {
     compile project(':uPortal-groups:uPortal-groups-filesystem')
@@ -67,6 +68,8 @@ dependencies {
     runtime "org.hsqldb:hsqldb:${hsqldbVersion}"
 
     compileOnly "${servletApiDependency}"
+
+    webjars "org.webjars.npm:bootstrap:${bootstrapVersion}"
 }
 
 node {
@@ -74,21 +77,45 @@ node {
     download = true
 }
 
+// Support for filtering properties files
+import org.apache.tools.ant.filters.ReplaceTokens
 processResources {
     filter(ReplaceTokens, tokens:['projectVersion': project.version])
 }
 
-war {
-    // Add generated CSS for Respondr skins to the war file
-    with {
-        from 'build/generated-sources/skin/main/webapp'
-        into '/'
+task prepareSkinResources {
+    // Unpack WebJars (part of the skin)
+    configurations.webjars.allDependencies.each {
+        String webjarName = it.name
+        String webjarVersion = it.version
+        String webjarFile = configurations.webjars.files(it).getAt(0)
+        // Stage 1:  Exploded WebJar
+        doLast {
+            copy {
+                from zipTree(webjarFile)
+                into "${buildDir}/webjars/${webjarName}-${webjarVersion}"
+            }
+        }
+        // Stage 2:  Contents of the WebJar included in the skin
+        doLast {
+            copy {
+                from "${buildDir}/webjars/${webjarName}-${webjarVersion}/META-INF/resources/webjars/${webjarName}/${webjarVersion}"
+                into "${buildDir}/generated-sources/skin/main/webapp/webjars/${webjarName}"
+            }
+        }
+    }
+    // Add Respondr LESS sources
+    doLast {
+        copy {
+            from 'src/main/webapp/media/skins/respondr'
+            into "${buildDir}/generated-sources/skin/main/webapp/media/skins/respondr"
+        }
     }
 }
 
-import org.jasig.resource.aggr.AggregationRequest;
-import org.jasig.resource.aggr.ResourcesAggregator;
-import org.jasig.resource.aggr.ResourcesAggregatorImpl;
+import org.jasig.resource.aggr.AggregationRequest
+import org.jasig.resource.aggr.ResourcesAggregator
+import org.jasig.resource.aggr.ResourcesAggregatorImpl
 task aggregateRespondrSkins {
     doLast {
         final ResourcesAggregator aggr = new ResourcesAggregatorImpl();
@@ -115,5 +142,14 @@ task aggregateRespondrSkins {
 }
 
 // Generate CSS for Respondr skins
+project.tasks.getByName('npm_run_compile-less').dependsOn(prepareSkinResources)
 aggregateRespondrSkins.dependsOn('npm_run_compile-less')
 processResources.dependsOn(aggregateRespondrSkins)
+
+war {
+    // Add generated CSS for Respondr skins to the war file
+    with {
+        from "${buildDir}/generated-sources/skin/main/webapp"
+        into '/'
+    }
+}

--- a/uPortal-webapp/package-lock.json
+++ b/uPortal-webapp/package-lock.json
@@ -75,11 +75,6 @@
         "hoek": "2.16.3"
       }
     },
-    "bootstrap": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
-      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",

--- a/uPortal-webapp/package.json
+++ b/uPortal-webapp/package.json
@@ -2,10 +2,7 @@
   "name": "uportal-webapp",
   "private": true,
   "scripts": {
-    "compile-less": "lessc src/main/webapp/media/skins/respondr/defaultSkin.less build/generated-sources/skin/main/webapp/media/skins/respondr/defaultSkin.css"
-  },
-  "dependencies": {
-    "bootstrap": "3.3.7"
+    "compile-less": "lessc build/generated-sources/skin/main/webapp/media/skins/respondr/defaultSkin.less build/generated-sources/skin/main/webapp/media/skins/respondr/defaultSkin.css"
   },
   "devDependencies": {
     "less": "^2.7.2"

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
@@ -24,7 +24,11 @@
  /* ==========================================================================*
     Bootstrap
     ==========================================================================*/
-@import "../../../../../../../node_modules/bootstrap/less/bootstrap.less";
+/*
+ * NOTE:  Do not change the location of Bootstrap sources lightly;  they must
+ * be included in the uPortal.war package.
+ */
+@import "../../../../webjars/bootstrap/less/bootstrap.less";
 
 /* ==========================================================================
    Utility mixins


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4924

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

uPortal 4 contained Bootstrap sources because we directly checked them into the repo.  For uPoirtal 5, we're downloading them and using them in the Gradle build.

That's excellent, but we need to include them (nevertheless) in the uPortal.war package so that uPortal-start can compile skins and so that the dynamic-respondr-skin portlet can function properly.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
