### PR TITLE
UP-4984:  Apply 'display: inline-block;' and 'font-size: 1.75rem;' to…

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
@@ -32,6 +32,10 @@
             position: absolute;  /* Place on top */
             width: 100%;         /* Hamburger on the right */
 
+            .locked-icon { /* These are the same rules as for standard chrome */
+                display: inline-block;
+                font-size: 1.75rem;
+            }
             .grab-handle {
                 display: inline-block;
                 position: relative;


### PR DESCRIPTION
… the .lock-icon for portlets with no-chrome (just as standard chrome)

https://issues.jasig.org/browse/UP-4984

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

There's a lock icon that Respondr applies to portlets that are locked in place by DLM restrictions.  It looks good in normal chrome, but bad in no-chrome (hamburger menu).

It was styled for normal, but simply overlooked for no-chrome.

### Before

![before](https://user-images.githubusercontent.com/1127174/34048994-f8ccb4b6-e172-11e7-8a04-737c66099726.png)

### After

![after](https://user-images.githubusercontent.com/1127174/34048998-ff6541da-e172-11e7-92ee-4d19a207a74e.png)


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
