### PR TITLE
UP-4954:  CAS AuthN -- Prevent uPortal from requiring a CAS PGT by de…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -150,11 +150,11 @@
      +-->
     <bean name="ticketValidationFilter" class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter">
         <property name="service" value="${cas.ticketValidationFilter.service}" />
-        <property name="proxyReceptorUrl" value="${cas.ticketValidationFilter.proxyReceptorUrl}" />
+        <property name="proxyReceptorUrl" value="${cas.ticketValidationFilter.proxyReceptorUrl:}" />
         <property name="ticketValidator">
             <bean class="org.jasig.cas.client.validation.Cas20ServiceTicketValidator">
                 <constructor-arg index="0" value="${cas.ticketValidationFilter.ticketValidator.server}" />
-                <property name="proxyCallbackUrl" value="${cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl}" />
+                <property name="proxyCallbackUrl" value="${cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl:}" />
             </bean>
         </property>
         <!--

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -52,7 +52,7 @@ org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.crede
 
 ## If the following 2 properties are defined (either with the values shown or other valid values),
 ## CAS authentication will also request a Proxy-Granting Ticket (PGT).  This feature requires
-## special permission in the CAS Servicec Manager.
+## special permission in the CAS Service Manager.
 #
 #cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
 #cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -19,7 +19,7 @@
 
 ##
 ##  CAS & Local Authentication
-##  
+##
 ##  The following is an example of configuring uPortal to use both CAS
 ##  and local user authentication (authentication by username and password
 ##  hash stored in the uPortal database).  It uses the UnionSecurityContext
@@ -46,11 +46,16 @@ cas.protocol=http
 cas.server=localhost:8080
 cas.context=/cas
 cas.ticketValidationFilter.service=${portal.protocol}://${portal.server}${portal.context}/Login
-cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
 cas.ticketValidationFilter.ticketValidator.server=${cas.protocol}://${cas.server}${cas.context}
-cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet
 org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.enabled=false
 org.apereo.portal.security.provider.cas.CasAssertionSecurityContextFactory.credentialToken=ticket
+
+## If the following 2 properties are defined (either with the values shown or other valid values),
+## CAS authentication will also request a Proxy-Granting Ticket (PGT).  This feature requires
+## special permission in the CAS Servicec Manager.
+#
+#cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
+#cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.server}${portal.context}/CasProxyServlet
 
 ## Simple (database)
 #


### PR DESCRIPTION
…fault

https://issues.jasig.org/browse/UP-4954

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Most uPortals in 2017 don't use PGTs.

If you need it, turn the feature on;  but the default should be that a PGT is not required from CAS.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
