### PR TITLE
Simplify database connection configuration by setting the defaults fo…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/rdbm.properties
+++ b/uPortal-webapp/src/main/resources/properties/rdbm.properties
@@ -33,16 +33,16 @@ hibernate.dialect=org.hibernate.dialect.HSQLDialect
 tomcat.jdbc.pool.logAbandoned=true
 
 ##### uPortal Raw Events DB
-RawEventsJdbcDriver=org.hsqldb.jdbc.JDBCDriver
-RawEventsJdbcUrl=jdbc:hsqldb:hsql://localhost:8887/uPortal
-RawEventsJdbcUser=sa
-RawEventsJdbcPassword=
+RawEventsJdbcDriver=${hibernate.connection.driver_class}
+RawEventsJdbcUrl=${hibernate.connection.url}
+RawEventsJdbcUser=${hibernate.connection.username}
+RawEventsJdbcPassword=${hibernate.connection.password}
 
 ##### uPortal Aggregate Events DB
-AggrEventsJdbcDriver=org.hsqldb.jdbc.JDBCDriver
-AggrEventsJdbcUrl=jdbc:hsqldb:hsql://localhost:8887/uPortal
-AggrEventsJdbcUser=sa
-AggrEventsJdbcPassword=
+AggrEventsJdbcDriver=${hibernate.connection.driver_class}
+AggrEventsJdbcUrl=${hibernate.connection.url}
+AggrEventsJdbcUser=${hibernate.connection.username}
+AggrEventsJdbcPassword=${hibernate.connection.password}
 
 ##### Hypersonic SQL - Server mode
 ##### Requires first starting Hypersonic SQL with the command:


### PR DESCRIPTION
…r 'Raw Events DB' and 'Aggregate Events DB' like so:  'RawEventsJdbcDriver=${hibernate.connection.driver_class}' etc.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This is a tiny but helpful change to the default configuration for database connections.

Currently you **must** specify full connection settings for all 3 data sources (unless you're using the embedded HSQLDB):
  - portal (main)
  - Raw Events
  - Aggregate Events

This change makes it so that if you're using the same connection info for all 3, you only have to specify it once, using the standard portal database properties.
  

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
