### PR TITLE
UP-4997:  (fix bug) Configuration of locales for i18n does not work i…

### DIFF
--- a/docs/implement/README.md
+++ b/docs/implement/README.md
@@ -11,3 +11,4 @@ users, groups, layouts, *etc.*
     5. Content (TBD)
 2. [Frontend](frontend/README.md)
 3. [Security](security.md)
+4. [Internationalization](i18n.md)

--- a/docs/implement/i18n.md
+++ b/docs/implement/i18n.md
@@ -1,0 +1,31 @@
+# Internationalization
+
+uPortal provides internationalization features.  There are three aspects to implementing support for
+another language in the portal: the uPortal (Spring) _MessageSource_, _uPortal Data_, and _Content
+Modules_.
+
+## uPortal MessageSource
+
+uPortal provides support for internationalizing UI strings through a Spring `MessageSource`.
+uPortal comes with several languages available, but you can add your own (or update an existing
+one) by adding a `Messages_{code}.properties` file in the classpath at `/properties/i18n/` where
+{code} is the two-character country code (e.g. 'fr' for French and 'de' for German).
+
+Use the `org.apereo.portal.i18n.LocaleManager.portal_locales` property to define the languages
+available in the portal.  Add this property to either `uPortal.properties` or `global.properties`.
+
+### Portal Locales Example
+
+```properties
+org.apereo.portal.i18n.LocaleManager.portal_locales=fr_FR
+```
+
+This value will limit the portal to _French_.
+
+## uPortal Data
+
+_TBD._
+
+## Content Modules
+
+_TBD._

--- a/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/account/UserAccountHelper.java
+++ b/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/account/UserAccountHelper.java
@@ -17,6 +17,7 @@ package org.apereo.portal.portlets.account;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.apereo.portal.groups.IEntityGroup;
 import org.apereo.portal.groups.IGroupMember;
 import org.apereo.portal.i18n.ILocaleStore;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.layout.dlm.remoting.IGroupListHelper;
 import org.apereo.portal.layout.dlm.remoting.JsonEntityBean;
 import org.apereo.portal.persondir.ILocalAccountDao;
@@ -65,6 +67,7 @@ public class UserAccountHelper {
     private static final String PORTLET_FNAME_LOGIN = "login";
 
     private ILocaleStore localeStore;
+    private LocaleManagerFactory localeManagerFactory;
     private ILocalAccountDao accountDao;
     private IPortalPasswordService passwordService;
     private List<Preference> accountEditAttributes;
@@ -78,6 +81,11 @@ public class UserAccountHelper {
     @Autowired
     public void setLocaleStore(ILocaleStore localeStore) {
         this.localeStore = localeStore;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     @Autowired
@@ -487,8 +495,9 @@ public class UserAccountHelper {
     protected Locale getCurrentUserLocale(final HttpServletRequest request) {
         final IPerson person = personManager.getPerson(request);
         final Locale[] userLocales = localeStore.getUserLocales(person);
-        final LocaleManager localeManager = new LocaleManager(person, userLocales);
-        final Locale locale = localeManager.getLocales()[0];
+        final LocaleManager localeManager =
+                localeManagerFactory.createLocaleManager(person, Arrays.asList(userLocales));
+        final Locale locale = localeManager.getLocales().get(0);
         return locale;
     }
 

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/layout/dlm/remoting/ChannelListController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/layout/dlm/remoting/ChannelListController.java
@@ -14,6 +14,7 @@
  */
 package org.apereo.portal.layout.dlm.remoting;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.EntityIdentifier;
 import org.apereo.portal.i18n.ILocaleStore;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.layout.dlm.remoting.registry.ChannelBean;
 import org.apereo.portal.layout.dlm.remoting.registry.ChannelCategoryBean;
 import org.apereo.portal.layout.dlm.remoting.registry.v43.PortletCategoryBean;
@@ -76,6 +78,7 @@ public class ChannelListController {
     private IPersonManager personManager;
     private IPortalSpELService spELService;
     private ILocaleStore localeStore;
+    private LocaleManagerFactory localeManagerFactory;
     private MessageSource messageSource;
     private IAuthorizationService authorizationService;
 
@@ -110,6 +113,11 @@ public class ChannelListController {
     @Autowired
     public void setLocaleStore(ILocaleStore localeStore) {
         this.localeStore = localeStore;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     @Autowired
@@ -465,9 +473,9 @@ public class ChannelListController {
     private Locale getUserLocale(IPerson user) {
         // get user locale
         Locale[] locales = localeStore.getUserLocales(user);
-        LocaleManager localeManager = new LocaleManager(user, locales);
-        Locale rslt = localeManager.getLocales()[0];
-        return rslt;
+        LocaleManager localeManager =
+                localeManagerFactory.createLocaleManager(user, Arrays.asList(locales));
+        return localeManager.getLocales().get(0);
     }
 
     /**

--- a/uPortal-core/src/main/java/org/apereo/portal/i18n/ILocaleManager.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/i18n/ILocaleManager.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.i18n;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * An instance of this interface manages locales on behalf of a user. Locale managers currently keep
+ * track of locales at the following levels:<br>
+ *
+ * <ol>
+ *   <li>User's locale preferences (associated with a user ID)
+ *   <li>Browser's locale preferences (from the Accept-Language request header)
+ *   <li>Session's locale preferences (set via the portal request parameter uP_locales)
+ *   <li>Portal's locale preferences (set in portal.properties)
+ * </ol>
+ *
+ * Eventually, they will also keep track of locale preferences at the following levels:<br>
+ *
+ * <ol>
+ *   <li>Layout node's locale preferences
+ *   <li>User profile's locale preferences
+ * </ol>
+ *
+ * @since 5.0
+ */
+public interface ILocaleManager {
+
+    List<Locale> getUserLocales();
+
+    void setUserLocales(List<Locale> userLocales);
+
+    List<Locale> getSessionLocales();
+
+    void setSessionLocales(List<Locale> sessionLocales);
+}

--- a/uPortal-core/src/main/java/org/apereo/portal/i18n/LocaleManagerFactory.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/i18n/LocaleManagerFactory.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.i18n;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.StringTokenizer;
+import javax.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.portal.security.IPerson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring-managed bean that produces {@link ILocaleManager} instances when needed.
+ *
+ * @since 5.0
+ */
+@Component
+public class LocaleManagerFactory {
+
+    @Value("${org.apereo.portal.i18n.LocaleManager.locale_aware:true}")
+    private boolean localeAware;
+
+    @Value(
+            "${org.apereo.portal.i18n.LocaleManager.portal_locales:en_US,fr_FR,es_ES,ja_JP,sv_SE,de_DE,mk_MK,lv_LV}")
+    private String portalLocalesProperty;
+
+    private List<Locale> portalLocales;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Populate <code>portalLocales</code> from a comma-delimited locale string list, e.g.
+     * "en_US,ja_JP"
+     */
+    @PostConstruct
+    public void init() {
+        logger.info("Using localeAware={}", localeAware);
+        logger.info("Using portalLocalesProperty='{}'", portalLocalesProperty);
+        if (StringUtils.isNotBlank(portalLocalesProperty)) {
+            final List<Locale> list = new ArrayList<>();
+            for (String token : portalLocalesProperty.split(",")) {
+                list.add(parseLocale(token.trim()));
+            }
+            portalLocales = Collections.unmodifiableList(list);
+            logger.info("Loaded the following portalLocales:  {}", portalLocales);
+        }
+    }
+
+    public boolean isLocaleAware() {
+        return localeAware;
+    }
+
+    public List<Locale> getPortalLocales() {
+        return portalLocales;
+    }
+
+    public LocaleManager createLocaleManager(IPerson person, List<Locale> userLocales) {
+        logger.debug("Creating LocalManager for user '{}'", person.getUserName());
+        return new LocaleManager(person, userLocales, portalLocales);
+    }
+
+    /**
+     * Helper method to produce a <code>java.util.Locale</code> object from a locale string such as
+     * en_US or ja_JP.
+     *
+     * @param localeString a locale string such as en_US
+     * @return a java.util.Locale object representing the locale string
+     */
+    public Locale parseLocale(String localeString) {
+        String language = null;
+        String country = null;
+        String variant = null;
+
+        // Sometimes people specify "en-US" instead of "en_US", so
+        // we'll try to clean that up.
+        localeString = localeString.replaceAll("-", "_");
+
+        StringTokenizer st = new StringTokenizer(localeString, "_");
+
+        if (st.hasMoreTokens()) {
+            language = st.nextToken();
+        }
+        if (st.hasMoreTokens()) {
+            country = st.nextToken();
+        }
+        if (st.hasMoreTokens()) {
+            variant = st.nextToken();
+        }
+
+        Locale locale = null;
+
+        if (variant != null) {
+            locale = new Locale(language, country, variant);
+        } else if (country != null) {
+            locale = new Locale(language, country);
+        } else if (language != null) {
+            locale = new Locale(language);
+        }
+
+        return locale;
+    }
+}

--- a/uPortal-i18n/src/main/java/org/apereo/portal/i18n/LocaleManagerLocaleResolver.java
+++ b/uPortal-i18n/src/main/java/org/apereo/portal/i18n/LocaleManagerLocaleResolver.java
@@ -14,6 +14,8 @@
  */
 package org.apereo.portal.i18n;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,9 +55,9 @@ public class LocaleManagerLocaleResolver implements LocaleResolver {
         final IUserInstance userInstance = this.userInstanceManager.getUserInstance(request);
         final LocaleManager localeManager = userInstance.getLocaleManager();
 
-        Locale[] locales = localeManager.getLocales();
-        if (locales != null && locales.length > 0) {
-            return locales[0];
+        List<Locale> locales = localeManager.getLocales();
+        if (locales != null && locales.size() > 0) {
+            return locales.get(0);
         }
 
         // if there was no LocaleManager was not able to determine the locale, return the locale
@@ -67,14 +69,14 @@ public class LocaleManagerLocaleResolver implements LocaleResolver {
     public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
         final IUserInstance userInstance = this.userInstanceManager.getUserInstance(request);
         final LocaleManager localeManager = userInstance.getLocaleManager();
-        localeManager.setSessionLocales(new Locale[] {locale});
+        localeManager.setSessionLocales(Collections.singletonList(locale));
 
         // if the current user is logged in, also update the persisted user locale
         final IUserInstance ui = userInstanceManager.getUserInstance(request);
         final IPerson person = ui.getPerson();
         if (!person.isGuest()) {
             try {
-                localeManager.persistUserLocales(new Locale[] {locale});
+                localeManager.setUserLocales(Collections.singletonList(locale));
                 localeStore.updateUserLocales(person, new Locale[] {locale});
                 final IUserPreferencesManager upm = ui.getPreferencesManager();
                 upm.getUserLayoutManager().loadUserLayout();

--- a/uPortal-i18n/src/main/java/org/apereo/portal/i18n/RDBMLocaleStore.java
+++ b/uPortal-i18n/src/main/java/org/apereo/portal/i18n/RDBMLocaleStore.java
@@ -48,6 +48,7 @@ public class RDBMLocaleStore implements ILocaleStore {
 
     protected TransactionOperations transactionOperations;
     protected JdbcOperations jdbcOperations;
+    private LocaleManagerFactory localeManagerFactory;
 
     @Autowired
     public void setPlatformTransactionManager(
@@ -59,6 +60,11 @@ public class RDBMLocaleStore implements ILocaleStore {
     @Resource(name = BasePortalJpaDao.PERSISTENCE_UNIT_NAME)
     public void setDataSource(DataSource dataSource) {
         this.jdbcOperations = new JdbcTemplate(dataSource);
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     @Override
@@ -81,7 +87,8 @@ public class RDBMLocaleStore implements ILocaleStore {
                             try {
                                 while (rs.next()) {
                                     final String localeString = rs.getString("LOCALE");
-                                    final Locale locale = LocaleManager.parseLocale(localeString);
+                                    final Locale locale =
+                                            localeManagerFactory.parseLocale(localeString);
                                     localeList.add(locale);
                                 }
                             } finally {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentActivator.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentActivator.java
@@ -18,6 +18,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -32,6 +33,7 @@ import org.apereo.portal.IUserIdentityStore;
 import org.apereo.portal.IUserProfile;
 import org.apereo.portal.UserProfile;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.layout.IUserLayoutStore;
 import org.apereo.portal.properties.PropertiesManager;
 import org.apereo.portal.security.IPerson;
@@ -65,6 +67,7 @@ public class FragmentActivator {
     private IUserIdentityStore identityStore;
     private IUserLayoutStore userLayoutStore;
     private ConfigurationLoader configurationLoader;
+    private LocaleManagerFactory localeManagerFactory;
 
     private static final String PROPERTY_ALLOW_EXPANDED_CONTENT =
             "org.apereo.portal.layout.dlm.allowExpandedContent";
@@ -122,6 +125,11 @@ public class FragmentActivator {
     @Autowired
     public void setUserLayoutStore(IUserLayoutStore userLayoutStore) {
         this.userLayoutStore = userLayoutStore;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     private static class UserViewKey implements Serializable {
@@ -356,7 +364,10 @@ public class FragmentActivator {
         try {
             // fix hard coded 1 later for multiple profiles
             IUserProfile profile = userLayoutStore.getUserProfileByFname(owner, "default");
-            profile.setLocaleManager(new LocaleManager(owner, new Locale[] {locale}));
+            final LocaleManager localeManager =
+                    localeManagerFactory.createLocaleManager(
+                            owner, Collections.singletonList(locale));
+            profile.setLocaleManager(localeManager);
 
             // see if we have structure & theme stylesheets for this user yet.
             // If not then fall back on system's selected stylesheets.

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
@@ -37,7 +37,6 @@ import org.apereo.portal.AuthorizationException;
 import org.apereo.portal.IUserIdentityStore;
 import org.apereo.portal.IUserProfile;
 import org.apereo.portal.PortalException;
-import org.apereo.portal.i18n.LocaleManager;
 import org.apereo.portal.io.xml.IPortalDataHandlerService;
 import org.apereo.portal.jdbc.RDBMServices;
 import org.apereo.portal.layout.LayoutStructure;
@@ -196,9 +195,9 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
     public Map<String, Document> getFragmentLayoutCopies() {
         // since this is only visible in fragment list in administrative portlet, use default portal
         // locale
-        final Locale defaultLocale = LocaleManager.getPortalLocales()[0];
+        final Locale defaultLocale = localeManagerFactory.getPortalLocales().get(0);
 
-        final Map<String, Document> layouts = new HashMap<String, Document>();
+        final Map<String, Document> layouts = new HashMap<>();
 
         final List<FragmentDefinition> definitions = this.fragmentUtils.getFragmentDefinitions();
         for (final FragmentDefinition fragmentDefinition : definitions) {
@@ -230,7 +229,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
             Set<String> fragmentNames) {
         final boolean isFragmentOwner = this.isFragmentOwner(person);
 
-        final Locale locale = profile.getLocaleManager().getLocales()[0];
+        final Locale locale = profile.getLocaleManager().getLocales().get(0);
         final IStylesheetDescriptor stylesheetDescriptor =
                 this.stylesheetDescriptorDao.getStylesheetDescriptor(stylesheetDescriptorId);
         final IStylesheetUserPreferences stylesheetUserPreferences =
@@ -278,8 +277,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                                 ? fragmentNodeId
                                 : labelBase + fragmentNodeId;
 
-                final MapPopulator<String, String> layoutAttributesPopulator =
-                        new MapPopulator<String, String>();
+                final MapPopulator<String, String> layoutAttributesPopulator = new MapPopulator<>();
                 fragmentStylesheetUserPreferences.populateLayoutAttributes(
                         fragmentNodeId, layoutAttributesPopulator);
                 final Map<String, String> layoutAttributes = layoutAttributesPopulator.getMap();
@@ -690,8 +688,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                     ssup.getAllLayoutAttributeNodeIds();
             for (final String nodeId : allLayoutAttributeNodeIds) {
 
-                final MapPopulator<String, String> layoutAttributesPopulator =
-                        new MapPopulator<String, String>();
+                final MapPopulator<String, String> layoutAttributesPopulator = new MapPopulator<>();
                 ssup.populateLayoutAttributes(nodeId, layoutAttributesPopulator);
                 final Map<String, String> layoutAttributes = layoutAttributesPopulator.getMap();
 
@@ -959,7 +956,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
             // track which entities from the user's pre-existing set are touched (all non-touched
             // entities will be removed)
             final Set<IPortletEntity> oldPortletEntities =
-                    new LinkedHashSet<IPortletEntity>(
+                    new LinkedHashSet<>(
                             this.portletEntityDao.getPortletEntitiesForUser(ownerUserId));
 
             final List<org.dom4j.Element> entries = preferencesElement.selectNodes("entry");
@@ -981,7 +978,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                             portletEntity.getPortletPreferences();
 
                     final List<org.dom4j.Element> valueElements = entry.selectNodes("value");
-                    final List<String> values = new ArrayList<String>(valueElements.size());
+                    final List<String> values = new ArrayList<>(valueElements.size());
                     for (final org.dom4j.Element valueElement : valueElements) {
                         values.add(valueElement.getText());
                     }
@@ -1061,11 +1058,9 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                                 stylesheetDescriptor, person, profile);
             }
 
-            final Map<String, Map<String, String>> oldLayoutAttributes =
-                    new HashMap<String, Map<String, String>>();
+            final Map<String, Map<String, String>> oldLayoutAttributes = new HashMap<>();
             for (final String nodeId : ssup.getAllLayoutAttributeNodeIds()) {
-                final MapPopulator<String, String> nodeAttributes =
-                        new MapPopulator<String, String>();
+                final MapPopulator<String, String> nodeAttributes = new MapPopulator<>();
                 ssup.populateLayoutAttributes(nodeId, nodeAttributes);
                 oldLayoutAttributes.put(nodeId, nodeAttributes.getMap());
             }
@@ -1185,7 +1180,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
     }
 
     private final ThreadLocal<Cache<Tuple<String, String>, Document>> layoutCacheHolder =
-            new ThreadLocal<Cache<Tuple<String, String>, Document>>();
+            new ThreadLocal<>();
 
     public void setLayoutImportExportCache(Cache<Tuple<String, String>, Document> layoutCache) {
         if (layoutCache == null) {
@@ -1214,7 +1209,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
 
         final Cache<Tuple<String, String>, Document> layoutCache = getLayoutImportExportCache();
         if (layoutCache != null) {
-            key = new Tuple<String, String>(person.getUserName(), profile.getProfileFname());
+            key = new Tuple<>(person.getUserName(), profile.getProfileFname());
             layoutDoc = layoutCache.getIfPresent(key);
             if (layoutDoc != null) {
                 return (Document) layoutDoc.cloneNode(true);
@@ -1246,7 +1241,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
         final FragmentDefinition ownedFragment =
                 this.fragmentUtils.getFragmentDefinitionByOwner(person);
         final boolean isLayoutOwnerDefault = this.isLayoutOwnerDefault(person);
-        final Set<String> fragmentNames = new LinkedHashSet<String>();
+        final Set<String> fragmentNames = new LinkedHashSet<>();
 
         final Document ILF;
         final Document PLF = this.getPLF(person, profile);
@@ -1285,7 +1280,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                         (String) person.getAttribute("username"));
             }
         } else {
-            final Locale locale = profile.getLocaleManager().getLocales()[0];
+            final Locale locale = profile.getLocaleManager().getLocales().get(0);
             final List<FragmentDefinition> applicableFragmentDefinitions =
                     this.fragmentUtils.getFragmentDefinitionsApplicableToPerson(person);
             final List<Document> applicableLayouts =
@@ -1393,7 +1388,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
      */
     private void updateCachedLayout(
             Document layout, IUserProfile profile, FragmentDefinition fragment) {
-        final Locale locale = profile.getLocaleManager().getLocales()[0];
+        final Locale locale = profile.getLocaleManager().getLocales().get(0);
         // need to make a copy that we can fragmentize
         layout = (Document) layout.cloneNode(true);
 
@@ -1536,7 +1531,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
     public FragmentNodeInfo getFragmentNodeInfo(String sId) {
         // grab local pointers to variables subject to change at any time
         final List<FragmentDefinition> fragments = this.fragmentUtils.getFragmentDefinitions();
-        final Locale defaultLocale = LocaleManager.getPortalLocales()[0];
+        final Locale defaultLocale = localeManagerFactory.getPortalLocales().get(0);
 
         final net.sf.ehcache.Element element = this.fragmentNodeInfoCache.get(sId);
         FragmentNodeInfo info =
@@ -1608,7 +1603,7 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
         structure.setAttribute("hidden", (ls.isHidden() ? "true" : "false"));
         structure.setAttribute("immutable", (ls.isImmutable() ? "true" : "false"));
         structure.setAttribute("unremovable", (ls.isUnremovable() ? "true" : "false"));
-        if (localeAware) {
+        if (localeManagerFactory.isLocaleAware()) {
             structure.setAttribute("locale", ls.getLocale()); // for i18n by Shoji
         }
 

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/user/UserInstanceManagerImpl.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/user/UserInstanceManagerImpl.java
@@ -15,6 +15,7 @@
 package org.apereo.portal.user;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -27,6 +28,7 @@ import org.apereo.portal.UserInstance;
 import org.apereo.portal.UserPreferencesManager;
 import org.apereo.portal.i18n.ILocaleStore;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.layout.IUserLayoutManager;
 import org.apereo.portal.layout.IUserLayoutStore;
 import org.apereo.portal.layout.UserLayoutManagerFactory;
@@ -51,6 +53,7 @@ public class UserInstanceManagerImpl implements IUserInstanceManager {
     private IPortalRequestUtils portalRequestUtils;
     private IProfileMapper profileMapper;
     private UserLayoutManagerFactory userLayoutManagerFactory;
+    private LocaleManagerFactory localeManagerFactory;
 
     @Autowired
     public void setUserLayoutManagerFactory(UserLayoutManagerFactory userLayoutManagerFactory) {
@@ -80,6 +83,11 @@ public class UserInstanceManagerImpl implements IUserInstanceManager {
     @Autowired
     public void setProfileMapper(IProfileMapper profileMapper) {
         this.profileMapper = profileMapper;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     /**
@@ -171,7 +179,7 @@ public class UserInstanceManagerImpl implements IUserInstanceManager {
             userProfile = userLayoutStore.getSystemProfileByFname(profileFname);
         }
 
-        if (localeManager != null && LocaleManager.isLocaleAware()) {
+        if (localeManager != null && localeManagerFactory.isLocaleAware()) {
             userProfile.setLocaleManager(localeManager);
         }
 
@@ -181,7 +189,7 @@ public class UserInstanceManagerImpl implements IUserInstanceManager {
     protected LocaleManager getLocaleManager(HttpServletRequest request, IPerson person) {
         final String acceptLanguage = request.getHeader("Accept-Language");
         final Locale[] userLocales = localeStore.getUserLocales(person);
-        return new LocaleManager(person, userLocales, acceptLanguage);
+        return localeManagerFactory.createLocaleManager(person, Arrays.asList(userLocales));
     }
 
     protected String getUserAgent(HttpServletRequest request) {

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/translator/MessageEntityTranslationController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/translator/MessageEntityTranslationController.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.i18n.Message;
 import org.apereo.portal.i18n.dao.IMessageDao;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,10 +42,16 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 public class MessageEntityTranslationController {
 
     private IMessageDao messageDao;
+    private LocaleManagerFactory localeManagerFactory;
 
     @Autowired
     public void setMessageDao(IMessageDao messageDao) {
         this.messageDao = messageDao;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
     }
 
     @ResourceMapping
@@ -67,7 +73,7 @@ public class MessageEntityTranslationController {
     @RequestMapping(params = "action=getEntity")
     public ModelAndView getEntity(
             @RequestParam("id") String code, @RequestParam("locale") String localeStr) {
-        final Locale locale = LocaleManager.parseLocale(localeStr);
+        final Locale locale = localeManagerFactory.parseLocale(localeStr);
         final Message message = messageDao.getMessage(code, locale);
         return new ModelAndView("json", "message", message);
     }
@@ -78,7 +84,7 @@ public class MessageEntityTranslationController {
             @RequestParam("id") String code,
             @RequestParam("locale") String localeStr,
             @RequestParam("value") String value) {
-        final Locale locale = LocaleManager.parseLocale(localeStr);
+        final Locale locale = localeManagerFactory.parseLocale(localeStr);
         if (locale != null && StringUtils.hasText(code) && StringUtils.hasText(value)) {
             final Message message = messageDao.getMessage(code, locale);
             if (message != null) {

--- a/uPortal-rendering/src/main/java/org/apereo/portal/rendering/xslt/LocaleTransformerConfigurationSource.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/rendering/xslt/LocaleTransformerConfigurationSource.java
@@ -15,6 +15,7 @@
 package org.apereo.portal.rendering.xslt;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -51,9 +52,9 @@ public class LocaleTransformerConfigurationSource extends TransformerConfigurati
             HttpServletRequest request, HttpServletResponse response) {
         final LocaleManager localeManager = this.getLocaleManager(request);
 
-        final Locale[] locales = localeManager.getLocales();
-        if (locales != null && locales.length > 0 && locales[0] != null) {
-            final String locale = locales[0].toString();
+        final List<Locale> locales = localeManager.getLocales();
+        if (locales != null && locales.size() > 0 && locales.get(0) != null) {
+            final String locale = locales.get(0).toString();
             final String xslLocale = locale.replace('_', '-');
             this.logger.debug("Setting USER_LANG to {}", xslLocale);
             return Collections.singletonMap("USER_LANG", (Object) xslLocale);
@@ -69,9 +70,9 @@ public class LocaleTransformerConfigurationSource extends TransformerConfigurati
     public CacheKey getCacheKey(HttpServletRequest request, HttpServletResponse response) {
         final LocaleManager localeManager = this.getLocaleManager(request);
 
-        final Locale[] locales = localeManager.getLocales();
-        if (locales != null && locales.length > 0 && locales[0] != null) {
-            final String locale = locales[0].toString();
+        final List<Locale> locales = localeManager.getLocales();
+        if (locales != null && locales.size() > 0 && locales.get(0) != null) {
+            final String locale = locales.get(0).toString();
             final String xslLocale = locale.replace('_', '-');
             return CacheKey.build(this.getClass().getName(), xslLocale);
         }

--- a/uPortal-security/uPortal-security-xslt/src/main/java/org/apereo/portal/security/xslt/XalanLayoutElementTitleHelper.java
+++ b/uPortal-security/uPortal-security-xslt/src/main/java/org/apereo/portal/security/xslt/XalanLayoutElementTitleHelper.java
@@ -15,7 +15,7 @@
 package org.apereo.portal.security.xslt;
 
 import java.util.Locale;
-import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.layout.dlm.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
@@ -29,9 +29,16 @@ public class XalanLayoutElementTitleHelper {
 
     private static MessageSource messageSource;
 
+    private static LocaleManagerFactory localeManagerFactory;
+
     @Autowired
     public void setMessageSource(MessageSource messageSource) {
         XalanLayoutElementTitleHelper.messageSource = messageSource;
+    }
+
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        XalanLayoutElementTitleHelper.localeManagerFactory = localeManagerFactory;
     }
 
     /**
@@ -49,7 +56,7 @@ public class XalanLayoutElementTitleHelper {
      */
     public static String getTitle(String id, String language, String name) {
         if (id != null && id.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {
-            final Locale locale = LocaleManager.parseLocale(language);
+            final Locale locale = localeManagerFactory.parseLocale(language);
             return messageSource.getMessage(name, new Object[] {}, name, locale);
         }
         return name;

--- a/uPortal-security/uPortal-security-xslt/src/main/java/org/apereo/portal/security/xslt/XalanMessageHelperBean.java
+++ b/uPortal-security/uPortal-security-xslt/src/main/java/org/apereo/portal/security/xslt/XalanMessageHelperBean.java
@@ -16,7 +16,8 @@ package org.apereo.portal.security.xslt;
 
 import java.util.Locale;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.stereotype.Service;
@@ -25,33 +26,40 @@ import org.springframework.stereotype.Service;
 public class XalanMessageHelperBean implements IXalanMessageHelper, MessageSourceAware {
     private MessageSource messageSource;
 
+    private LocaleManagerFactory localeManagerFactory;
+
     @Override
     public void setMessageSource(MessageSource messageSource) {
         this.messageSource = messageSource;
     }
 
+    @Autowired
+    public void setLocaleManagerFactory(LocaleManagerFactory localeManagerFactory) {
+        this.localeManagerFactory = localeManagerFactory;
+    }
+
     @Override
     public String getMessage(String code, String language) {
-        final Locale locale = LocaleManager.parseLocale(language);
+        final Locale locale = localeManagerFactory.parseLocale(language);
         final String message = messageSource.getMessage(code, null, locale);
         return message;
     }
 
     @Override
     public String getMessage(String code, String language, String arg1) {
-        final Locale locale = LocaleManager.parseLocale(language);
+        final Locale locale = localeManagerFactory.parseLocale(language);
         return messageSource.getMessage(code, new Object[] {arg1}, locale);
     }
 
     @Override
     public String getMessage(String code, String language, String arg1, String arg2) {
-        final Locale locale = LocaleManager.parseLocale(language);
+        final Locale locale = localeManagerFactory.parseLocale(language);
         return messageSource.getMessage(code, new Object[] {arg1, arg2}, locale);
     }
 
     @Override
     public String getMessage(String code, String language, String arg1, String arg2, String arg3) {
-        final Locale locale = LocaleManager.parseLocale(language);
+        final Locale locale = localeManagerFactory.parseLocale(language);
         return messageSource.getMessage(code, new Object[] {arg1, arg2, arg3}, locale);
     }
 

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/DefinitionHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/DefinitionHeaderProvider.java
@@ -15,6 +15,7 @@
 package org.apereo.portal.soffit;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.apereo.portal.i18n.ILocaleStore;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.portlet.marketplace.IMarketplaceService;
 import org.apereo.portal.portlet.marketplace.MarketplacePortletDefinition;
 import org.apereo.portal.portlet.om.IPortletDefinition;
@@ -62,6 +64,8 @@ public class DefinitionHeaderProvider extends AbstractHeaderProvider {
     @Autowired private ILocaleStore localeStore;
 
     @Autowired private DefinitionService definitionService;
+
+    @Autowired private LocaleManagerFactory localeManagerFactory;
 
     @Override
     public Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse) {
@@ -130,8 +134,8 @@ public class DefinitionHeaderProvider extends AbstractHeaderProvider {
     private Locale getUserLocale(IPerson user) {
         // get user locale
         Locale[] locales = localeStore.getUserLocales(user);
-        LocaleManager localeManager = new LocaleManager(user, locales);
-        Locale rslt = localeManager.getLocales()[0];
-        return rslt;
+        LocaleManager localeManager =
+                localeManagerFactory.createLocaleManager(user, Arrays.asList(locales));
+        return localeManager.getLocales().get(0);
     }
 }

--- a/uPortal-tenants/src/main/java/org/apereo/portal/tenants/AbstractTenantOperationsListener.java
+++ b/uPortal-tenants/src/main/java/org/apereo/portal/tenants/AbstractTenantOperationsListener.java
@@ -14,12 +14,14 @@
  */
 package org.apereo.portal.tenants;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.i18n.ILocaleStore;
 import org.apereo.portal.i18n.LocaleManager;
+import org.apereo.portal.i18n.LocaleManagerFactory;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.url.IPortalRequestUtils;
@@ -43,6 +45,8 @@ public abstract class AbstractTenantOperationsListener implements ITenantOperati
     @Autowired private IPersonManager personManager;
 
     @Autowired private ILocaleStore localeStore;
+
+    @Autowired private LocaleManagerFactory localeManagerFactory;
 
     @Autowired private MessageSource messageSource;
 
@@ -107,8 +111,9 @@ public abstract class AbstractTenantOperationsListener implements ITenantOperati
         final HttpServletRequest req = this.portalRequestUtils.getCurrentPortalRequest();
         final IPerson person = personManager.getPerson(req);
         final Locale[] userLocales = localeStore.getUserLocales(person);
-        final LocaleManager localeManager = new LocaleManager(person, userLocales);
-        final Locale locale = localeManager.getLocales()[0];
+        final LocaleManager localeManager =
+                localeManagerFactory.createLocaleManager(person, Arrays.asList(userLocales));
+        final Locale locale = localeManager.getLocales().get(0);
         return locale;
     }
 

--- a/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletRequestWrapper.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletRequestWrapper.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +36,6 @@ import org.apereo.portal.security.IPerson;
 import org.apereo.portal.services.GroupService;
 import org.apereo.portal.user.IUserInstance;
 import org.apereo.portal.user.IUserInstanceManager;
-import org.apereo.portal.utils.ArrayEnumerator;
 import org.apereo.portal.utils.web.AbstractHttpServletRequestWrapper;
 
 /**
@@ -58,7 +58,7 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
 
     protected final Log logger = LogFactory.getLog(this.getClass());
 
-    private final Map<String, String> additionalHeaders = new LinkedHashMap<String, String>();
+    private final Map<String, String> additionalHeaders = new LinkedHashMap<>();
     private final HttpServletResponse httpServletResponse;
     private final IUserInstanceManager userInstanceManager;
 
@@ -128,7 +128,7 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
 
     @Override
     public Enumeration<String> getHeaderNames() {
-        final Set<String> headerNames = new LinkedHashSet<String>();
+        final Set<String> headerNames = new LinkedHashSet<>();
 
         for (final Enumeration<String> headerNamesEnum = super.getHeaderNames();
                 headerNamesEnum.hasMoreElements(); ) {
@@ -263,8 +263,8 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
         final IUserInstance userInstance =
                 this.userInstanceManager.getUserInstance(this.getWrappedRequest());
         final LocaleManager localeManager = userInstance.getLocaleManager();
-        final Locale[] locales = localeManager.getLocales();
-        return locales[0];
+        final List<Locale> locales = localeManager.getLocales();
+        return locales.get(0);
     }
 
     /* (non-Javadoc)
@@ -279,7 +279,7 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
         final IUserInstance userInstance =
                 this.userInstanceManager.getUserInstance(this.getWrappedRequest());
         final LocaleManager localeManager = userInstance.getLocaleManager();
-        final Locale[] locales = localeManager.getLocales();
-        return new ArrayEnumerator<Locale>(locales);
+        final List<Locale> locales = localeManager.getLocales();
+        return Collections.enumeration(locales);
     }
 }

--- a/uPortal-webapp/src/test/resources/org/apereo/portal/rendering/renderingPipelineTestContext.xml
+++ b/uPortal-webapp/src/test/resources/org/apereo/portal/rendering/renderingPipelineTestContext.xml
@@ -19,19 +19,19 @@
     under the License.
 
 -->
-<beans xmlns="http://www.springframework.org/schema/beans" 
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
-                           
+
     <alias name="staxSerializingComponent" alias="renderingPipeline"/>
-    
+
     <bean id="portletContentPlaceholderEventSource" class="org.apereo.portal.character.stream.PortletContentPlaceholderEventSource" />
     <bean id="portletHeaderPlaceholderEventSource" class="org.apereo.portal.character.stream.PortletHeaderPlaceholderEventSource" />
     <bean id="portletTitlePlaceholderEventSource" class="org.apereo.portal.character.stream.PortletTitlePlaceholderEventSource" />
     <bean id="portletHelpPlaceholderEventSource" class="org.apereo.portal.character.stream.PortletHelpPlaceholderEventSource" />
-    
+
     <!-- StAX to String serialization -->
     <bean id="staxSerializingComponent" class="org.apereo.portal.rendering.StAXSerializingComponent">
         <property name="wrappedComponent" ref="postThemeTransformLogger" />
@@ -52,12 +52,12 @@
             </map>
         </property>
     </bean>
-    
+
     <bean id="postThemeTransformLogger" class="org.apereo.portal.rendering.LoggingStAXComponent">
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_THEME" />
         <property name="wrappedComponent" ref="themeTransformComponent" />
     </bean>
-    
+
     <!-- theme transformation -->
     <bean id="themeTransformComponent" class="org.apereo.portal.rendering.xslt.XSLTComponent">
         <property name="wrappedComponent" ref="postStructureTransformLogger" />
@@ -96,7 +96,7 @@
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_STRUCT" />
         <property name="wrappedComponent" ref="structureTransformComponent" />
     </bean>
-    
+
     <bean id="structureTransformComponent" class="org.apereo.portal.rendering.xslt.XSLTComponent">
         <property name="wrappedComponent" ref="postStructureAttributeIncorporationLogger" />
         <property name="transformerSource">
@@ -125,7 +125,7 @@
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_SAI" />
         <property name="wrappedComponent" ref="structureAttributeIncorporationComponent" />
     </bean>
-    
+
     <!-- structure attribute incorporation -->
     <bean id="structureAttributeIncorporationComponent" class="org.apereo.portal.rendering.StAXAttributeIncorporationComponent">
         <property name="wrappedComponent" ref="postUserLayoutStoreLogger" />
@@ -143,7 +143,7 @@
             </bean>
         </property>
     </bean>
-    
+
     <bean id="postUserLayoutStoreLogger" class="org.apereo.portal.rendering.LoggingStAXComponent">
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_LAYOUT" />
         <property name="wrappedComponent" ref="userLayoutStoreComponent" />
@@ -157,9 +157,9 @@
 
     <!-- Utility Beans -->
     <bean class="org.apereo.portal.xml.XmlUtilitiesImpl" />
-    
+
     <bean class="org.apereo.portal.utils.cache.resource.TemplatesBuilder">
-        <!-- 
+        <!--
         <property name="transformerAttributes">
             <map>
                 <entry key="generate-translet" value="true" />
@@ -171,58 +171,57 @@
         </property>
          -->
     </bean>
-    
+
     <bean class="org.apereo.portal.utils.cache.resource.CachingResourceLoaderImpl" />
-    
+
     <bean id="testSpelService" class="org.apereo.portal.spring.spel.PortalSpELServiceImpl" />
-    
+
     <bean class="org.apereo.portal.url.PortalRequestUtilsImpl" />
-    
+
     <bean id="org.apereo.portal.utils.cache.resource.CachingResourceLoader" class="org.springframework.cache.ehcache.EhCacheFactoryBean" />
     <bean id="SpELExpressionCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean" />
 
     <bean id="xslPortalUrlProvider" class="org.apereo.portal.url.xml.XsltPortalUrlProvider" />
-    
+
     <bean id="xalanMessageHelper" class="org.apereo.portal.security.xslt.XalanMessageHelper"/>
     <bean id="xalanAuthorizationHelper" class="org.apereo.portal.security.xslt.XalanAuthorizationHelper" />
     <bean id="xalanLayoutElementTitleHelper" class="org.apereo.portal.security.xslt.XalanLayoutElementTitleHelper"/>
     <bean id="xalanRestJsonHelper" class="org.apereo.portal.security.xslt.XalanRestJsonHelper"/>
     <bean id="xalanGroupMembershipHelper" class="org.apereo.portal.security.xslt.XalanGroupMembershipHelper"/>
-    
-    
+
+
     <bean id="userInstanceManager" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.user.IUserInstanceManager" />
     </bean>
-    
+
     <bean id="portalUrlProvider" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.url.IPortalUrlProvider" />
     </bean>
-    
+
     <bean id="portletWindowRegistry" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.portlet.registry.IPortletWindowRegistry" />
     </bean>
-    
+
     <bean id="portletEntityRegistry" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.portlet.registry.IPortletEntityRegistry" />
     </bean>
-    
+
     <bean id="resourcesElementsProvider" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.jasig.resourceserver.utils.aggr.ResourcesElementsProvider" />
     </bean>
-    
+
     <bean id="xalanMessageHelperBean" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.security.xslt.IXalanMessageHelper" />
     </bean>
-    
+
     <bean id="xalanAuthorizationHelperBean" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.security.xslt.IXalanAuthorizationHelper" />
     </bean>
-    
+
     <bean id="xalanGroupMembershipHelperBean" class="org.apereo.portal.spring.MockitoFactoryBean">
         <constructor-arg value="org.apereo.portal.security.xslt.IXalanGroupMembershipHelper" />
     </bean>
-    
-    
+
     <bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
         <property name="alwaysUseMessageFormat" value="true" />
         <property name="cacheSeconds" value="60" />
@@ -232,8 +231,9 @@
             <list>
                 <value>classpath:/properties/i18n/Messages</value>
             </list>
-        </property>                                     
+        </property>
     </bean>
-    
-    
+
+    <bean class="org.apereo.portal.i18n.LocaleManagerFactory" />
+
 </beans>


### PR DESCRIPTION
…n uPortal 5

https://issues.jasig.org/browse/UP-4997

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

The property for configuring locales (portal.properties) is `org.apereo.portal.i18n.LocaleManager.portal_locales`.  It's currently not possible to change the default value in the uP5 way.

In uP5, all properties in portal.properties are obligated to accept configuration in uPortal.properties and/or global.properties.

This property currently ignores that method of configuration.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
