### PR TITLE
UP-4980:  Portlet Manager -- regression where newly selected principa…

### DIFF
--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/portletadmin/PortletAdministrationHelper.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/portletadmin/PortletAdministrationHelper.java
@@ -257,7 +257,7 @@ public final class PortletAdministrationHelper implements ServletContextAware {
                 form.addPermission(principalBean.getTypeAndIdHash() + "_" + perm.getActivity());
             }
         }
-        form.setPrincipals(principalBeans);
+        form.setPrincipals(principalBeans, false);
     }
 
     /*
@@ -279,8 +279,7 @@ public final class PortletAdministrationHelper implements ServletContextAware {
                 GroupService.getDistinguishedGroup(IPerson.DISTINGUISHED_GROUP);
         final JsonEntityBean everyoneBean =
                 new JsonEntityBean(everyoneGroup, groupListHelper.getEntityType(everyoneGroup));
-        form.setPrincipals(Collections.singleton(everyoneBean));
-        form.initPermissionsForPrincipal(everyoneBean);
+        form.setPrincipals(Collections.singleton(everyoneBean), true);
 
         return form;
     }


### PR DESCRIPTION
…ls no longer receive BROWSE & SUBSCRIBE by default

https://issues.jasig.org/browse/UP-4980

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Until recently, whenever you added new principals in the Portlet Manager they would automatically receive both BROWSE & SUBSCRIBE permission by default.  (You could easily toggle one of them off if that wasn't what you intended.)  This behavior worked nicely b/c 99% of the time you intend to grant both BROWSE & SUBSCRIBE when you add a principal.

But recently support for managing CONFIGURE was added to the mix.  This addition broke the very brittle method of calculating whether the principal was new and should (therefore) receive these permissions by default.

A new method was implemented, but it introduced a regression:  it only works when there are already some principals selected;  it doesn't work when principals are selected for the first time.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
