### PR TITLE
UP-4978: Apply xmlns attribute globally to stylesheet

### DIFF
--- a/uPortal-webapp/src/main/resources/org/apereo/portal/io/xml/portlet/upgradePortlet_43.xsl
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/io/xml/portlet/upgradePortlet_43.xsl
@@ -21,7 +21,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns:portlet="https://source.jasig.org/schemas/uportal/io/portlet-definition"
+                xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition"
                 xmlns:ns2="https://source.jasig.org/schemas/uportal">
 
     <xsl:output indent="yes"/>


### PR DESCRIPTION
This change prevents import errors and test failures caused by empty xmlns attributes appearing when a portlet definition is transformed by the data upgrade process.

https://issues.jasig.org/browse/UP-4978

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x ] the [individual contributor license agreement][] is signed
-   [x ] commit message follows [commit guidelines][]

##### Description of change
In some circumstances when a portlet definition is passed through the automatic upgrade process, the lifecycle element in the resulting portlet definition has an empty xmlns attribute. This can cause:

- a test failure in testUpgradeTestPortlet43to50, as described on the issue tracker for UP-4978; 
- failures on the dataInit task in uPortal-start if local data includes portlet definitions that contain a lifecycle element.

From investigation, it looks as though the issue happens on the transform of the portlet definition in org.apereo.portal.io.xml.XsltDataUpgrader.java, similar to the problem described here: https://stackoverflow.com/questions/3504672/xslt-blank-xmlns-after-transform. 

I have tracked the cause down to the appearance of a literal element <lifecycle> in the file uPortal-webapp/src/main/resources/org/apereo/portal/io/xml/portlet/upgradePortlet_43.xsl.  I've implemented one of the suggestions from stack overflow - applying the xmlns attribute at stylesheet level. There is more than one way of fixing the problem, but this seemed like the simplest given the limited context in which it arises.

After applying the change locally:

- I no longer see the test failure in testUpgradeTestPortlet43to50; 
- I can successfully run dataInit within uPortal-start using my local uPortal UP-4978 branch without error.

This is my first pull request for uPortal. I have completed an ICLA but I'm not sure if there is (or needs to be) a CCLA for my organisation - The University of Edinburgh.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
