### PR TITLE
UP-4985:  Add a SimplePredicate class to uPortal-rendering/src/main/java/org/apereo/portal/rendering/predicates that's easy to configure in Spring

### DIFF
--- a/uPortal-rendering/src/main/java/org/apereo/portal/rendering/predicates/SimplePredicate.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/rendering/predicates/SimplePredicate.java
@@ -15,17 +15,15 @@
 package org.apereo.portal.rendering.predicates;
 
 import java.util.function.Predicate;
-
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.beans.factory.annotation.Required;
 
 /**
  * It's great that Java 8 provides native, language-level support for predicates, but they don't
  * make it easy to configure them in Spring EL (which is something we do for the Rendering
- * Pipeline).  This class is essentially a hard-coded <code>Predicate</code>;  you specify
- * <code>true</code> or <code>false</code>.  The <code>HttpServletRequest</code> is ignored.
+ * Pipeline). This class is essentially a hard-coded <code>Predicate</code>; you specify <code>true
+ * </code> or <code>false</code>. The <code>HttpServletRequest</code> is ignored.
  *
  * @since 5.0
  */
@@ -40,7 +38,7 @@ public class SimplePredicate implements Predicate<HttpServletRequest> {
     }
 
     @PostConstruct
-    public void init(){
+    public void init() {
         value = Boolean.valueOf(valueString);
     }
 

--- a/uPortal-rendering/src/main/java/org/apereo/portal/rendering/predicates/SimplePredicate.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/rendering/predicates/SimplePredicate.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.rendering.predicates;
+
+import java.util.function.Predicate;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Required;
+
+/**
+ * It's great that Java 8 provides native, language-level support for predicates, but they don't
+ * make it easy to configure them in Spring EL (which is something we do for the Rendering
+ * Pipeline).  This class is essentially a hard-coded <code>Predicate</code>;  you specify
+ * <code>true</code> or <code>false</code>.  The <code>HttpServletRequest</code> is ignored.
+ *
+ * @since 5.0
+ */
+public class SimplePredicate implements Predicate<HttpServletRequest> {
+
+    private String valueString;
+    private boolean value;
+
+    @Required
+    public void setValue(String value) {
+        this.valueString = value;
+    }
+
+    @PostConstruct
+    public void init(){
+        value = Boolean.valueOf(valueString);
+    }
+
+    @Override
+    public boolean test(HttpServletRequest httpServletRequest) {
+        return value;
+    }
+}


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4985

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

The new Java 8-based Predicate objects are not easy to configure in Spring.  A simple Predicate impl that does Boolean.valueOf on a String would be a big help.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
