### PR TITLE
UP-4970: Add aria-label attribute to the web search submit button

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
@@ -37,9 +37,10 @@
           <div class="input-group">
             <spring:message code="search" var="searchPlaceholder" />
             <spring:message code="search.terms" var="searchTitle" />
+            <spring:message code="submit" var="searchSubmit" />
             <input id="${n}webSearchInput" class="searchInput input-large search-query form-control" value="" name="query" type="search" placeholder="${searchPlaceholder}" title="${searchTitle}"/>
             <span class="input-group-btn">
-              <button id="webSearchSubmit" type="submit" name="submit" class="btn btn-default" value="${searchLabel}">
+              <button id="webSearchSubmit" type="submit" name="submit" aria-label="${searchSubmit}" class="btn btn-default" value="${searchLabel}">
                 <span>${searchLabel}</span>
                 <i class="fa fa-search" aria-hidden="true"></i>
               </button>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] [message properties][] have been updated with new phrases (existing property used)
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Add an aria-label attribute to webSearchSubmit button.

According to WCAG 2.0 guidelines, buttons must have discernible text that clearly describes the destination, purpose, function, or action for screen reader users.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
