### PR TITLE
UP-5011:  Provide a mechanism for configuring which Soffit data model…

### DIFF
--- a/docs/developer/soffits/soffit_data_model.md
+++ b/docs/developer/soffits/soffit_data_model.md
@@ -15,6 +15,26 @@ are (currently) four objects in this data model:
   portal;  these are settings defined by and consumed by the portal itself, like
   _title_ and _chrome style_
 
+## Sharing Data Model Objects with a Soffit
+
+These objects can be shared by the portal with a soffit on each request, but
+<strong>none of them will be sent automatically</strong>.  Under the hood, data
+model objects are sent to soffits as Jason Web Tokens (JWTs) using HTTP headers.
+Web servers place limits (usually configurable) on the size of the header area
+for inbound and outbound requests.  The more data model elements sent, the
+greater the risk of exceeding this limit.  In typical cases sending all four
+elements is somewhat risky;  sending fewer (1, 2, or 3) should be safe.
+
+You can instruct uPortal to send each data model object using a dedicated
+<em>portlet preference</em> in the publishing record (metadata) of each soffit.
+The default value of each preference is <code>false</code>;  set it to
+<code>true</code> to send the element.
+
+* <code>Bearer</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includeAuthorization</code>
+* <code>PortalRequest</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includePortalRequest</code>
+* <code>Preferences</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includePreferences</code>
+* <code>Definition</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includeDefinition</code>
+
 ## Accessing Data Model Objects in a JSP
 
 Each of these objects is defined within the Expression Language (EL) Context in

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/AuthorizationHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/AuthorizationHeaderProvider.java
@@ -31,6 +31,7 @@ import org.apereo.portal.groups.IGroupMember;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.services.GroupService;
 import org.apereo.portal.soffit.connector.AbstractHeaderProvider;
+import org.apereo.portal.soffit.connector.SoffitConnectorController;
 import org.apereo.portal.soffit.model.v1_0.Bearer;
 import org.apereo.portal.soffit.service.BearerService;
 import org.apereo.services.persondir.IPersonAttributeDao;
@@ -45,12 +46,20 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class AuthorizationHeaderProvider extends AbstractHeaderProvider {
 
+    public static final String INCLUDE_PREFERENCE =
+            SoffitConnectorController.class.getName() + ".includeAuthorization";
+
     @Autowired private IPersonAttributeDao personAttributeDao;
 
     @Autowired private BearerService bearerService;
 
     @Override
     public Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse) {
+
+        // Include?
+        if (!isIncluded(renderRequest, INCLUDE_PREFERENCE)) {
+            return null;
+        }
 
         // Username
         final String username = getUsername(renderRequest);

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/DefinitionHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/DefinitionHeaderProvider.java
@@ -40,6 +40,7 @@ import org.apereo.portal.portlet.registry.IPortletWindowRegistry;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.soffit.connector.AbstractHeaderProvider;
+import org.apereo.portal.soffit.connector.SoffitConnectorController;
 import org.apereo.portal.soffit.model.v1_0.Definition;
 import org.apereo.portal.soffit.service.DefinitionService;
 import org.apereo.portal.url.IPortalRequestUtils;
@@ -52,6 +53,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @since 5.0
  */
 public class DefinitionHeaderProvider extends AbstractHeaderProvider {
+
+    public static final String INCLUDE_PREFERENCE =
+            SoffitConnectorController.class.getName() + ".includeDefinition";
 
     @Autowired private IPortalRequestUtils portalRequestUtils;
 
@@ -69,6 +73,11 @@ public class DefinitionHeaderProvider extends AbstractHeaderProvider {
 
     @Override
     public Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse) {
+
+        // Include?
+        if (!isIncluded(renderRequest, INCLUDE_PREFERENCE)) {
+            return null;
+        }
 
         // Username
         final String username = getUsername(renderRequest);

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/AbstractHeaderProvider.java
@@ -15,6 +15,7 @@
 package org.apereo.portal.soffit.connector;
 
 import java.util.Date;
+import javax.portlet.PortletPreferences;
 import javax.portlet.PortletSession;
 import javax.portlet.RenderRequest;
 import org.slf4j.Logger;
@@ -28,6 +29,12 @@ public abstract class AbstractHeaderProvider implements IHeaderProvider {
     private String guestUserName;
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected final boolean isIncluded(RenderRequest renderRequest, String preferenceName) {
+        final PortletPreferences preferences = renderRequest.getPreferences();
+        final String rslt = preferences.getValue(preferenceName, Boolean.FALSE.toString());
+        return Boolean.valueOf(rslt);
+    }
 
     protected final String getUsername(RenderRequest renderRequest) {
         final String rslt =

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/IHeaderProvider.java
@@ -26,5 +26,13 @@ import org.apache.http.Header;
  */
 public interface IHeaderProvider {
 
+    /**
+     * Prepares an appropriate HTTP header for inclusion in the outbound request to the remote
+     * soffit. May return <code>null</code>, in which case the header should be ignored.
+     *
+     * @param renderRequest The current <code>RenderRequest</code>
+     * @param renderResponse The current <code>RenderResponse</code>
+     * @return Ann appropriate HTTP header or <code>null</code>
+     */
     Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse);
 }

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PortalRequestHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PortalRequestHeaderProvider.java
@@ -32,12 +32,19 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class PortalRequestHeaderProvider extends AbstractHeaderProvider {
 
+    public static final String INCLUDE_PREFERENCE =
+            SoffitConnectorController.class.getName() + ".includePortalRequest";
     public static final String NAMESPACE_PREFIX = "n_";
 
     @Autowired private PortalRequestService portalRequestService;
 
     @Override
     public Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse) {
+
+        // Include?
+        if (!isIncluded(renderRequest, INCLUDE_PREFERENCE)) {
+            return null;
+        }
 
         // Username
         final String username = getUsername(renderRequest);
@@ -84,7 +91,7 @@ public class PortalRequestHeaderProvider extends AbstractHeaderProvider {
             parameters.put(y.getKey(), Arrays.asList(y.getValue()));
         }
 
-        // Preferences header
+        // PortalRequest header
         final PortalRequest portalRequest =
                 portalRequestService.createPortalRequest(
                         properties, attributes, parameters, username, getExpiration(renderRequest));

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PreferencesHeaderProvider.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/PreferencesHeaderProvider.java
@@ -35,10 +35,18 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class PreferencesHeaderProvider extends AbstractHeaderProvider {
 
+    public static final String INCLUDE_PREFERENCE =
+            SoffitConnectorController.class.getName() + ".includePreferences";
+
     @Autowired private PreferencesService preferencesService;
 
     @Override
     public Header createHeader(RenderRequest renderRequest, RenderResponse renderResponse) {
+
+        // Include?
+        if (!isIncluded(renderRequest, INCLUDE_PREFERENCE)) {
+            return null;
+        }
 
         // Username
         final String username = getUsername(renderRequest);

--- a/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
+++ b/uPortal-soffit/uPortal-soffit-connector/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
@@ -139,7 +139,9 @@ public class SoffitConnectorController implements ApplicationContextAware {
                 // Send the data model as encrypted JWT HTTP headers
                 for (IHeaderProvider headerProvider : headerProviders) {
                     final Header header = headerProvider.createHeader(req, res);
-                    getMethod.addHeader(header);
+                    if (header != null) {
+                        getMethod.addHeader(header);
+                    }
                 }
 
                 // Send the request

--- a/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
+++ b/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
@@ -41,6 +41,18 @@ public class Bearer extends AbstractTokenizable {
         this.groups = Collections.unmodifiableList(groups);
     }
 
+    /**
+     * Supports proxying a missing data model element.
+     *
+     * @since 5.1
+     */
+    protected Bearer() {
+        super(null);
+        this.username = null;
+        this.attributes = null;
+        this.groups = null;
+    }
+
     public String getUsername() {
         return username;
     }

--- a/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
+++ b/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
@@ -48,6 +48,20 @@ public class Definition extends AbstractTokenizable {
         this.parameters = Collections.unmodifiableMap(parameters);
     }
 
+    /**
+     * Supports proxying a missing data model element.
+     *
+     * @since 5.1
+     */
+    protected Definition() {
+        super(null);
+        this.title = null;
+        this.fname = null;
+        this.description = null;
+        this.categories = null;
+        this.parameters = null;
+    }
+
     public String getTitle() {
         return title;
     }

--- a/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
+++ b/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
@@ -89,7 +89,7 @@ public class PortalRequest extends AbstractTokenizable {
 
         private final String name;
 
-        private Attributes(String name) {
+        Attributes(String name) {
             this.name = name;
         }
 
@@ -111,6 +111,18 @@ public class PortalRequest extends AbstractTokenizable {
         this.properties = Collections.unmodifiableMap(properties);
         this.attributes = Collections.unmodifiableMap(attributes);
         this.parameters = Collections.unmodifiableMap(parameters);
+    }
+
+    /**
+     * Supports proxying a missing data model element.
+     *
+     * @since 5.1
+     */
+    protected PortalRequest() {
+        super(null);
+        this.properties = null;
+        this.attributes = null;
+        this.parameters = null;
     }
 
     /**

--- a/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
+++ b/uPortal-soffit/uPortal-soffit-core/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
@@ -34,6 +34,16 @@ public class Preferences extends AbstractTokenizable {
         this.preferencesMap = Collections.unmodifiableMap(preferencesMap);
     }
 
+    /**
+     * Supports proxying a missing data model element.
+     *
+     * @since 5.1
+     */
+    protected Preferences() {
+        super(null);
+        this.preferencesMap = null;
+    }
+
     public List<String> getValues(String name) {
         return preferencesMap.get(name);
     }

--- a/uPortal-soffit/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/MissingModelElement.java
+++ b/uPortal-soffit/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/MissingModelElement.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.soffit.renderer;
+
+import java.util.List;
+import java.util.Map;
+import org.apereo.portal.soffit.model.v1_0.Bearer;
+import org.apereo.portal.soffit.model.v1_0.Definition;
+import org.apereo.portal.soffit.model.v1_0.PortalRequest;
+import org.apereo.portal.soffit.model.v1_0.Preferences;
+
+/**
+ * Used in the place of a missing element from the Soffit data model. Throws an appropriate {@link
+ * MissingModelElementException} if any method is called.
+ *
+ * @since 5.1
+ */
+public class MissingModelElement {
+
+    public static final PortalRequest PORTAL_REQUEST =
+            new PortalRequest() {
+                @Override
+                public Map<String, String> getProperties() {
+                    throw new MissingModelElementException(PortalRequest.class);
+                }
+
+                @Override
+                public Map<String, List<String>> getAttributes() {
+                    throw new MissingModelElementException(PortalRequest.class);
+                }
+
+                @Override
+                public Map<String, List<String>> getParameters() {
+                    throw new MissingModelElementException(PortalRequest.class);
+                }
+
+                @Override
+                public String getEncryptedToken() {
+                    throw new MissingModelElementException(PortalRequest.class);
+                }
+            };
+
+    // Bearer
+    public static final Bearer BEARER =
+            new Bearer() {
+                @Override
+                public String getUsername() {
+                    throw new MissingModelElementException(Bearer.class);
+                }
+
+                @Override
+                public Map<String, List<String>> getAttributes() {
+                    throw new MissingModelElementException(Bearer.class);
+                }
+
+                @Override
+                public List<String> getGroups() {
+                    throw new MissingModelElementException(Bearer.class);
+                }
+
+                @Override
+                public String getEncryptedToken() {
+                    throw new MissingModelElementException(Bearer.class);
+                }
+            };
+
+    // Preferences
+    public static final Preferences PREFERENCES =
+            new Preferences() {
+                @Override
+                public List<String> getValues(String name) {
+                    throw new MissingModelElementException(Preferences.class);
+                }
+
+                @Override
+                public Map<String, List<String>> getPreferencesMap() {
+                    throw new MissingModelElementException(Preferences.class);
+                }
+
+                @Override
+                public String getEncryptedToken() {
+                    throw new MissingModelElementException(Preferences.class);
+                }
+            };
+
+    // Definition
+    public static final Definition DEFINITION =
+            new Definition() {
+                @Override
+                public String getTitle() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+
+                @Override
+                public String getFname() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+
+                @Override
+                public String getDescription() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+
+                @Override
+                public List<String> getCategories() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+
+                @Override
+                public Map<String, List<String>> getParameters() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+
+                @Override
+                public String getEncryptedToken() {
+                    throw new MissingModelElementException(Definition.class);
+                }
+            };
+}

--- a/uPortal-soffit/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/MissingModelElementException.java
+++ b/uPortal-soffit/uPortal-soffit-renderer/src/main/java/org/apereo/portal/soffit/renderer/MissingModelElementException.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.soffit.renderer;
+
+import org.apereo.portal.soffit.ITokenizable;
+
+/**
+ * Thrown when a Soffit attempts to use a data model element that is not present in the request from
+ * the <code>SoffitConnectorController</code>. Desired model attributes must be listed in the
+ * portlet publication record.
+ *
+ * @since 5.1
+ */
+public class MissingModelElementException extends RuntimeException {
+
+    public MissingModelElementException(Class<? extends ITokenizable> attributeClass) {
+        super(
+                "Soffit data model attribute requested but missing from the request header: "
+                        + attributeClass.getSimpleName());
+    }
+}

--- a/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -1075,7 +1075,6 @@
             <preference>
                 <name>enabled</name>
                 <value>true</value>
-                <read-only>false</read-only>
             </preference>
             <preference>
                 <!-- The session timeout warning will start displaying this many seconds before
@@ -1085,19 +1084,16 @@
                 -->
                 <name>dialogDisplaySeconds</name>
                 <value>60</value>
-                <read-only>false</read-only>
             </preference>
             <preference>
                 <!-- This URL is relative to the root of the uPortal instance -->
                 <name>resetSessionURLFragment</name>
                 <value>/api/ajax-success</value>
-                <read-only>false</read-only>
             </preference>
             <preference>
                 <!-- This URL is relative to the root of the uPortal instance -->
                 <name>logoutURLFragment</name>
                 <value>/Logout</value>
-                <read-only>false</read-only>
             </preference>
         </portlet-preferences>
 
@@ -1130,6 +1126,28 @@
             <preference>
                 <!-- This preference identifies the remote service -->
                 <name>org.apereo.portal.soffit.connector.SoffitConnectorController.serviceUrl</name>
+            </preference>
+            <!--
+             | The following preferences control which elements of the data model (HTTP headers)
+             | will be sent to the remote service.  Sending all of them always runs the risk of
+             | exceeding the maximum allowable header size.  For example, the default
+             | maxHttpHeaderSize in Tomcat 8 is 8192 bytes (8 KB).
+             +-->
+            <preference>
+                <name>org.apereo.portal.soffit.connector.SoffitConnectorController.includeAuthorization</name>
+                <value>false</value>
+            </preference>
+            <preference>
+                <name>org.apereo.portal.soffit.connector.SoffitConnectorController.includeDefinition</name>
+                <value>false</value>
+            </preference>
+            <preference>
+                <name>org.apereo.portal.soffit.connector.SoffitConnectorController.includePortalRequest</name>
+                <value>false</value>
+            </preference>
+            <preference>
+                <name>org.apereo.portal.soffit.connector.SoffitConnectorController.includePreferences</name>
+                <value>false</value>
             </preference>
         </portlet-preferences>
     </portlet>


### PR DESCRIPTION
… elements are included in the request;  include none of them by default

https://issues.jasig.org/browse/UP-5011

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ ] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][]
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

## Sharing Data Model Objects with a Soffit

These objects can be shared by the portal with a soffit on each request, but
<strong>none of them will be sent automatically</strong>.  Under the hood, data
model objects are sent to soffits as Jason Web Tokens (JWTs) using HTTP headers.
Web servers place limits (usually configurable) on the size of the header area
for inbound and outbound requests.  The more data model elements sent, the
greater the risk of exceeding this limit.  In typical cases sending all four
elements is somewhat risky;  sending fewer (1, 2, or 3) should be safe.

You can instruct uPortal to send each data model object using a dedicated
<em>portlet preference</em> in the publishing record (metadata) of each soffit.
The default value of each preference is <code>false</code>;  set it to
<code>true</code> to send the element.

* <code>Bearer</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includeAuthorization</code>
* <code>PortalRequest</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includePortalRequest</code>
* <code>Preferences</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includePreferences</code>
* <code>Definition</code>:  <code>org.apereo.portal.soffit.connector.SoffitConnectorController.includeDefinition</code>

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
