### PR TITLE
ci(travis): drop trusty for linux ci testing, cross jdk testing remains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ matrix:
     - os: linux
       dist: xenial
       jdk: openjdk8
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk8
-    - os: linux
-      dist: trusty
-      jdk: openjdk8
     - os: osx
       osx_image: xcode9.2 # OSX 10.12, Oracle Java 8
       script: ./gradlew -u -S --no-daemon --no-parallel build # skip coveralls on MacOS


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

:notebook: This is a non-breaking change, aimed at streamlining the testing process for uPortal 5.1+

drop ubuntu trusty (14.04) in favor of Ubuntu xenial (16.04) in continuous integration.
uPortal primarily cares about ensuring current jdks are supported, and we focus on actively supported operating systems.
Trusty LTS will be reaching end of life in April 2019.
JDK 8 was being tested, and JDK 8 continues to be tested on the Xenial build.

uPortal will likely continue to work on Ubuntu Trusty thanks to the abstraction provided by the JDK.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
