### PR TITLE
fix(grid): ensure the flexgrid styles remain consistent on small screens

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/grids.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/grids.less
@@ -10,6 +10,14 @@
   .fn-set-width-column-for-size(@number-of-columns, sm);
   .fn-set-width-column-for-size(@number-of-columns, md);
   .fn-set-width-column-for-size(@number-of-columns, lg);
+
+  // On smaller than xs screen sizes all content should be full screen
+  @media (max-width: @screen-xs-max) {
+    .up-portlet-wrapper,
+    .fl-reorderer-dropMarker {
+      width: 100%;
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This ensures that on extra extra small screensizes (<480px) all portlets will display at full screen width.
![selection_002](https://user-images.githubusercontent.com/3107513/37170976-a2237b70-22c9-11e8-99d8-b23324455416.png)


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
