### PR TITLE
build(gradle): enable gradle build cache by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ matrix:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
-      sudo: required
     - os: linux
       dist: trusty
       jdk: openjdk8
-      sudo: required
     - os: osx
       osx_image: xcode9.1 # OSX 10.12, Oracle Java 8
 
@@ -19,7 +17,7 @@ env:
 
 # The 'build' task runs most things, including test, check, & static analysis
 install: true
-script: ./gradlew -u -i -S --no-build-cache --no-parallel build jacocoAggregateReport coveralls
+script: ./gradlew -u -S --no-daemon --no-build-cache --no-parallel build jacocoAggregateReport coveralls
 
 cache:
   directories:
@@ -29,6 +27,6 @@ cache:
 # publish VersionEye results for master branch
 deploy:
   provider: script
-  script: ./gradlew versioneye-update -Pversioneye.api_key=$VERSION_EYE_TOKEN
+  script: ./gradlew versioneye-update --no-daemon --no-build-cache --no-parallel -Pversioneye.api_key=$VERSION_EYE_TOKEN
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 # The 'build' task runs most things, including test, check, & static analysis
 install: true
-script: ./gradlew -u -i -q -S build jacocoAggregateReport coveralls
+script: ./gradlew -u -i -S --no-build-cache --no-parallel build jacocoAggregateReport coveralls
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - gradlew.bat --version
 # The 'build' task runs most things, including test, check, & static analysis
 build: off
-test_script: gradlew.bat -u -i -S --no-build-cache --no-parallel build
+test_script: gradlew.bat -u -S --no-daemon --no-build-cache --no-parallel build
 cache:
   - C:\Users\appveyor\.npm
   - C:\Users\appveyor\.gradle

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - gradlew.bat --version
 # The 'build' task runs most things, including test, check, & static analysis
 build: off
-test_script: gradlew.bat -u -i -S build
+test_script: gradlew.bat -u -i -S --no-build-cache --no-parallel build
 cache:
   - C:\Users\appveyor\.npm
   - C:\Users\appveyor\.gradle

--- a/docs/developer/other/RELEASE.md
+++ b/docs/developer/other/RELEASE.md
@@ -20,7 +20,7 @@ signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
 Run the following command:
 
 ```sh
-./gradlew clean release -Dorg.gradle.parallel=false
+./gradlew clean release --no-parallel
 ```
 
 :warning: During the `release` task, you will be prompted for a release version (e.g. `5.0.3`) and a

--- a/gradle.properties
+++ b/gradle.properties
@@ -115,4 +115,5 @@ jstreeVersion=3.3.4
 
 # gradle settings
 org.gradle.parallel=true
+org.gradle.caching=true
 versioneye.projectid=59e525762de28c000f9188ae


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

> The Gradle build cache is a cache mechanism that aims to save time by reusing outputs produced by other builds. The build cache works by storing (locally or remotely) build outputs and allowing builds to fetch these outputs from the cache when it is determined that inputs have not changed, avoiding the expensive work of regenerating them.

this PR enabled build cache by default for developer builds of uPortal.
However CI will intentionally avoid build cache to ensure a prestine build each time.
Additionally parallel mode has been disabled on CI to ensure logs are readable.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
