### PR TITLE
UP-4957:  The default value of cors.allowed.origins should probably b…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -102,7 +102,7 @@
      | Security-related filters
      +-->
     <bean id="corsFilter" class="org.apereo.portal.security.filter.CorsFilter">
-        <property name="allowedOrigins" value="${cors.allowed.origins:*}" />
+        <property name="allowedOrigins" value="${cors.allowed.origins:}" />
         <property name="allowedHttpMethods" value="${cors.allowed.methods:GET,HEAD}" />
         <property name="allowedHttpHeaders" value="${cors.allowed.headers:Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers}" />
         <property name="exposedHeaders" value="${cors.exposed.headers:}" />


### PR DESCRIPTION
…e blank, meaning no other origins may access uPortal resources with JS;  if you want to enable it, it's simple enough to specify the origin(s) from which you want to access it

https://issues.jasig.org/browse/UP-4957

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

@bjagg 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
