### PR TITLE
ci(travis): add open jdk 8 to test matrix - rel-4-3-patches backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,32 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
     - os: linux
+      dist: trusty
+      jdk: openjdk8
+    - os: linux
       dist: precise
       jdk: oraclejdk8
+    - os: linux
+      dist: precise
+      jdk: openjdk8
     - os: linux
       dist: trusty
       jdk: openjdk7
     - os: linux
       dist: precise
       jdk: openjdk7
+      before_install:
+        # Fix buffer overflow in getLocalHostName of OpenJDK 7 by shortening the host name
+        - cat /etc/hosts
+        - sudo hostname "$(hostname | cut -c1-63)"
+        - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts > /tmp/hosts
+        - sudo mv /tmp/hosts /etc/hosts
+        - cat /etc/hosts
     - os: linux
       dist: precise
       jdk: oraclejdk7
     - os: osx
-      osx_image: xcode8.3 # OS X 10.12
+      osx_image: xcode9.1 # OS X 10.12
     - os: osx
       osx_image: xcode7.3 # OS X 10.11
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
       dist: precise
       jdk: oraclejdk8
     - os: linux
-      dist: precise
-      jdk: openjdk8
-    - os: linux
       dist: trusty
       jdk: openjdk7
     - os: linux


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

add a fix for buffer overflow on precise open jdk 7.
update MacOS test image.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
