### PR TITLE
UP-5005:  AdHocGroupTester uses GroupService.SearchMethod.CONTAINS wh…

### DIFF
--- a/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/AdHocGroupTester.java
+++ b/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/AdHocGroupTester.java
@@ -109,7 +109,7 @@ public final class AdHocGroupTester implements IPersonTester {
                 rslt,
                 person.getUserName(),
                 isNotTest ? "is not" : "is",
-                groupName);
+                entityGroup.getName());
         return rslt;
     }
 
@@ -141,7 +141,7 @@ public final class AdHocGroupTester implements IPersonTester {
     private static IEntityGroup findGroupByName(String groupName) {
         EntityIdentifier[] identifiers =
                 GroupService.searchForGroups(
-                        groupName, GroupService.SearchMethod.CONTAINS, IPerson.class);
+                        groupName, GroupService.SearchMethod.DISCRETE, IPerson.class);
         for (EntityIdentifier entityIdentifier : identifiers) {
             if (entityIdentifier.getType().equals(IEntityGroup.class)) {
                 return GroupService.findGroup(entityIdentifier.getKey());

--- a/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletRequestWrapper.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletRequestWrapper.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.Validate;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apereo.portal.EntityIdentifier;
 import org.apereo.portal.groups.IEntityGroup;
 import org.apereo.portal.groups.IGroupMember;
@@ -37,6 +35,8 @@ import org.apereo.portal.services.GroupService;
 import org.apereo.portal.user.IUserInstance;
 import org.apereo.portal.user.IUserInstanceManager;
 import org.apereo.portal.utils.web.AbstractHttpServletRequestWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Portal wide request wrapper. Provides portal specific information for request parameters,
@@ -56,7 +56,7 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
     public static final String ATTRIBUTE__HTTP_SERVLET_RESPONSE =
             PortalHttpServletRequestWrapper.class.getName() + ".PORTAL_HTTP_SERVLET_RESPONSE";
 
-    protected final Log logger = LogFactory.getLog(this.getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final Map<String, String> additionalHeaders = new LinkedHashMap<>();
     private final HttpServletResponse httpServletResponse;
@@ -248,7 +248,14 @@ public class PortalHttpServletRequestWrapper extends AbstractHttpServletRequestW
         final EntityIdentifier personEntityId = person.getEntityIdentifier();
         final IGroupMember personGroupMember = GroupService.getGroupMember(personEntityId);
 
-        return personGroupMember.isDeepMemberOf(groupForRole);
+        final boolean rslt = personGroupMember.isDeepMemberOf(groupForRole);
+        logger.trace(
+                "Answering {} for isUserInRole where user='{}', role='{}', and groupForRole='{}'",
+                rslt,
+                person.getUserName(),
+                role,
+                groupForRole.getName());
+        return rslt;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
…en it should use GroupService.SearchMethod.DISCRETE

https://issues.jasig.org/browse/UP-5005

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

The AdHocGroupTester is a PAGS tester that evaluates membership in the associated group based on your membership/non-membership in another group.

To perform these tests, it (necessarily) obtains a reference to this other group through the Groups API.  They way it does so is bugged:  it searches for a group that CONTAINS a string (in its name), when it should search for a group that IS a string.

Consider:  'graduate students' vs. 'undergraduate students'

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
