### PR TITLE
docs: correct reference to bootstrap in docs comment

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/javascript/uportal/fluid-jquery-compatibility.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/javascript/uportal/fluid-jquery-compatibility.js
@@ -20,19 +20,19 @@
 
 /*
  * The role of this library is to support the continued use of Fluid Infusion 1.4
- * in Respondr for as long as we need it (with any luck, not long).  Boostrap 3
+ * in Respondr for as long as we need it (with any luck, not long).  Bootstrap 3
  * requires jQuery 1.9.x or higher;  but Fluid 1.4 (still the most recent)
  * supports only 1.6.x.  uPortal has a lot of interfaces written with Fluid.
  * The short-term strategy will be to deal with this issue as follows:
- * 
+ *
  *   - Load jQuery 1.6.x (compatible with Fluid 1.4)
  *   - Load jQueryUI 1.8.x (compatible with Fluid 1.4)
  *   - Load Fluid 1.4
  *   - Remove jQuery 1.6.x from the global namespace (this file)
  *   - Load jQuery 1.10.x (compatible with Bootstrap 3)
- * 
+ *
  * This approach means that we will be loading two copies of the jQuery library
- * in the theme alone (before we even consider portlets).  These steps MUST BE 
+ * in the theme alone (before we even consider portlets).  These steps MUST BE
  * PERFORMED IN THIS ORDER.
  */
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

:memo: corrected `boostrap` -> `bootstrap`

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
