### PR TITLE
UP-4953:  Shift CSRF Prevention to baked-in capabilities of Spring Se…

### DIFF
--- a/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
+++ b/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
@@ -17,10 +17,8 @@ package org.apereo.portal.security.csrf;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
@@ -30,17 +28,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * Concrete implementation of Spring's <code>RequestMatcher</code> that tells Spring Security which
- * requests (URLs) to protect with CSRF tokens.  Nearly all URLs are protected.  The exceptions are
+ * requests (URLs) to protect with CSRF tokens. Nearly all URLs are protected. The exceptions are
  * uPortal's REST APIs (which are secured by other means and should be available to non-portal
  * clients) and a few odds-and-ends like /Login.
  */
 @Component("portalCsrfSecurityRequestMatcher")
 public class PortalCsrfSecurityRequestMatcher implements RequestMatcher {
 
-    private static final String[] IGNORED_METHODS = new String[] {
-        HttpMethod.GET.toString(),
-        HttpMethod.HEAD.toString()
-    };
+    private static final String[] IGNORED_METHODS =
+            new String[] {HttpMethod.GET.toString(), HttpMethod.HEAD.toString()};
 
     private static final String LOGIN_PATTERN = "/Login.*";
 
@@ -48,11 +44,8 @@ public class PortalCsrfSecurityRequestMatcher implements RequestMatcher {
 
     private static final String API_PATTERN = "/api.*";
 
-    private static final String[] IGNORED_PATTERNS = new String[] {
-        LOGIN_PATTERN,
-        LOGOUT_PATTERN,
-        API_PATTERN
-    };
+    private static final String[] IGNORED_PATTERNS =
+            new String[] {LOGIN_PATTERN, LOGOUT_PATTERN, API_PATTERN};
 
     private final Set<RequestMatcher> ignoredMatchers = new HashSet<>();
 
@@ -61,29 +54,34 @@ public class PortalCsrfSecurityRequestMatcher implements RequestMatcher {
     @PostConstruct
     public void init() {
         Arrays.stream(IGNORED_PATTERNS)
-            .forEach(pattern -> ignoredMatchers.add(new RegexRequestMatcher(pattern, null)));
-        logger.info("CSRF token protection ignoring the following methods: {}", Arrays.asList(IGNORED_METHODS));
-        logger.info("CSRF token protection ignoring the following patterns: {}", Arrays.asList(IGNORED_PATTERNS));
+                .forEach(pattern -> ignoredMatchers.add(new RegexRequestMatcher(pattern, null)));
+        logger.info(
+                "CSRF token protection ignoring the following methods: {}",
+                Arrays.asList(IGNORED_METHODS));
+        logger.info(
+                "CSRF token protection ignoring the following patterns: {}",
+                Arrays.asList(IGNORED_PATTERNS));
     }
 
     @Override
     public boolean matches(HttpServletRequest request) {
 
         // Check the method
-        boolean rslt = Arrays.stream(IGNORED_METHODS)
-            .noneMatch(s -> s.equalsIgnoreCase(request.getMethod()));
+        boolean rslt =
+                Arrays.stream(IGNORED_METHODS)
+                        .noneMatch(s -> s.equalsIgnoreCase(request.getMethod()));
 
         // Check URI
         if (rslt) {
-            rslt = ignoredMatchers.stream()
-                .noneMatch(matcher -> matcher.matches(request));
+            rslt = ignoredMatchers.stream().noneMatch(matcher -> matcher.matches(request));
         }
 
-        logger.trace("Spring CSRF protection for method='{}', URI='{}' is {}",
-            request.getMethod(), request.getRequestURI(), rslt ? "ENABLED" : "DISABLED");
+        logger.trace(
+                "Spring CSRF protection for method='{}', URI='{}' is {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                rslt ? "ENABLED" : "DISABLED");
 
         return rslt;
-
     }
-
 }

--- a/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
+++ b/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.security.csrf;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Concrete implementation of Spring's <code>RequestMatcher</code> that tells Spring Security which
+ * requests (URLs) to protect with CSRF tokens.  Nearly all URLs are protected.  The exceptions are
+ * uPortal's REST APIs (which are secured by other means and should be available to non-portal
+ * clients) and a few odds-and-ends like /Login.
+ */
+@Component("portalCsrfSecurityRequestMatcher")
+public class PortalCsrfSecurityRequestMatcher implements RequestMatcher {
+
+    private static final String[] IGNORED_METHODS = new String[] {
+        HttpMethod.GET.toString(),
+        HttpMethod.HEAD.toString()
+    };
+
+    private static final String LOGIN_PATTERN = "/Login.*";
+
+    private static final String LOGOUT_PATTERN = "/Logout.*";
+
+    private static final String API_PATTERN = "/api.*";
+
+    private static final String[] IGNORED_PATTERNS = new String[] {
+        LOGIN_PATTERN,
+        LOGOUT_PATTERN,
+        API_PATTERN
+    };
+
+    private final Set<RequestMatcher> ignoredMatchers = new HashSet<>();
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostConstruct
+    public void init() {
+        Arrays.stream(IGNORED_PATTERNS)
+            .forEach(pattern -> ignoredMatchers.add(new RegexRequestMatcher(pattern, null)));
+        logger.info("CSRF token protection ignoring the following methods: {}", Arrays.asList(IGNORED_METHODS));
+        logger.info("CSRF token protection ignoring the following patterns: {}", Arrays.asList(IGNORED_PATTERNS));
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+
+        // Check the method
+        boolean rslt = Arrays.stream(IGNORED_METHODS)
+            .noneMatch(s -> s.equalsIgnoreCase(request.getMethod()));
+
+        // Check URI
+        if (rslt) {
+            rslt = ignoredMatchers.stream()
+                .noneMatch(matcher -> matcher.matches(request));
+        }
+
+        logger.trace("Spring CSRF protection for method='{}', URI='{}' is {}",
+            request.getMethod(), request.getRequestURI(), rslt ? "ENABLED" : "DISABLED");
+
+        return rslt;
+
+    }
+
+}

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IPortalUrlBuilder.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IPortalUrlBuilder.java
@@ -19,22 +19,21 @@ import org.apereo.portal.portlet.om.IPortletWindowId;
 
 /** Builds a portal URL */
 public interface IPortalUrlBuilder extends IUrlBuilder {
+
     /**
      * @return The layout folder this URL targets, if null {@link #getTargetPortletWindowId()} will
      *     not be null.
      */
-    public String getTargetFolderId();
+    String getTargetFolderId();
 
     /**
      * @return The portlet window ID this URL targets, if null {@link #getTargetFolderId()} will not
      *     be null.
      */
-    public IPortletWindowId getTargetPortletWindowId();
+    IPortletWindowId getTargetPortletWindowId();
 
     /** @return The type of URL that will be generated, will never return null. */
-    public UrlType getUrlType();
-
-    //get/set secure
+    UrlType getUrlType();
 
     /**
      * Get the {@link IPortletUrlBuilder} for the specified {@link IPortletWindowId}. Multiple calls
@@ -43,7 +42,7 @@ public interface IPortalUrlBuilder extends IUrlBuilder {
      * @param portletWindowId The id of the portlet window to get the url builder for, not null.
      * @return The url builder for the portlet window, not null.
      */
-    public IPortletUrlBuilder getPortletUrlBuilder(IPortletWindowId portletWindowId);
+    IPortletUrlBuilder getPortletUrlBuilder(IPortletWindowId portletWindowId);
 
     /**
      * If {@link #getTargetPortletWindowId()} does not return null this will return the {@link
@@ -51,17 +50,17 @@ public interface IPortalUrlBuilder extends IUrlBuilder {
      *
      * @throws IllegalStateException if {@link #getTargetPortletWindowId()} returns null
      */
-    public IPortletUrlBuilder getTargetedPortletUrlBuilder();
+    IPortletUrlBuilder getTargetedPortletUrlBuilder();
 
     /**
      * @return All of the portlet url builders that have been created for this portal url.
      *     Unmodifiable Map
      */
-    public Map<IPortletWindowId, IPortletUrlBuilder> getPortletUrlBuilders();
+    Map<IPortletWindowId, IPortletUrlBuilder> getPortletUrlBuilders();
 
     /**
      * @return Generate a URL to be used in markup or as a redirect. The URL will be absolute,
      *     starting with a / or with a protocol such as http://
      */
-    public String getUrlString();
+    String getUrlString();
 }

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IPortletUrlBuilder.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IPortletUrlBuilder.java
@@ -23,63 +23,64 @@ import org.apereo.portal.portlet.om.IPortletWindowId;
 
 /** Builds a URL for a specific portlet. */
 public interface IPortletUrlBuilder extends IUrlBuilder {
+
     /** @return The portlet window this url builder is for */
-    public IPortletWindowId getPortletWindowId();
+    IPortletWindowId getPortletWindowId();
 
     /** @return The parent {@link IPortalUrlBuilder} of this {@link IPortletUrlBuilder} */
-    public IPortalUrlBuilder getPortalUrlBuilder();
+    IPortalUrlBuilder getPortalUrlBuilder();
 
     /**
      * @see PortletURL#setWindowState(WindowState)
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} returns {@link
      *     UrlType#RESOURCE}
      */
-    public void setWindowState(WindowState windowState);
+    void setWindowState(WindowState windowState);
     /**
      * @see PortletURL#getWindowState()
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} returns {@link
      *     UrlType#RESOURCE}
      */
-    public WindowState getWindowState();
+    WindowState getWindowState();
 
     /**
      * @see PortletURL#setPortletMode(PortletMode)
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} returns {@link
      *     UrlType#RESOURCE}
      */
-    public void setPortletMode(PortletMode portletMode);
+    void setPortletMode(PortletMode portletMode);
     /**
      * @see PortletURL#getPortletMode()
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} returns {@link
      *     UrlType#RESOURCE}
      */
-    public PortletMode getPortletMode();
+    PortletMode getPortletMode();
 
     /**
      * @see ResourceURL#setResourceID(String)
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} does not
      *     return {@link UrlType#RESOURCE}
      */
-    public void setResourceId(String resourceId);
+    void setResourceId(String resourceId);
     /**
      * @see ResourceURL#setResourceID(String)
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} does not
      *     return {@link UrlType#RESOURCE}
      */
-    public String getResourceId();
+    String getResourceId();
 
     /**
      * @see ResourceURL#setCacheability(String)
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} does not
      *     return {@link UrlType#RESOURCE}
      */
-    public void setCacheability(String cacheability);
+    void setCacheability(String cacheability);
     /**
      * @see ResourceURL#getCacheability()
      * @throws IllegalStateException If parent {@link IPortalUrlBuilder#getUrlType()} does not
      *     return {@link UrlType#RESOURCE}
      */
-    public String getCacheability();
+    String getCacheability();
 
     /**
      * Get the public render parameters set by this portlet. The Map is mutable and making changes
@@ -87,14 +88,14 @@ public interface IPortletUrlBuilder extends IUrlBuilder {
      *
      * @return Map containing currently set parameters.
      */
-    public Map<String, String[]> getPublicRenderParameters();
+    Map<String, String[]> getPublicRenderParameters();
 
     /**
      * @param copyCurrentRenderParameters If set to true all current private render parameters are
      *     copied to the URL
      */
-    public void setCopyCurrentRenderParameters(boolean copyCurrentRenderParameters);
+    void setCopyCurrentRenderParameters(boolean copyCurrentRenderParameters);
 
     /** @return If the current private render parameters should be copied to the generared URL */
-    public boolean getCopyCurrentRenderParameters();
+    boolean getCopyCurrentRenderParameters();
 }

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IUrlBuilder.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IUrlBuilder.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 /** Base class to define common methods for URL builders */
 public interface IUrlBuilder {
+
     /**
      * Sets a URL parameter
      *
@@ -27,9 +28,10 @@ public interface IUrlBuilder {
      * @param name The parameter name
      * @param values The value or values for the parameter
      */
-    public void setParameter(String name, String... values);
+    void setParameter(String name, String... values);
+
     /** @see #setParameter(String, String...) */
-    public void setParameter(String name, List<String> values);
+    void setParameter(String name, List<String> values);
 
     /**
      * Adds a URL parameter
@@ -40,7 +42,7 @@ public interface IUrlBuilder {
      * @param name The parameter name
      * @param values The value or values for the parameter
      */
-    public void addParameter(String name, String... values);
+    void addParameter(String name, String... values);
 
     /**
      * Sets a parameter map for this URL.
@@ -49,7 +51,7 @@ public interface IUrlBuilder {
      *
      * @param parameters Map containing parameters
      */
-    public void setParameters(Map<String, List<String>> parameters);
+    void setParameters(Map<String, List<String>> parameters);
 
     /**
      * Get the current parameters. The Map is mutable and making changes to the Map will affect the
@@ -57,5 +59,5 @@ public interface IUrlBuilder {
      *
      * @return Map containing currently set parameters.
      */
-    public Map<String, String[]> getParameters();
+    Map<String, String[]> getParameters();
 }

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IUrlSyntaxProvider.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IUrlSyntaxProvider.java
@@ -52,8 +52,7 @@ public interface IUrlSyntaxProvider {
      * @return A URL to be used in markup or as a redirect. The URL will be absolute, starting with
      *     a / or with a protocol such as http://
      */
-    String generateUrl(
-            HttpServletRequest request, IPortalActionUrlBuilder portalActionUrlBuilder);
+    String generateUrl(HttpServletRequest request, IPortalActionUrlBuilder portalActionUrlBuilder);
 
     /**
      * Attempts to answer whether the two URLs <strong>definitely refer to different</strong>

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IUrlSyntaxProvider.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IUrlSyntaxProvider.java
@@ -21,13 +21,14 @@ import javax.servlet.http.HttpServletRequest;
  * IPortalRequestInfo}
  */
 public interface IUrlSyntaxProvider {
+
     /**
      * Get the portal request information for the specified request.
      *
      * @param request The current portal request
      * @return Information about the current request
      */
-    public IPortalRequestInfo getPortalRequestInfo(HttpServletRequest request);
+    IPortalRequestInfo getPortalRequestInfo(HttpServletRequest request);
 
     /**
      * Get the canonical url for this portal request.
@@ -35,7 +36,7 @@ public interface IUrlSyntaxProvider {
      * @param request The current portal request
      * @return The canonical URL for the request
      */
-    public String getCanonicalUrl(HttpServletRequest request);
+    String getCanonicalUrl(HttpServletRequest request);
 
     /**
      * @param request The current request
@@ -43,7 +44,7 @@ public interface IUrlSyntaxProvider {
      * @return A URL to be used in markup or as a redirect. The URL will be absolute, starting with
      *     a / or with a protocol such as http://
      */
-    public String generateUrl(HttpServletRequest request, IPortalUrlBuilder portalUrlBuilder);
+    String generateUrl(HttpServletRequest request, IPortalUrlBuilder portalUrlBuilder);
 
     /**
      * @param request The current request
@@ -51,7 +52,7 @@ public interface IUrlSyntaxProvider {
      * @return A URL to be used in markup or as a redirect. The URL will be absolute, starting with
      *     a / or with a protocol such as http://
      */
-    public String generateUrl(
+    String generateUrl(
             HttpServletRequest request, IPortalActionUrlBuilder portalActionUrlBuilder);
 
     /**
@@ -61,6 +62,6 @@ public interface IUrlSyntaxProvider {
      *
      * @return TRUE if the two URLs certainly refer to different content; otherwise FALSE
      */
-    public boolean doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+    boolean doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
             String requestPath, String canonicalPath);
 }

--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -33,8 +33,8 @@
         <security:custom-filter position="PRE_AUTH_FILTER" ref="portalPreAuthenticationFilter" />
         <security:intercept-url pattern="**" />
         <security:session-management session-authentication-strategy-ref="sessionAuthenticationStrategy" />
-        <!-- Spring Security's baked-in CSRF solution would be a challenge to integrate with portlets -->
-        <security:csrf disabled="true" />
+        <!-- Apply Spring Security's baked-in CSRF solution to most non-GET, non-HEAD requests -->
+        <security:csrf request-matcher-ref="portalCsrfSecurityRequestMatcher"/>
     </security:http>
 
     <bean id="sessionAuthenticationStrategy" class="org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy" />

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/attribute-swapper/attributesForm.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/attribute-swapper/attributesForm.jsp
@@ -42,11 +42,11 @@
             </ul>
         </div>
     </div>
-	
+
     <!-- Portlet Content -->
 	<div class="fl-widget-content content portlet-content" role="main">
-		
-        <form:form modelAttribute="attributeSwapRequest" action="${attributeSwapUrl}">
+
+        <form:form modelAttribute="attributeSwapRequest" action="${attributeSwapUrl}" method="POST">
             <table class="portlet-table table table-hover">
                 <thead>
                     <tr>
@@ -87,11 +87,11 @@
                     </c:forEach>
                 </tbody>
             </table>
-                
+
             <div class="buttons">
                 <spring:message var="updateAttributesText" code="update.attributes" />
                 <input type="submit" class="button btn primary" name="_eventId_updateAttributes" value="${updateAttributesText}" />
-                
+
                 <spring:message var="resetAttributesText" code="reset.attributes" />
                 <input type="submit" class="button btn" name="_eventId_resetAttributes" value="${resetAttributesText}" />
             </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/confirmRemove.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/confirmRemove.jsp
@@ -19,22 +19,22 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:renderURL var="formUrl">
+<portlet:actionURL var="formUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
-</portlet:renderURL>
+</portlet:actionURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
 <div class="fl-widget portlet grp-mgr view-confirmremove" role="section">
-    
+
     <!-- Portlet Title -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="delete.group"/></h2>
     </div> <!-- end: portlet-title -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
-        
+
     <form action="${formUrl}" method="POST">
 
         <!-- Portlet Section -->
@@ -46,14 +46,14 @@
             <spring:message code="delete.group.confirmation" arguments="${ group.name }"/>
           </div>
         </div> <!-- end: portlet-section -->
-        
+
         <!-- Portlet Buttons -->
         <div class="buttons">
           <input class="button btn primary" type="submit" value="<spring:message code="remove"/>" name="_eventId_removeGroup"/>
           <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
         </div>
-        
+
         </form> <!-- End Form -->
-        
+
     </div>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/editDetails.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/editDetails.jsp
@@ -19,32 +19,32 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:renderURL var="formUrl">
+<portlet:actionURL var="formUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
-</portlet:renderURL>
+</portlet:actionURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
 <div class="fl-widget portlet grp-mgr view-editdetails" role="section">
-    
+
     <!-- Portlet Title -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="edit.group.details"/></h2>
     </div> <!-- end: portlet-title -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" role="main">
         <form:form action="${ formUrl }" method="POST" modelAttribute="group">
-        
+
             <!-- Portlet Messages -->
             <spring:hasBindErrors name="group">
                 <div class="portlet-msg-error portlet-msg error" role="alert">
                     <form:errors path="*" element="div"/>
                 </div> <!-- end: portlet-msg -->
             </spring:hasBindErrors>
-            
+
             <div class="portlet-form">
-            
+
                 <table class="table table-hover purpose-layout" summary="<spring:message code="basicInfo.generalSettingsTableSummary"/>">
                     <thead>
                         <tr>
@@ -56,11 +56,11 @@
                         <tr>
                             <td class="label"><label for="name"><spring:message code="name"/>:</label></td>
                             <td><form:input path="name"/></td>
-                        </tr>  
+                        </tr>
                         <tr>
                             <td class="label"><label for="description"><spring:message code="description"/>:</label></td>
                             <td><form:input path="description"/></td>
-                        </tr>  
+                        </tr>
                     </tbody>
                 </table>
                 <div class="buttons">

--- a/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -23,6 +23,13 @@
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
  version="2.0">
+
+    <!-- Added to address issues with double-encoding.  (Many URLs were getting encoded twice, which would break them.) -->
+    <container-runtime-option>
+        <name>javax.portlet.escapeXml</name>
+        <value>false</value>
+    </container-runtime-option>
+
     <portlet>
         <portlet-name>AttributeSwapperPortlet</portlet-name>
         <display-name xml:lang="en">Attribute Swapper Portlet</display-name>


### PR DESCRIPTION
…curity

https://issues.jasig.org/browse/UP-4953

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

We recently updated Spring to version 4, as well as the version of Spring Security to match.  The new version of Spring Security enables token-based CSRF protection by default.

We can shift our efforts in this direction and take advantage of this feature for most portal URLs.  (Not the REST APIs, and a few ods-and-ends.) 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
