### PR TITLE
UP-4934: Set size of varbinary for MS SQL Server SQL used by JDBC_PING.

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -122,7 +122,7 @@
                 CREATE TABLE JGROUPSPING (
                     own_addr varchar(200) NOT NULL,
                     cluster_name varchar(200) NOT NULL,
-                    ping_data varbinary DEFAULT NULL,
+                    ping_data varbinary(5000) DEFAULT NULL,
                     PRIMARY KEY (own_addr, cluster_name)
                 )
             </value>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Correct SQL for SQL Server

<!-- Reference Links -->
https://issues.jasig.org/browse/UP-4934

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
