### PR TITLE
UP-4927:  Rename of region 'pre-header' --> 'eyebrow' for uP5

### DIFF
--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IDataUpgrader.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IDataUpgrader.java
@@ -23,8 +23,9 @@ import javax.xml.transform.Source;
  * upgraders may be run in succession to translate very old data into the most recent format.
  */
 public interface IDataUpgrader {
+
     /** @return The {@link PortalDataKey}s this upgrader can operate on */
-    public Set<PortalDataKey> getSourceDataTypes();
+    Set<PortalDataKey> getSourceDataTypes();
 
     /**
      * Upgrade the external XML data format to a newer format
@@ -32,5 +33,5 @@ public interface IDataUpgrader {
      * @return true if the caller should handle the importing of the result, false if this class
      *     handled it internally.
      */
-    public boolean upgradeData(Source source, Result result);
+    boolean upgradeData(Source source, Result result);
 }

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -100,15 +100,15 @@
         </xsl:if>
     </xsl:template>
 
-    <!-- ========== TEMPLATE: PRE-HEADER ========== -->
+    <!-- ========== TEMPLATE: EYEBROW ========== -->
     <!-- ========================================== -->
     <!--
      | This template renders portlets in the top-right greeting area.
     -->
-    <xsl:template name="region.pre-header">
-        <xsl:if test="//region[@name='pre-header']/channel">
-            <div id="region-pre-header" class="portal-user">
-                <xsl:for-each select="//region[@name='pre-header']/channel">
+    <xsl:template name="region.eyebrow">
+        <xsl:if test="//region[@name='eyebrow']/channel">
+            <div id="region-eyebrow" class="portal-user">
+                <xsl:for-each select="//region[@name='eyebrow']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />
                 </xsl:for-each>
             </div>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -734,7 +734,7 @@
                                    </div>
                                 </div>
                             </a>
-                            <xsl:call-template name="region.pre-header" />
+                            <xsl:call-template name="region.eyebrow" />
                         </div>
                     </div>
                     <xsl:call-template name="region.header-top" />

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -82,7 +82,7 @@
 }
 
 .portal-global {
-    /* TODO:  Convert the div.portal-global to be the div.region-pre-header
+    /* TODO:  Convert the div.portal-global to be the div.region-eyebrow
        (in the XSL) and move these styles to regions.less */
     padding: 6px 2px 2px 2px;
     .gradient(@portal-global-background-color, @portal-global-background-gradient);

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
@@ -58,7 +58,7 @@
     }
 
     /* ==========================================================================
-       Namespace: .region-pre-header
+       Namespace: .region-eyebrow
        ========================================================================== */
     #up-sticky-nav {
         -webkit-transition: all .25s ease-out;
@@ -70,7 +70,7 @@
         z-index: 1000;
         width: 100%;
 
-        #region-pre-header {
+        #region-eyebrow {
             padding: 2px 0;
 
             .up-portlet-wrapper {
@@ -81,7 +81,7 @@
     }
 
     /* =================================================================================================================
-       Namespace: .region-pre-header #up-sticky-nav : Animated Hamburger Toggle button for mobile offcanvas navigation
+       Namespace: .region-eyebrow #up-sticky-nav : Animated Hamburger Toggle button for mobile offcanvas navigation
        ================================================================================================================= */
 
     .hamburger {


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4927

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

`Eyebrow` is simply a cleaner/clearer/better name than `Pre Header`.  A new major version is the best time to make this change.

Some details about it...

  - Layouts exported from uP4 would need to be adjusted (if they include content for the `pre-header` region);  but many/most will not migrate fragment layouts
  - Those who are already on the path with uP5 will need to adjust their data
  - These changes are few in number (3 items in quickstart)
  - This info will be in the "Upgrade Notes" section of the release notes

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
