### PR TITLE
ci(travis): add open jdk 8 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       jdk: openjdk8
       sudo: required
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.1 # OSX 10.12, Oracle Java 8
 
 # The 'build' task runs most things, including test, check, & static analysis
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: java
 
 matrix:
-  fast_finish: true
   include:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
+      sudo: required
+    - os: linux
+      dist: trusty
+      jdk: openjdk8
       sudo: required
     - os: osx
       osx_image: xcode8.3


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

also removes unused `fast_finish` property.
`fast_finish` is only used if there are allowed failures.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
