### PR TITLE
UP-4950:  Regression in the Groups Selector stemming from Porta…

### DIFF
--- a/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/provider/SimplePersonManager.java
+++ b/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/provider/SimplePersonManager.java
@@ -16,15 +16,15 @@ package org.apereo.portal.security.provider;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.PortalSecurityException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Manages the storage of an IPerson object in a user's session. */
 public class SimplePersonManager extends AbstractPersonManager {
 
-    private static final Log log = LogFactory.getLog(SimplePersonManager.class);
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * Retrieve an IPerson object for the incoming request
@@ -40,15 +40,17 @@ public class SimplePersonManager extends AbstractPersonManager {
         // Return the person object if it exists in the user's session
         if (session != null) {
             person = (IPerson) session.getAttribute(PERSON_SESSION_KEY);
+            logger.debug("getPerson -- person object retrieved from session is [{}]", person);
         }
 
         if (person == null) {
             try {
                 // Create a guest person
                 person = createGuestPerson(request);
+                logger.debug("getPerson -- created a new guest person [{}]", person);
             } catch (Exception e) {
                 // Log the exception
-                log.error("Exception creating guest person.", e);
+                logger.error("Exception creating guest person.", e);
             }
             // Add this person object to the user's session
             if (person != null && session != null) {

--- a/uPortal-spring/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
+++ b/uPortal-spring/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
@@ -23,7 +23,6 @@ import org.apereo.portal.security.IAuthorizationPrincipal;
 import org.apereo.portal.security.IPermission;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
-import org.apereo.portal.security.PersonFactory;
 import org.apereo.portal.services.AuthorizationServiceFacade;
 import org.apereo.portal.url.IPortalRequestUtils;
 import org.slf4j.Logger;
@@ -160,7 +159,8 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
         if (authPrincipal instanceof UserDetails) {
             // User is authenticated
             UserDetails userDetails = (UserDetails) authPrincipal;
-            logger.trace("getAuthorizationPrincipal -- AUTHENTICATED, userDetails=[{}]", userDetails);
+            logger.trace(
+                    "getAuthorizationPrincipal -- AUTHENTICATED, userDetails=[{}]", userDetails);
             username = userDetails.getUsername();
         } else {
             // Which guest user are we?

--- a/uPortal-spring/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
+++ b/uPortal-spring/src/main/java/org/apereo/portal/spring/security/evaluator/PortalPermissionEvaluator.java
@@ -92,7 +92,8 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
         }
 
         logger.trace(
-                "In hasPermission() - owner=[{}], activity=[{}], targetId=[{}] ",
+                "In hasPermission() - principal=[{}], owner=[{}], activity=[{}], targetId=[{}] ",
+                principal,
                 activity.getOwnerFname(),
                 activity.getActivityFname(),
                 targetId);
@@ -152,18 +153,20 @@ public class PortalPermissionEvaluator implements PermissionEvaluator {
     /** Prepare a uPortal IAuthorizationPrincipal based in the Spring principal */
     private IAuthorizationPrincipal getAuthorizationPrincipal(Authentication authentication) {
 
-        String username =
-                PersonFactory.GUEST_USERNAMES.get(0); // default -- first unauthenticated user
+        final Object authPrincipal = authentication.getPrincipal();
+        logger.trace("getAuthorizationPrincipal -- authPrincipal=[{}]", authPrincipal);
 
-        Object authPrincipal = authentication.getPrincipal();
+        String username;
         if (authPrincipal instanceof UserDetails) {
             // User is authenticated
             UserDetails userDetails = (UserDetails) authPrincipal;
+            logger.trace("getAuthorizationPrincipal -- AUTHENTICATED, userDetails=[{}]", userDetails);
             username = userDetails.getUsername();
         } else {
             // Which guest user are we?
             final HttpServletRequest req = portalRequestUtils.getCurrentPortalRequest();
             final IPerson person = personManager.getPerson(req);
+            logger.trace("getAuthorizationPrincipal -- UNAUTHENTICATED, person=[{}]", person);
             username = person.getUserName();
         }
 

--- a/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
+++ b/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
@@ -56,14 +56,11 @@ public class PortalPreAuthenticatedProcessingFilter
 
     private static final String SWAPPER_LOG_NAME = "org.jasig.portal.portlets.swapper";
 
-    /**
-     * Log for identity swapper activity.
-     */
+    /** Log for identity swapper activity. */
     private final Logger swapperLog = LoggerFactory.getLogger(SWAPPER_LOG_NAME);
 
     /**
-     * "Regular" log.  This variable covers a commons-logging log of the same name in the
-     * superclass.
+     * "Regular" log. This variable covers a commons-logging log of the same name in the superclass.
      */
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -177,9 +174,11 @@ public class PortalPreAuthenticatedProcessingFilter
 
         if (logger.isDebugEnabled()) {
             final HttpServletRequest httpr = (HttpServletRequest) request;
-            logger.debug("FINISHED [{}] for URI='{}' in {}ms #milestone", uuid,
-                httpr.getRequestURI(),
-                Long.toString(System.currentTimeMillis() - timestamp));
+            logger.debug(
+                    "FINISHED [{}] for URI='{}' in {}ms #milestone",
+                    uuid,
+                    httpr.getRequestURI(),
+                    Long.toString(System.currentTimeMillis() - timestamp));
         }
     }
 
@@ -216,13 +215,16 @@ public class PortalPreAuthenticatedProcessingFilter
         IdentitySwapHelper identitySwapHelper = null;
         final String requestedSessionId = request.getRequestedSessionId();
         if (request.isRequestedSessionIdValid()) {
-            logger.debug("doPortalAuthentication for valid requested session id='{}'",
-                requestedSessionId);
+            logger.debug(
+                    "doPortalAuthentication for valid requested session id='{}'",
+                    requestedSessionId);
             identitySwapHelper =
                     getIdentitySwapDataAndInvalidateSession(request, originalAuthentication);
         } else {
-            logger.trace("Requested session id='{}' was not valid, so no attempt to apply " +
-                "swapping rules.", requestedSessionId);
+            logger.trace(
+                    "Requested session id='{}' was not valid, so no attempt to apply "
+                            + "swapping rules.",
+                    requestedSessionId);
         }
 
         HttpSession s = request.getSession(true);
@@ -406,7 +408,8 @@ public class PortalPreAuthenticatedProcessingFilter
                             this, identitySwapHelper.getTargetProfile(), person, request);
             this.publishProfileSelectionEvent(event);
         } else {
-            logger.trace("No requested or swapper profile requested so no profile selection event.");
+            logger.trace(
+                    "No requested or swapper profile requested so no profile selection event.");
         }
     }
 
@@ -421,18 +424,24 @@ public class PortalPreAuthenticatedProcessingFilter
     }
 
     private void logForLoginPath(final String currentPath) {
-        logger.debug("Path [{}] is loginPath, so cleared security context so we can re-establish " +
-                "it once the new session is established.", currentPath);
+        logger.debug(
+                "Path [{}] is loginPath, so cleared security context so we can re-establish "
+                        + "it once the new session is established.",
+                currentPath);
     }
 
     private void logForLogoutPath(final String currentPath) {
-        logger.debug("Path [{}] is logoutPath, so cleared security context so can re-establish " +
-            "it once the new session is established.", currentPath);
+        logger.debug(
+                "Path [{}] is logoutPath, so cleared security context so can re-establish "
+                        + "it once the new session is established.",
+                currentPath);
     }
 
     private void logForNonLoginOrLogoutPath(final String currentPath) {
-        logger.trace("Path [{}] is neither a login nor a logout path, so no uPortal-custom " +
-            "filtering.", currentPath);
+        logger.trace(
+                "Path [{}] is neither a login nor a logout path, so no uPortal-custom "
+                        + "filtering.",
+                currentPath);
     }
 
     private void retrieveCredentialAndPrincipalTokens() {
@@ -507,5 +516,4 @@ public class PortalPreAuthenticatedProcessingFilter
         super.setApplicationEventPublisher(anApplicationEventPublisher);
         this.eventPublisher = anApplicationEventPublisher;
     }
-
 }

--- a/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
+++ b/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
@@ -97,8 +97,8 @@ public class PortalPreAuthenticatedProcessingFilter
 
     /**
      * This setting controls whether Spring's <code>SecurityContextHolder</code> will be reset
-     * (emptied) whenever a login request is processed.  The default is <code>true</code>, and this
-     * option should only be set to <code>false</code> with extreme care.  Problems occur When this
+     * (emptied) whenever a login request is processed. The default is <code>true</code>, and this
+     * option should only be set to <code>false</code> with extreme care. Problems occur When this
      * setting is <code>false</code> in portals that permits unauthenticated users because
      * authenticated users tend to retain their unauthenticated identity (e.g. 'guest') in Spring
      * Security.

--- a/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
+++ b/uPortal-spring/src/main/java/org/apereo/portal/spring/security/preauth/PortalPreAuthenticatedProcessingFilter.java
@@ -27,8 +27,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apereo.portal.layout.profile.ProfileSelectionEvent;
 import org.apereo.portal.portlets.swapper.IdentitySwapperPrincipal;
 import org.apereo.portal.portlets.swapper.IdentitySwapperSecurityContext;
@@ -39,6 +37,8 @@ import org.apereo.portal.security.IdentitySwapperManager;
 import org.apereo.portal.security.mvc.LoginController;
 import org.apereo.portal.services.Authentication;
 import org.apereo.portal.spring.security.PortalPersonUserDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -54,7 +54,18 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 public class PortalPreAuthenticatedProcessingFilter
         extends AbstractPreAuthenticatedProcessingFilter {
 
-    private final Log swapperLog = LogFactory.getLog("org.jasig.portal.portlets.swapper");
+    private static final String SWAPPER_LOG_NAME = "org.jasig.portal.portlets.swapper";
+
+    /**
+     * Log for identity swapper activity.
+     */
+    private final Logger swapperLog = LoggerFactory.getLogger(SWAPPER_LOG_NAME);
+
+    /**
+     * "Regular" log.  This variable covers a commons-logging log of the same name in the
+     * superclass.
+     */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private String loginPath = "/Login";
     private String logoutPath = "/Logout";
@@ -99,15 +110,15 @@ public class PortalPreAuthenticatedProcessingFilter
     @Override
     public void afterPropertiesSet() {
         super.afterPropertiesSet();
-        this.credentialTokens = new HashMap<String, String>(1);
-        this.principalTokens = new HashMap<String, String>(1);
+        this.credentialTokens = new HashMap<>(1);
+        this.principalTokens = new HashMap<>(1);
         this.retrieveCredentialAndPrincipalTokens();
     }
 
     /**
      * Set the path to the portal's local login servlet.
      *
-     * @param loginPath
+     * @param loginPath The path to the portal's local login servlet
      */
     public void setLoginPath(String loginPath) {
         this.loginPath = loginPath;
@@ -116,7 +127,7 @@ public class PortalPreAuthenticatedProcessingFilter
     /**
      * Set the path to the portal's local logout servlet.
      *
-     * @param logoutPath
+     * @param logoutPath The path to the portal's local logout servlet
      */
     public void setLogoutPath(String logoutPath) {
         this.logoutPath = logoutPath;
@@ -128,23 +139,18 @@ public class PortalPreAuthenticatedProcessingFilter
 
         // Set up some DEBUG logging for performance troubleshooting
         final long timestamp = System.currentTimeMillis();
-        UUID uuid =
-                null; // Tagging with a UUID (instead of username) because username changes in the /Login process
+        // Tagging with a UUID (instead of username) because username changes in the /Login process
+        UUID uuid = null;
         if (logger.isDebugEnabled()) {
             uuid = UUID.randomUUID();
             final HttpServletRequest httpr = (HttpServletRequest) request;
-            logger.debug(
-                    "STARTING ["
-                            + uuid.toString()
-                            + "] for URI="
-                            + httpr.getRequestURI()
-                            + " #milestone");
+            logger.debug("STARTING [{}] for URI='{}' #milestone", uuid, httpr.getRequestURI());
         }
 
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String currentPath = httpServletRequest.getServletPath();
 
-        /**
+        /*
          * Override the base class's main filter method to bypass this filter if we're currently at
          * the login servlet. Since that servlet sets up the user session and authentication, we
          * need it to run before this filter is useful.
@@ -171,14 +177,9 @@ public class PortalPreAuthenticatedProcessingFilter
 
         if (logger.isDebugEnabled()) {
             final HttpServletRequest httpr = (HttpServletRequest) request;
-            logger.debug(
-                    "FINISHED ["
-                            + uuid
-                            + "] for URI="
-                            + httpr.getRequestURI()
-                            + " in "
-                            + Long.toString(System.currentTimeMillis() - timestamp)
-                            + "ms #milestone");
+            logger.debug("FINISHED [{}] for URI='{}' in {}ms #milestone", uuid,
+                httpr.getRequestURI(),
+                Long.toString(System.currentTimeMillis() - timestamp));
         }
     }
 
@@ -191,6 +192,7 @@ public class PortalPreAuthenticatedProcessingFilter
         }
         // otherwise, use the person's current SecurityContext as the credentials
         final IPerson person = personManager.getPerson(request);
+        logger.debug("getPreAuthenticatedCredentials -- person=[{}]", person);
         return person.getSecurityContext();
     }
 
@@ -201,8 +203,9 @@ public class PortalPreAuthenticatedProcessingFilter
         if (session == null) {
             return null;
         }
-        // otherwise, use the current IPerson as the UserDetails
+        // Otherwise, use the current IPerson as the UserDetails
         final IPerson person = personManager.getPerson(request);
+        logger.debug("getPreAuthenticatedPrincipal -- person=[{}]", person);
         return new PortalPersonUserDetails(person);
     }
 
@@ -213,21 +216,13 @@ public class PortalPreAuthenticatedProcessingFilter
         IdentitySwapHelper identitySwapHelper = null;
         final String requestedSessionId = request.getRequestedSessionId();
         if (request.isRequestedSessionIdValid()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "doPortalAuthentication for valid requested session id "
-                                + requestedSessionId);
-            }
+            logger.debug("doPortalAuthentication for valid requested session id='{}'",
+                requestedSessionId);
             identitySwapHelper =
                     getIdentitySwapDataAndInvalidateSession(request, originalAuthentication);
         } else {
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                        "Requested session id "
-                                + requestedSessionId
-                                + " was not valid "
-                                + "so no attempt to apply swapping rules.");
-            }
+            logger.trace("Requested session id='{}' was not valid, so no attempt to apply " +
+                "swapping rules.", requestedSessionId);
         }
 
         HttpSession s = request.getSession(true);
@@ -349,19 +344,14 @@ public class PortalPreAuthenticatedProcessingFilter
                 if (identitySwapHelper.isSwapRequest()) {
                     identitySwapHelper.setOriginalAuthenticationForSwap(originalAuth);
                 }
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Invalidating the impersonated session in un-swapping.");
-                }
+                logger.debug("Invalidating the impersonated session in un-swapping.");
                 s.invalidate();
             }
         } catch (IllegalStateException ise) {
             // ISE indicates session was already invalidated.
             // This is fine.  This servlet trying to guarantee that the session has been invalidated;
             // it doesn't have to insist that it is the one that invalidated it.
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                        "LoginServlet attempted to invalidate an already invalid session.", ise);
-            }
+            logger.trace("LoginServlet attempted to invalidate an already invalid session.", ise);
         }
         return identitySwapHelper;
     }
@@ -416,53 +406,33 @@ public class PortalPreAuthenticatedProcessingFilter
                             this, identitySwapHelper.getTargetProfile(), person, request);
             this.publishProfileSelectionEvent(event);
         } else {
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                        "No requested or swapper profile requested so no profile selection event.");
-            }
+            logger.trace("No requested or swapper profile requested so no profile selection event.");
         }
     }
 
     private void publishProfileSelectionEvent(final ProfileSelectionEvent event) {
         try {
             this.eventPublisher.publishEvent(event);
-        } catch (final Exception exceptionFiringProfileSelection) {
+        } catch (final Exception e) {
             // failing to swap as the desired profile selection is bad,
             // but preventing login entirely is worse.  Log the exception and continue.
-            logger.error(
-                    "Exception on firing profile selection event " + event,
-                    exceptionFiringProfileSelection);
+            logger.error("Exception on firing profile selection event='{}'", event, e);
         }
     }
 
     private void logForLoginPath(final String currentPath) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "Path ["
-                            + currentPath
-                            + "] is loginPath, so cleared security context"
-                            + " so we can re-establish it once the new session is established.");
-        }
+        logger.debug("Path [{}] is loginPath, so cleared security context so we can re-establish " +
+                "it once the new session is established.", currentPath);
     }
 
     private void logForLogoutPath(final String currentPath) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "Path ["
-                            + currentPath
-                            + "] is logoutPath, so cleared security context"
-                            + " so can re-establish it once the new session is established.");
-        }
+        logger.debug("Path [{}] is logoutPath, so cleared security context so can re-establish " +
+            "it once the new session is established.", currentPath);
     }
 
     private void logForNonLoginOrLogoutPath(final String currentPath) {
-        if (logger.isTraceEnabled()) {
-            logger.trace(
-                    "Path ["
-                            + currentPath
-                            + "] is neither a login nor a logout path,"
-                            + " so no uPortal-custom filtering.");
-        }
+        logger.trace("Path [{}] is neither a login nor a logout path, so no uPortal-custom " +
+            "filtering.", currentPath);
     }
 
     private void retrieveCredentialAndPrincipalTokens() {
@@ -538,14 +508,4 @@ public class PortalPreAuthenticatedProcessingFilter
         this.eventPublisher = anApplicationEventPublisher;
     }
 
-    /**
-     * Convenience method for sub-classes to access the event publisher without having to override
-     * this class implementation of setApplicationEventPublisher (which this class had to override
-     * in its parent class because that parent class failed to expose a getter method like this!)
-     *
-     * @return the Spring application event publisher.
-     */
-    protected final ApplicationEventPublisher getApplicationEventPublisher() {
-        return this.eventPublisher;
-    }
 }

--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -42,7 +42,6 @@
     <bean id="portalPreAuthenticationFilter"
         class="org.apereo.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter">
         <property name="authenticationManager" ref="authenticationManager" />
-        <property name="clearSecurityContextPriorToPortalAuthentication" value="true" />
     </bean>
 
     <bean id="preAuthProvider"

--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -42,7 +42,7 @@
     <bean id="portalPreAuthenticationFilter"
         class="org.apereo.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter">
         <property name="authenticationManager" ref="authenticationManager" />
-        <property name="clearSecurityContextPriorToPortalAuthentication" value="false" />
+        <property name="clearSecurityContextPriorToPortalAuthentication" value="true" />
     </bean>
 
     <bean id="preAuthProvider"


### PR DESCRIPTION
…lPreAuthenticatedProcessingFilter

https://issues.jasig.org/browse/UP-4950

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This change fixes the regression -- specifically `clearSecurityContextPriorToPortalAuthentication=true` (most of the changes are updates to logging) -- but probably undoes the fix for [UP-4613](https://issues.jasig.org/browse/UP-4613).

  - See also https://github.com/Jasig/uPortal/commit/b55488d17550091500d5fcbd9b581484386efb1a

I need to connect with @groybal next week.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
