### PR TITLE
build(gradle): add plugin that generates a visualization of task graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'me.champeau.buildscan-recipes' version '0.2.0'
     id 'org.standardout.versioneye' version '1.5.0'
     id 'net.researchgate.release' version '2.4.0'
+    id 'cz.malohlava' version '1.0.3'
 
     // Sub project plugins
     id 'com.github.sherter.google-java-format' version '0.6' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id 'me.champeau.buildscan-recipes' version '0.2.0'
     id 'org.standardout.versioneye' version '1.5.0'
     id 'net.researchgate.release' version '2.4.0'
+    // Records all tasks in task graph, generates `build/reports/visteg.dot`
+    // dot file can be converted to an image using graphviz. `dot -Tsvg -O -v visteg.dot`
     id 'cz.malohlava' version '1.0.3'
 
     // Sub project plugins
@@ -57,6 +59,7 @@ allprojects {
       errorprone 'com.google.errorprone:error_prone_core:2.1.1'
     }
 
+    // Version has to be set directly here, using a variable does not set Java compatability version
     sourceCompatibility = 1.8
 
     gradleLint.criticalRules = [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Every task run will generate a *build/reports/visteg.dot* file.
This file can be converted to svg or png using graphviz `dot -Tsvg visteg.dot -O -v`.

Ref: https://github.com/mmalohlava/gradle-visteg
Example output: [visteg.dot.svg.zip](https://github.com/Jasig/uPortal/files/1377973/visteg.dot.svg.zip)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
