### PR TITLE
UP-4966 Implement lifecycle state BROWSE permissions

### DIFF
--- a/uPortal-core/src/main/java/org/apereo/portal/security/IPermission.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/security/IPermission.java
@@ -52,22 +52,26 @@ public interface IPermission {
 
     /**
      * Allows the user to browse for a portlet that is in the <code>CREATED</code> lifecycle state.
+     *
      * @since 5.0
      */
     String PORTLET_BROWSE_CREATED_ACTIVITY = "BROWSE_CREATED";
     /**
      * Allows the user to browse for a portlet that is in the <code>APPROVED</code> lifecycle state.
+     *
      * @since 5.0
      */
     String PORTLET_BROWSE_APPROVED_ACTIVITY = "BROWSE_APPROVED";
     /**
-     * The standard <code>BROWSE</code> activity. Allows the user to browse marketplace
-     * entries and search for a portlet in the <code>PUBLISHED</code> lifecycle state.
+     * The standard <code>BROWSE</code> activity. Allows the user to browse marketplace entries and
+     * search for a portlet in the <code>PUBLISHED</code> lifecycle state.
+     *
      * @since 4.1
      */
     String PORTLET_BROWSE_ACTIVITY = "BROWSE";
     /**
      * Allows the user to browse for a portlet that is in the <code>EXPIRED</code> lifecycle state.
+     *
      * @since 5.0
      */
     String PORTLET_BROWSE_EXPIRED_ACTIVITY = "BROWSE_EXPIRED";

--- a/uPortal-core/src/main/java/org/apereo/portal/security/IPermission.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/security/IPermission.java
@@ -45,12 +45,32 @@ public interface IPermission {
      */
     String PORTLET_SUBSCRIBER_EXPIRED_ACTIVITY = "SUBSCRIBE_EXPIRED";
 
+    /*
+     * Portlet browse permissions listed
+     * hierarchically by lifecycle state
+     */
+
     /**
-     * Portlet subscribe permission to view ("browse") marketplace entry.
-     *
+     * Allows the user to browse for a portlet that is in the <code>CREATED</code> lifecycle state.
+     * @since 5.0
+     */
+    String PORTLET_BROWSE_CREATED_ACTIVITY = "BROWSE_CREATED";
+    /**
+     * Allows the user to browse for a portlet that is in the <code>APPROVED</code> lifecycle state.
+     * @since 5.0
+     */
+    String PORTLET_BROWSE_APPROVED_ACTIVITY = "BROWSE_APPROVED";
+    /**
+     * The standard <code>BROWSE</code> activity. Allows the user to browse marketplace
+     * entries and search for a portlet in the <code>PUBLISHED</code> lifecycle state.
      * @since 4.1
      */
     String PORTLET_BROWSE_ACTIVITY = "BROWSE";
+    /**
+     * Allows the user to browse for a portlet that is in the <code>EXPIRED</code> lifecycle state.
+     * @since 5.0
+     */
+    String PORTLET_BROWSE_EXPIRED_ACTIVITY = "BROWSE_EXPIRED";
 
     /**
      * Permission to favorite/star a portlet.

--- a/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/security/provider/AuthorizationImpl.java
+++ b/uPortal-security/uPortal-security-permissions/src/main/java/org/apereo/portal/security/provider/AuthorizationImpl.java
@@ -418,9 +418,10 @@ public class AuthorizationImpl implements IAuthorizationService {
     @RequestCache
     public boolean canPrincipalBrowse(
             IAuthorizationPrincipal principal, IPortletDefinition portlet) {
-
         String owner = IPermission.PORTAL_SUBSCRIBE;
+
         String target = PermissionHelper.permissionTargetIdForPortletDefinition(portlet);
+
         PortletLifecycleState state = portlet.getLifecycleState();
 
         /*
@@ -429,7 +430,7 @@ public class AuthorizationImpl implements IAuthorizationService {
          */
         String permission;
         if (state.equals(PortletLifecycleState.PUBLISHED)
-            || state.equals(PortletLifecycleState.MAINTENANCE)) {
+                || state.equals(PortletLifecycleState.MAINTENANCE)) {
             // NB:  There is no separate BROWSE permission for MAINTENANCE
             // mode;  everyone simply sees the 'out of service' message
             permission = IPermission.PORTLET_BROWSE_ACTIVITY;
@@ -441,7 +442,8 @@ public class AuthorizationImpl implements IAuthorizationService {
             permission = IPermission.PORTLET_BROWSE_EXPIRED_ACTIVITY;
         } else {
             throw new AuthorizationException(
-                "Unrecognized lifecycle state for channel " + portlet.getPortletDefinitionId().getStringId());
+                    "Unrecognized lifecycle state for channel "
+                            + portlet.getPortletDefinitionId().getStringId());
         }
 
         // Test the appropriate permission.

--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/marketplace/MarketplaceService.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/marketplace/MarketplaceService.java
@@ -289,9 +289,7 @@ public class MarketplaceService implements IMarketplaceService, ApplicationListe
                 portletDefinition,
                 "Cannot determine whether a user can browse a null portlet definition.");
 
-        final String portletPermissionEntityId =
-                PermissionHelper.permissionTargetIdForPortletDefinition(portletDefinition);
-        return mayBrowse(principal, portletPermissionEntityId);
+        return authorizationService.canPrincipalBrowse(principal, portletDefinition);
     }
 
     @Override

--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/marketplace/MarketplaceService.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/marketplace/MarketplaceService.java
@@ -37,7 +37,6 @@ import org.apereo.portal.security.IAuthorizationPrincipal;
 import org.apereo.portal.security.IAuthorizationService;
 import org.apereo.portal.security.IPermission;
 import org.apereo.portal.security.IPerson;
-import org.apereo.portal.security.PermissionHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_APPROVED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_APPROVED_portlets-permission-set.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Administrators</group>
+    </principal>
+    <activity>BROWSE_APPROVED</activity>
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_CREATED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_CREATED_portlets-permission-set.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Administrators</group>
+    </principal>
+    <activity>BROWSE_CREATED</activity>
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_EXPIRED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Administrators_BROWSE_EXPIRED_portlets-permission-set.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Administrators</group>
+    </principal>
+    <activity>BROWSE_EXPIRED</activity>
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_APPROVED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_APPROVED_portlets-permission-set.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Fragment Owners</group>
+    </principal>
+    <activity>BROWSE_APPROVED</activity>
+    <!-- NOTE:  Be aware as of uPortal 4.2 adding BROWSE to category groups (category element in the portlet definition
+         files) means the portlets in the category will show up in the Customize drawer, search auto-suggest, search
+         results, and the Marketplace.  -->
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_CREATED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_CREATED_portlets-permission-set.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Fragment Owners</group>
+    </principal>
+    <activity>BROWSE_CREATED</activity>
+    <!-- NOTE:  Be aware as of uPortal 4.2 adding BROWSE to category groups (category element in the portlet definition
+         files) means the portlets in the category will show up in the Customize drawer, search auto-suggest, search
+         results, and the Marketplace.  -->
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_EXPIRED_portlets-permission-set.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/permission_set/Fragment_Owners_BROWSE_EXPIRED_portlets-permission-set.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<permission-set script="classpath://org/jasig/portal/io/import-permission_set_v3-1.crn">
+    <owner>UP_PORTLET_SUBSCRIBE</owner>
+    <principal-type>org.jasig.portal.groups.IEntityGroup</principal-type>
+    <principal>
+        <group>${tenant.name} Fragment Owners</group>
+    </principal>
+    <activity>BROWSE_EXPIRED</activity>
+    <!-- NOTE:  Be aware as of uPortal 4.2 adding BROWSE to category groups (category element in the portlet definition
+         files) means the portlets in the category will show up in the Customize drawer, search auto-suggest, search
+         results, and the Marketplace.  -->
+    <target permission-type="GRANT">
+        <group>${tenant.name} Portlets</group>
+    </target>
+</permission-set>


### PR DESCRIPTION
Replicate the portlet SUBSCRIBE permission model for portlet BROWSE permissions so that expired portlets cannot be browsed by non-admin users in the marketplace or searched for using the portal search.

##### Checklist

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added

##### Description of change

The BROWSE permission which governs access to portlets in search, Customize, and in the Marketplace has been updated to take account of portlet lifecycle state in the same manner as the SUBSCRIBE permission, thereby preventing non-admin users from seeing unpublished portlets. This reflects the normal expectation that setting a portlet to expired means it is no longer visible, overriding other permissions.

Changes are as follows:

- new permissions BROWSE_CREATED, BROWSE_APPROVED and BROWSE_EXPIRED have been added to the UP_PORTLET_SUBSCRIBE permission owner; 
- org.apereo.portal.security.provider.AuthorizationImpl.canPrincipalBrowse (IAuthorizationPrincipal, IPortletDefinition) and org.apereo.portal.portlet.marketplace.MarketplaceService.mayBrowsePortlet() have been modified to take account of lifecycle state when checking BROWSE access for portlets;
-  sample data for the new permissions has been added.

Note that the original UP-4966 issue only mentions restricting browse for expired portlets, but it seemed to make sense to avoid confusion and simply mirror the behaviour for SUBSCRIBE permissions.

After applying these changes locally:

- expired portlets do not appear in the Customize drawer for a non-admin user;
- the portal search box does not show expired portlets in results for a non-admin user;
- the Marketplace portlet does not list expired portlets for a non-admin user;
- the Marketplace portlet search does not return expired portlets in results for a non-admin user.

###### Tests & Documentation

I have left the Checklist items for tests and documentation in place and unchecked above as I'm not sure whether action is required for these.  I couldn't find any tests that ought to be updated - all tests are passing when I run './gradlew test' - and I wasn't sure what new tests might be required or where to add them.  For documentation, again I'm not confident about what will need to be changed.  Any guidance on these two items would be most welcome!

###### Impact on uPortal-start

If the change in this pull request is accepted, a corresponding change in uPortal-start will be required. The file which defines the BROWSE & SUBSCRIBE permissions that control rendering of and subscription to uPortal content, UP_PORTLET_SUBSCRIBE.permission-owner.xml, is no longer part of uPortal.  It now exists in uPortal-start in [data/base/permission_owner][].  This file requires activity element definitions for the Browse Approved (BROWSE_APPROVED), Browse Created (BROWSE_CREATED) and Browse Expired (BROWSE_EXPIRED) permissions, for example:

` 

    <activity>
        <name>Browse Approved</name>
        <fname>BROWSE_APPROVED</fname>
        <desc>Browse uPortal content that is approved, but not yet published</desc>
        <targetProvider>channelsAndCategoriesTargetProvider</targetProvider>
    </activity>
    <activity>
        <name>Browse Created</name>
        <fname>BROWSE_CREATED</fname>
        <desc>Browse to uPortal content that has not yet been approved or published</desc>
        <targetProvider>channelsAndCategoriesTargetProvider</targetProvider>
    </activity>
    <activity>
        <name>Browse Expired</name>
        <fname>BROWSE_EXPIRED</fname>
        <desc>View expired uPortal content in the Marketplace</desc>
        <targetProvider>channelsAndCategoriesTargetProvider</targetProvider>
    </activity>

`

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[data/base/permission_owner]: https://github.com/Jasig/uPortal-start/blob/master/data/base/permission_owner/UP_PORTLET_SUBSCRIBE.permission-owner.xml
