### PR TITLE
docs: add direct links to uPortal 5.0 and 5.1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ detailed documentation for each uPortal release.
 
 Additional information about uPortal is available in the Manual.
 
-* [uPortal 5.0 Manual](https://jasig.github.io/uPortal)
+* [uPortal 5.1 Manual](https://jasig.github.io/uPortal)
+* [uPortal 5.0 Manual](https://github.com/Jasig/uPortal/tree/v5.0.6/docs)
 * [uPortal 4.3 Manual](https://wiki.jasig.org/display/UPM43/Home)
 * [uPortal 4.2 Manual](https://wiki.jasig.org/display/UPM42/Home)
 * [uPortal 4.1 Manual](https://wiki.jasig.org/display/UPM41/Home)

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,6 +195,7 @@ below.
 
 ## Documentation for Previous Releases
 
+*   [uPortal 5.0 Manual](https://github.com/Jasig/uPortal/tree/v5.0.6/docs)
 *   [uPortal 4.3](https://wiki.jasig.org/display/UPM43/Home)
 *   [uPortal 4.2](https://wiki.jasig.org/display/UPM42/Home)
 *   [uPortal 4.1](https://wiki.jasig.org/display/UPM41/Home)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds direct link to view uPortal 5.0 manual, updates link for latest manual to clarify it is uPortal 5.1

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
