### PR TITLE
UP-5008:  Convert FragmentDefinition.index (which no longer exists, r…

### DIFF
--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/IUserLayoutStore.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/IUserLayoutStore.java
@@ -198,5 +198,5 @@ public interface IUserLayoutStore {
      * Returns a double value indicating the precedence value declared for a fragment. Fragments
      * with greater precedence come before those with lower precedence.
      */
-    double getFragmentPrecedence(int index);
+    double getFragmentPrecedence(long id);
 }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/Constants.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/Constants.java
@@ -53,7 +53,10 @@ public class Constants {
     public static final String LCL_ORIGIN = "origin";
     public static final String ATT_ORIGIN = NS + LCL_ORIGIN;
     public static final String ATT_PRECEDENCE = NS + "precedence";
+
+    /** Represents the fragment's unique, numeric identifier. */
     public static final String ATT_FRAGMENT = NS + "fragment";
+
     public static final String LCL_FRAGMENT_NAME = "fragmentName";
     public static final String ATT_FRAGMENT_NAME = NS + LCL_FRAGMENT_NAME;
     public static final String LCL_IS_TEMPLATE_USER = "isTemplateUser";

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/Evaluator.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/Evaluator.java
@@ -64,6 +64,10 @@ public abstract class Evaluator {
         entityVersion = -1;
     }
 
+    public long getId() {
+        return evaluatorId;
+    }
+
     public abstract boolean isApplicable(IPerson person);
 
     /**

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/FragmentDefinition.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/dlm/FragmentDefinition.java
@@ -66,8 +66,6 @@ public class FragmentDefinition extends EvaluatorGroup {
     @Column(name = "DESCRIPTION")
     private String description;
 
-    /* These variables are bound to a uP userId later in the life cycle, not managed by hibernate */
-    @Transient private int index = 0; // index of definition within config file
     @Transient String defaultLayoutOwnerID = null;
 
     /** No-arg constructor required by JPA/Hibernate. */
@@ -149,14 +147,6 @@ public class FragmentDefinition extends EvaluatorGroup {
 
     public List<Evaluator> getEvaluators() {
         return this.evaluators;
-    }
-
-    public int getIndex() {
-        return index;
-    }
-
-    public void setIndex(int index) {
-        this.index = index;
     }
 
     public boolean isNoAudienceIncluded() {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentActivator.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentActivator.java
@@ -462,7 +462,7 @@ public class FragmentActivator {
         setIdsAndAttribs(
                 layout,
                 layout.getAttribute(Constants.ATT_ID),
-                "" + fragment.getIndex(),
+                "" + fragment.getId(),
                 "" + fragment.getPrecedence());
     }
 

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentComparator.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentComparator.java
@@ -26,12 +26,9 @@ import java.util.Comparator;
  */
 public class FragmentComparator implements Comparator<FragmentDefinition> {
 
-    public int compare(FragmentDefinition obj1, FragmentDefinition obj2) {
-        FragmentDefinition frag1 = (FragmentDefinition) obj1;
-        FragmentDefinition frag2 = (FragmentDefinition) obj2;
-
+    public int compare(FragmentDefinition frag1, FragmentDefinition frag2) {
         if (frag1.getPrecedence() == frag2.getPrecedence()) {
-            return frag1.getIndex() - frag2.getIndex();
+            return (int) (frag1.getId() - frag2.getId());
         } else {
             return (int) (frag2.getPrecedence() - frag1.getPrecedence());
         }

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/Precedence.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/Precedence.java
@@ -20,7 +20,7 @@ import org.apereo.portal.spring.locator.UserLayoutStoreLocator;
 /** @since 2.5 */
 public final class Precedence {
     private double precedence = 0.0;
-    private int index = -1;
+    private long fragmentId = -1;
     private static Precedence userPrecedence = new Precedence();
 
     private Precedence() {}
@@ -31,13 +31,13 @@ public final class Precedence {
     }
 
     public String toString() {
-        return "p[" + precedence + ", " + index + "]";
+        return "p[" + precedence + ", " + fragmentId + "]";
     }
 
-    private Precedence(String fragmentIdx) {
-        int fragmentIndex = 0;
+    private Precedence(String fragmentId) {
+        long id;
         try {
-            fragmentIndex = Integer.parseInt(fragmentIdx);
+            id = Long.parseLong(fragmentId);
         } catch (Exception e) {
             // if unparsable default to lowest priority.
             return;
@@ -45,21 +45,20 @@ public final class Precedence {
 
         final IUserLayoutStore dls = UserLayoutStoreLocator.getUserLayoutStore();
 
-        this.precedence = dls.getFragmentPrecedence(fragmentIndex);
-        this.index = fragmentIndex;
+        this.precedence = dls.getFragmentPrecedence(id);
+        this.fragmentId = id;
     }
 
     /**
      * Returns true of this complete precedence is less than the complete precedence of the passed
-     * in Precedence object. The complete precedence takes into account the location in the
-     * configuration file of the fragment definition. If the "precedence" value is equal then the
-     * precedence object with the lowest index has the higher complete precedence. And index of -1
-     * indicates the highest index in the file.
+     * in Precedence object. The complete precedence takes into account the Id of the fragment
+     * definition (so that no two fragments may have exactly the same precedence). If the
+     * "precedence" value is equal then the precedence object with the lowest fragmentId has the
+     * higher complete precedence.
      */
     public boolean isLessThan(Precedence p) {
         if (this.precedence < p.precedence
-                || (this.precedence == p.precedence
-                        && (this.index == -1 && p.index > -1 || this.index > p.index))) return true;
+                || (this.precedence == p.precedence && this.fragmentId > p.fragmentId)) return true;
         return false;
     }
 

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
@@ -318,21 +318,18 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
     }
 
     @Override
-    public double getFragmentPrecedence(int index) {
+    public double getFragmentPrecedence(long id) {
         final List<FragmentDefinition> definitions = this.fragmentUtils.getFragmentDefinitions();
-        if (index < 0 || index > definitions.size() - 1) {
-            return 0;
-        }
 
         // must pass through the array looking for the fragment with this
         // index since the array was sorted by precedence and then index
         // within precedence.
         for (final FragmentDefinition fragmentDefinition : definitions) {
-            if (fragmentDefinition.getIndex() == index) {
+            if (fragmentDefinition.getId() == id) {
                 return fragmentDefinition.getPrecedence();
             }
         }
-        return 0; // should never get here.
+        return 0D; // should never get here.
     }
 
     /**

--- a/uPortal-marketplace/src/main/java/org/apereo/portal/portlet/marketplace/MarketplacePortletDefinition.java
+++ b/uPortal-marketplace/src/main/java/org/apereo/portal/portlet/marketplace/MarketplacePortletDefinition.java
@@ -307,7 +307,9 @@ public class MarketplacePortletDefinition implements IPortletDefinition {
     }
 
     /**
-     * @return a set of categories that this portlet directly belongs too. Will not traverse up the
+     * Provides the categories this portlet is a member of. Used in the JSP for Portlet Marketplace.
+     *
+     * @return a set of categories that this portlet directly belongs to. Will not traverse up the
      *     category tree and return grandparent categories and farther. Will not return null. Might
      *     return empty set.
      */
@@ -319,6 +321,9 @@ public class MarketplacePortletDefinition implements IPortletDefinition {
     }
 
     /**
+     * Provides a collection of portlets related to this one. Used in the JSP for Portlet
+     * Marketplace.
+     *
      * @return a set of portlets that include all portlets in this portlets immediate categories and
      *     children categories Will not return null. Will not include self in list. Might return an
      *     empty set.


### PR DESCRIPTION
…eally) to FragmentDefinition.id

https://issues.jasig.org/browse/UP-5008

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Pre-JPA DLM used to track the 'index' of a FragmentDefinition – meaning the position of the fragment within the XML config file.  In modern DLM the file is gone, but the field is still there (and it always has a value of 0).

This discrepancy doesn't seem to have a significant negative impact on the portal, but should be cleaned up.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
