### PR TITLE
ci: preserve global npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script: ./gradlew -u -i -q -S build jacocoAggregateReport coveralls
 
 cache:
   directories:
+    - $HOME/.npm/
     - $HOME/.gradle/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,5 @@ install:
 build: off
 test_script: gradlew.bat -u -i -S build
 cache:
-  - .gradle
+  - C:\Users\appveyor\.npm
   - C:\Users\appveyor\.gradle


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

local `node_modules` folder will still need to be rebuilt each build.
npm can save some time by reusing a copy from its cache folder, rather than downloading from network.
similar to how caching `.gradle` allows CI to preserve its local maven instance between builds.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
