### PR TITLE
UP-4973:  Enhance (and simplify) the columns.xsl structure transform …

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/structure/columns/columns.xsl
+++ b/uPortal-webapp/src/main/resources/layout/structure/columns/columns.xsl
@@ -85,7 +85,7 @@
         </xsl:choose>
     </xsl:variable>
 
-    <!-- ROOT template.  Chooses between templates that produce <layout_fragment> 
+    <!-- ROOT template.  Chooses between templates that produce <layout_fragment>
          (in DETACHED window state) and simply <layout> (in the general case). -->
     <xsl:template match="layout">
         <xsl:choose>
@@ -98,7 +98,7 @@
         </xsl:choose>
     </xsl:template>
 
-    <!-- NORMAL page template.  Governs the overall structure when the page is 
+    <!-- NORMAL page template.  Governs the overall structure when the page is
          non-detached. -->
     <xsl:template match="folder[@type='root']" mode="NORMAL">
         <layout>
@@ -209,7 +209,7 @@
         </layout>
     </xsl:template>
 
-    <!-- DETACHED page template.  Governs the overall structure when the page is 
+    <!-- DETACHED page template.  Governs the overall structure when the page is
          rendering a portlet in detached window state. -->
     <xsl:template match="folder[@type='root']" mode="DETACHED">
         <layout_fragment>
@@ -229,7 +229,7 @@
                 <!-- For detached mode, include regions hidden-top, page-top, page-bottom, and hidden-bottom. -->
                 <xsl:for-each select="child::folder[@type='hidden-top' or @type='page-top' or @type='page-bottom' or @type='hidden-bottom']">
                     <xsl:call-template name="region"/>
-                </xsl:for-each> 
+                </xsl:for-each>
             </regions>
             <content>
                 <xsl:attribute name="hasFavorites"><xsl:value-of select="$hasFavorites" /></xsl:attribute>
@@ -308,32 +308,10 @@
 
     <xsl:template name="column">
         <column>
-            <xsl:attribute name="ID">
-                <xsl:value-of select="@ID"/>
-            </xsl:attribute>
-            <xsl:attribute name="priority">
-                <xsl:value-of select="@priority"/>
-            </xsl:attribute>
-            <xsl:attribute name="width">
-                <xsl:value-of select="@width"/>
-            </xsl:attribute>
-            <xsl:if test="@dlm:moveAllowed = 'false'">
-                <xsl:attribute name="dlm:moveAllowed">false</xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@dlm:deleteAllowed = 'false'">
-                <xsl:attribute name="dlm:deleteAllowed">false</xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@dlm:editAllowed = 'false'">
-                <xsl:attribute name="dlm:editAllowed">false</xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@dlm:addChildAllowed = 'false'">
-                <xsl:attribute name="dlm:addChildAllowed">false</xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@dlm:precedence > 0">
-                <xsl:attribute name="dlm:precedence">
-                    <xsl:value-of select="@dlm:precedence"/>
-                </xsl:attribute>
-            </xsl:if>
+            <!-- Copy folder attributes verbatim -->
+            <xsl:for-each select="attribute::*">
+                <xsl:attribute name="{name()}"><xsl:value-of select="."/></xsl:attribute>
+            </xsl:for-each>
             <xsl:apply-templates/>
         </column>
     </xsl:template>


### PR DESCRIPTION
…to make attributes on columns a 'pass through' (like attributes on tabs)

https://issues.jasig.org/browse/UP-4973

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

The columns.xsl structure transform processes <folder> elements that represent both tab nodes and column nodes.  For some reason, attributes on tab nodes are a 'pass through' -- whatever comes in goes out -- but attributes on columns are not:  the transform copies only a hard-coded set of attributes.

This arrangement is silly.  We can make the transform (1) simpler and (2) more flexible/powerful by making column attributes a 'pass through' as well.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
