### PR TITLE
chore(dependencies): change 'org.hsqldb:hsqldb' from runtime to provi…

### DIFF
--- a/uPortal-webapp/build.gradle
+++ b/uPortal-webapp/build.gradle
@@ -62,10 +62,10 @@ dependencies {
     runtime "com.thoughtworks.xstream:xstream:${xstreamVersion}"
 
     /*
-     * The HSQL driver jar should always be included with 'vanilla' uPortal
-     * from Apereo;  aditional JDBC drivers may be added in the overlay process
+     * The HSQL driver jar should always be provided by uPortal-start;
+     * that way, it has complete control over the version in the deployment.
      */
-    runtime "org.hsqldb:hsqldb:${hsqldbVersion}"
+    providedRuntime "org.hsqldb:hsqldb:${hsqldbVersion}"
 
     webjars "org.webjars.npm:bootstrap:${bootstrapVersion}"
     webjars "org.webjars.npm:jstree:${jstreeVersion}"


### PR DESCRIPTION
…dedRuntime so that it won't be included in the uPortal war artifact

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Including the hsqldb driver jar with the published war artifact is causing us grief when we try to update the version.  It makes more sense to let `uPortal-start` control all the driver jars in use with the deployment.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
