### PR TITLE
docs-fr(glossary & i18n) Add i18n and glossary in french doc

### DIFF
--- a/docs/fr/GLOSSAIRE.md
+++ b/docs/fr/GLOSSAIRE.md
@@ -1,0 +1,18 @@
+# Glossaire
+
+<dl>
+  <dt>
+    Portlet
+  </dt>
+  <dd>
+    Les portlets sont des composants logiciels d'interface utilisateur pluggables qui sont gérés et affichés dans un portail Web.
+    uPortal utilise la [spécification des portlet JSR 168 and JSR 286](https://en.wikipedia.org/wiki/Java_Portlet_Specification).
+  </dd>
+
+  <dt>
+    Soffit
+  </dt>
+  <dd>
+    Soffit est une technologie pour créer du contenu fonctionnant dans Apereo uPortal. Elle est conçue comme une alternative au développement de portlet JSR-286. Soffit est une stratégie pour ajouter du contenu à uPortal. Elle définit et gère la relation entre les objets de contenu (soffits) et le service du portail lui-même.
+  </dd>
+ </dl>

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -186,13 +186,14 @@ ci-après.
 
 ## Sections
 
-* [Build / Déployer uPortal](monter-et-deployer-uportal.md)
-* [Implémenter uPortal](implementer/README.md)
-* [Administration Système d'uPortal](sysadmin/README.md)
-* [Guide du développeur](developper/README.md)
-* [Navigateurs Web supportés](NAVIGATEURS_SUPPORTES.md)
-* [Accessibilité](ACCESSIBILITE.md)
-* [Contributeurs au projet](COMMITTERS.md)
+1.  [Build / Déployer uPortal](monter-et-deployer-uportal.md)
+2.  [Implémenter uPortal](implementer/README.md)
+3.  [Administration Système d'uPortal](sysadmin/README.md)
+4.  [Guide du développeur](developper/README.md)
+5.  [Navigateurs Web supportés](NAVIGATEURS_SUPPORTES.md)
+6.  [Accessibilité](ACCESSIBILITE.md)
+7.  [Contributeurs au projet](COMMITTERS.md)
+8.  [Glossaire](GLOSSAIRE.md)
 
 ## Liens externes
 

--- a/docs/fr/implementer/README.md
+++ b/docs/fr/implementer/README.md
@@ -3,10 +3,12 @@
 Cette section couvre les sujets liés à la mise en œuvre du portail : l'ajout d'
 utilisateurs, de groupes, sa mises en page, *etc.*
 
-1. [Authentification](authentification/README.md)
-2. [Attributs utilisateur](user-attributes/README.md)
-3. Groupes et autorisations (à déterminer)
-4. Gestion de la mise en page (à déterminer)
-5. Contenu (à déterminer)
-6. [Frontend](frontend/README.md)
-7. [Sécurité](securite.md)
+1. Sous-systèmes principaux du noyau
+    1. [Authentification](authentification/README.md)
+    2. [Attributs utilisateur](user-attributes/README.md)
+    3. Groupes et autorisations (à déterminer)
+    4. Gestion de la mise en page (à déterminer)
+    5. Contenu (à déterminer)
+2. [Frontend](frontend/README.md)
+3. [Sécurité](securite.md)
+4. [Internationalisation](i18n.md)

--- a/docs/fr/implementer/i18n.md
+++ b/docs/fr/implementer/i18n.md
@@ -1,0 +1,28 @@
+# Internationalisation
+
+uPortal fournit des fonctionnalités d'internationalisation. Il y a trois aspects dans l'implementation 
+du support d'une autre langage dans le portail : les _MessageSource_ du portail (en Spring), _les données d'uPortal (uPortal Data)_ et _les modules de contenus (Content Modules)_.
+
+## uPortal MessageSource
+
+uPortal prend en charge l'internationalisation des chaînes de caractères de l'interface utilisateur via une source spring `MessageSource`.
+uPortal est livré avec plusieurs langues disponibles, mais vous pouvez ajouter les vôtres (ou mettre à jour une existante) en ajoutant un fichier `Messages_{code}.properties` dans le chemin de classe dans `/properties/i18n/`où {code} est le code de pays (par exemple «fr» pour le français et «de» pour l'allemand).
+
+Utiliser la propriété `org.apereo.portal.i18n.LocaleManager.portal_locales` pour definir les langues disponibles dans le portail. Ajouter cette propriété soit dans `uPortal.properties`, soit dans `global.properties`.
+
+### Exemple de localisation du portail
+
+```properties
+org.apereo.portal.i18n.LocaleManager.portal_locales=fr_FR
+```
+
+Cette valeur limitera le portail au _français_. 
+Vous pouvez en ajouter plusieurs en les séparant par une virgule.
+
+## uPortal Data
+
+_à faire_
+
+## Content Modules
+
+_à faire_


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [x] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Provide the french translation of the glossary and i18n docs.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
