### PR TITLE
build(gradle): update soffit renderer to use same Spring version as core

### DIFF
--- a/uPortal-soffit/uPortal-soffit-renderer/build.gradle
+++ b/uPortal-soffit/uPortal-soffit-renderer/build.gradle
@@ -14,7 +14,7 @@ dependencies {
      * We are working to upgrade the rest of uPortal to Spring 4.  When that happens, this
      * difference can & should be removed.
      */
-    compile "org.springframework:spring-webmvc:4.3.1.RELEASE"
+    compile "org.springframework:spring-webmvc:${springVersion}"
 
     testCompile("junit:junit:${junitVersion}") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Since both soffits and core now are both on Spring 4.
Update soffits to leverage the core spring version.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
