### PR TITLE
UP-4939:  Provide sensible defaults for the org.apereo.services.perso…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/ehcache.xml
+++ b/uPortal-webapp/src/main/resources/properties/ehcache.xml
@@ -331,16 +331,16 @@
 
 
 
-    <!-- ******************** Per-Datasource Person Directory Caches ******************** -->
+    <!-- ******************** Person Directory Caches ******************** -->
+
     <!--
-     | Caches the final merge results of a person directory query, short cache to ensure the
-     | individual attribute source caches are honored
+     | Caches the final merge results of a person directory query.
      | - 1 x user
      | - not replicated - doesn't represent an updatable data store
      +-->
     <cache name="org.apereo.services.persondir.USER_INFO.merged"
-        eternal="false" maxElementsInMemory="500" overflowToDisk="false" diskPersistent="false"
-        timeToIdleSeconds="30" timeToLiveSeconds="60" memoryStoreEvictionPolicy="LRU" statistics="true" >
+        eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false"
+        timeToIdleSeconds="0" timeToLiveSeconds="900" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory class="org.apereo.portal.utils.cache.SpringCacheEventListenerFactory" properties="beanName=tagTrackingCacheEventListener" listenFor="local" />
     </cache>
 


### PR DESCRIPTION
…ndir.USER_INFO.merged

https://issues.jasig.org/browse/UP-4939

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Out of the box, the org.apereo.services.persondir.USER_INFO.merged cache is the only cache in uPortal for user attributes.

Currently it is set to 30 sec TTI and 60 sec TTL.  That is too low for a typical portal -- these settings will likely cause performance issues integrating with LDAP, etc.

We should make it 900 sec (15 min) TTL.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
