### PR TITLE
ci(travis): include ubuntu xenial in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: java
 matrix:
   include:
     - os: linux
+      dist: xenial
+      jdk: oraclejdk8
+    - os: linux
+      dist: xenial
+      jdk: openjdk8
+    - os: linux
       dist: trusty
       jdk: oraclejdk8
     - os: linux


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds ubuntu xenial environment to uPortal test matrix.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
