### PR TITLE
UP-4988:  Disable JGroups initialize_sql in favor of handling schema …

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -92,62 +92,6 @@
     <!-- Resolver that can be used to dynamically look up property values at run-time -->
     <bean id="propertyResolver" factory-bean="primaryPropertyPlaceholderConfigurer" factory-method="getPropertyResolver"/>
 
-    <!-- Need to capture this value in a bean for map key, using el -->
-    <bean id="hibernateDialect" class="java.lang.String">
-        <constructor-arg value="${hibernate.dialect}"/>
-    </bean>
-
-    <!-- Define default JGROUPS DDL used by most databases -->
-    <bean id="jgroupsDefaultInitSql" class="java.lang.String">
-        <constructor-arg>
-            <value>
-                CREATE TABLE JGROUPSPING (
-                    own_addr varchar(200) NOT NULL,
-                    cluster_name varchar(200) NOT NULL,
-                    ping_data blob DEFAULT NULL,
-                    PRIMARY KEY (own_addr, cluster_name)
-                )
-            </value>
-        </constructor-arg>
-    </bean>
-
-    <!-- And JGROUPS DDL used by MS SQL Server -->
-    <bean id="jgroupsSqlServerInitSql" class="java.lang.String">
-        <constructor-arg>
-            <value>
-                CREATE TABLE JGROUPSPING (
-                    own_addr varchar(200) NOT NULL,
-                    cluster_name varchar(200) NOT NULL,
-                    ping_data varbinary(5000) DEFAULT NULL,
-                    PRIMARY KEY (own_addr, cluster_name)
-                )
-            </value>
-        </constructor-arg>
-    </bean>
-
-    <!-- And JGROUPS DDL used by PostgresSQL Server -->
-    <bean id="jgroupsPostgreSQLInitSql" class="java.lang.String">
-        <constructor-arg>
-            <value>
-                CREATE TABLE IF NOT EXISTS JGROUPSPING (
-                    own_addr varchar(200) NOT NULL,
-                    cluster_name varchar(200) NOT NULL,
-                    ping_data BYTEA DEFAULT NULL,
-                    PRIMARY KEY (own_addr, cluster_name)
-                )
-            </value>
-        </constructor-arg>
-    </bean>
-
-    <!-- Map of JGroups DDL by hibernate.dialect (all Hibernate dialects not listed here will use jgroupsDefaultInitSql) -->
-    <util:map id="jgroupsInitSqlMap" map-class="java.util.HashMap">
-        <!-- Most RDBMS platforms use standard DDL, but MS SQL Server uses something different -->
-        <entry key="org.hibernate.dialect.SQLServerDialect" value="#{@jgroupsSqlServerInitSql}" />
-        <entry key="org.hibernate.dialect.SQLServer2008Dialect" value="#{@jgroupsSqlServerInitSql}" />
-        <entry key="org.hibernate.dialect.PostgreSQLDialect" value="#{@jgroupsPostgreSQLInitSql}" />
-        <entry key="org.hibernate.dialect.PostgresPlusDialect" value="#{@jgroupsPostgreSQLInitSql}" />
-    </util:map>
-
     <!-- Add properties for jgroups.xml as that is not a Spring context -->
     <bean id="systemPropertySetter" class="org.apereo.portal.spring.context.SystemPropertySetter">
         <property name="systemProperties">
@@ -158,7 +102,6 @@
                 <prop key="hibernate.connection.url">${hibernate.connection.url}</prop>
                 <prop key="hibernate.connection.username">${hibernate.connection.username}</prop>
                 <prop key="hibernate.connection.password">${hibernate.connection.password}</prop>
-                <prop key="jgroupsInitSql">#{@jgroupsInitSqlMap[@hibernateDialect] != null ? @jgroupsInitSqlMap[@hibernateDialect] : @jgroupsDefaultInitSql}</prop>
                 <prop key="org.apereo.portal.jgroups.auth.token">${org.apereo.portal.jgroups.auth.token:DEV-345B45TB3}</prop>
             </props>
         </property>

--- a/uPortal-webapp/src/main/resources/properties/db/tables.xml
+++ b/uPortal-webapp/src/main/resources/properties/db/tables.xml
@@ -424,6 +424,27 @@
     <not-null>ENTITY_KEY</not-null>
   </table>
 
+  <!-- Used by the the JGroups JDBC_Ping component;  see http://www.fafonso.com/jgroups/unicast/postgresql/jdbc/ping/cluster/2016/08/07/jgroups-with-postgresql.html. -->
+  <table sinceMajor="5" sinceMinor="0">
+    <name>JGROUPSPING</name>
+    <desc>Each row represents a web server or CLI node participating in the cluster for invalidation caching.</desc>
+    <columns>
+      <column> <name>own_addr</name>       <type>VARCHAR</type>     <param>200</param>
+        <desc>Idintifies the node individually within the cluster</desc>
+      </column>
+      <column> <name>cluster_name</name>       <type>VARCHAR</type>     <param>200</param>
+        <desc>The JDBC_Ping component supports multiple clusters, though uPortal uses only one</desc>
+      </column>
+      <column> <name>ping_data</name>       <type>VARBINARY</type>     <param>5000</param>
+        <desc>The JDBC_Ping component supports multiple clusters, though uPortal uses only one</desc>
+      </column>
+    </columns>
+    <primary-key>own_addr</primary-key>
+    <primary-key>cluster_name</primary-key>
+    <not-null>own_addr</not-null>
+    <not-null>cluster_name</not-null>
+  </table>
+
 </tables>
 
 

--- a/uPortal-webapp/src/main/resources/properties/jgroups.xml
+++ b/uPortal-webapp/src/main/resources/properties/jgroups.xml
@@ -42,13 +42,14 @@
          thread_pool.keep_alive_time="30000"
     />
 
-    <!-- user database for discovery -->
+    <!-- User database for discovery;  initialize_sql to blank prevents
+         table creation, which we handle with Hibernate via dbloader -->
     <JDBC_PING
             connection_url="${hibernate.connection.url}"
             connection_username="${hibernate.connection.username}"
             connection_password="${hibernate.connection.password}"
             connection_driver="${hibernate.connection.driver_class}"
-            initialize_sql="${jgroupsInitSql}"
+            initialize_sql=""
     />
     <MERGE3  min_interval="5000"
              max_interval="30000"


### PR DESCRIPTION
…generation with dbloader

https://issues.jasig.org/browse/UP-4988

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This is a fix I think many folks will enjoy...

DbLoader may appear to be an unattractive piece of ancient, custom uPortal tech -- and on a superficial level it is, just a bit -- but "under the hood" it has much more modern and better-maintained features than the JGroups initialize_sql setting (which generates the JGROUPSPING table, used by uPortal).

As of several years ago, DbLoader was refactored to be a thin wrapper around Hibernate;  it leverages Hibernate's features for dialects & JDBC type mapping.  It's actually pretty slick at it's job, and using it to create the JGROUPSPING table in a platform-agnostic way is a lot less messy than doing so with initialize_sql (i.e. the native JGroups feature).

In addition to being more elegant, it enjoys this important advantage:  it participates in schema drop & re-creation within the dataInit task.  Thiis difference means that the table will be "scrubbed" of any orphaned data on each dataInit or portalInit.  (Orphaned data in the table is the source of JGroups-related slowness when starting a new uPortal app context in Tomcat or within the CLI tools.)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
