### PR TITLE
NOJIRA: Pin version of Error Prone core used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ allprojects {
     apply plugin: 'com.github.sherter.google-java-format'
     apply plugin: 'net.ltgt.errorprone'
 
+    dependencies {
+      errorprone 'com.google.errorprone:error_prone_core:2.0.21'
+    }
+
     sourceCompatibility = 1.8
 
     gradleLint.criticalRules = [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

error prone core 2.1 is throwing

``` log
java.lang.ClassCastException: com.sun.tools.javac.tree.JCTree$JCExpressionStatement cannot be cast to com.sun.source.tree.BlockTree
```
https://travis-ci.org/Jasig/uPortal/jobs/267344574#L1023-L1032

reverting back to previous minor release resolves the issue

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
