### PR TITLE
UP-4940: Resolve sticky header issues at 798px screen width

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
@@ -285,7 +285,7 @@
 
 }
 
-@media only screen and (min-width: 769px) {
+@media only screen and (min-width: @screen-sm-min) {
 
     .portal {
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

:link: https://issues.jasig.org/browse/UP-4940

`min-width` for sticky header style switch set to 769px.
The rest of the application switches at 768px, causing sticky header to be out of sync at that specific screen width.
This changes the `min-width` value to 768px and leverages the bootstrap `@screen-sm-min` variable to ensure this stays in sync with the rest of the application.

### :movie_camera:  Before

![responsiveness-issue](https://user-images.githubusercontent.com/3107513/30505794-bef81cdc-9a2b-11e7-890d-28b6139b42b9.gif)

### :movie_camera: After

![responsiveness-resolution](https://user-images.githubusercontent.com/3107513/30505799-c5623f8a-9a2b-11e7-8f68-4530be2ac60a.gif)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
