### PR TITLE
UP-4961:  Changed org.jasig class to org.apereo, and fixed versioning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.0.1
+version=5.0.1-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/UserLayoutHelperImpl.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/UserLayoutHelperImpl.java
@@ -87,7 +87,7 @@ public class UserLayoutHelperImpl extends JdbcDaoSupport implements IUserLayoutH
     /**
      * @param personAttributes
      * @see
-     *     org.apereo.portal.layout.IUserLayoutHelper#resetUserLayout(org.jasig.services.persondir.IPersonAttributes)
+     *     org.apereo.portal.layout.IUserLayoutHelper#resetUserLayout(org.apereo.services.persondir.IPersonAttributes)
      */
     @Override
     public void resetUserLayout(final IPersonAttributes personAttributes) {

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-user-layout.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-user-layout.xml
@@ -23,8 +23,8 @@
     xsi:schemaLocation="http://www.springframework.org/schema/webflow
                           http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
 
-    <input name="person" type="org.jasig.services.persondir.IPersonAttributes" required="true" />
-    
+    <input name="person" type="org.apereo.services.persondir.IPersonAttributes" required="true" />
+
     <view-state id="reset-confirm">
         <transition on="confirm" to="reset-result">
             <!-- Choose resetUserLayoutAllProfiles if on layout reset, you need
@@ -33,10 +33,10 @@
         </transition>
         <transition on="cancel" to="reset-complete"/>
     </view-state>
-    
+
     <view-state id="reset-result">
-        <transition on="continue" to="reset-complete" />        
+        <transition on="continue" to="reset-complete" />
     </view-state>
-    
+
     <end-state id="reset-complete"/>
 </flow>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included
-   [x] documentation is changed or added
-   [x] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
Resolves issue https://issues.jasig.org/browse/UP-4961 by switching the org.jasig class reference to org.apereo.

Also added a change so a local build of uPortal is built as 5.0.1-SNAPSHOT.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
