### PR TITLE
docs: designate 3 Committers as emeriti

### DIFF
--- a/docs/COMMITTERS.md
+++ b/docs/COMMITTERS.md
@@ -10,7 +10,6 @@
  - Daniel McCallum (dmccallum)
  - Drew Wills (drewwills)
  - James Wennmacher (jameswennmacher)
- - Jeff Cross (jeffbcross)
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
@@ -23,6 +22,7 @@
 ## Committers Emeriti
 
  - Eric Dalquist (edalquist)
+ - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
 
 ## What's a Committer?

--- a/docs/COMMITTERS.md
+++ b/docs/COMMITTERS.md
@@ -9,7 +9,6 @@
  - Christian Murphy (ChristianMurphy)
  - Daniel McCallum (dmccallum)
  - Drew Wills (drewwills)
- - James Wennmacher (jameswennmacher)
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
@@ -22,6 +21,7 @@
 ## Committers Emeriti
 
  - Eric Dalquist (edalquist)
+ - James Wennmacher (jameswennmacher)
  - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
 

--- a/docs/COMMITTERS.md
+++ b/docs/COMMITTERS.md
@@ -12,7 +12,6 @@
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
- - Nicholas Blair (nblair)
  - Paul Spaude (pspaude)
  - Tim Levett (timlevett)
  - Timothy A Vertein (vertein)
@@ -24,6 +23,7 @@
  - James Wennmacher (jameswennmacher)
  - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
+ - Nicholas Blair (nblair)
 
 ## What's a Committer?
 

--- a/docs/COMMITTERS.md
+++ b/docs/COMMITTERS.md
@@ -20,7 +20,7 @@
  - Timothy A Vertein (vertein)
  - William G. Thompson, Jr. (wgthom)
 
-## Committers Emeritus
+## Committers Emeriti
 
  - Eric Dalquist (edalquist)
  - Jen Bourey (bourey)

--- a/docs/fr/COMMITTERS.md
+++ b/docs/fr/COMMITTERS.md
@@ -9,7 +9,6 @@
  - Christian Murphy (ChristianMurphy)
  - Daniel McCallum (dmccallum)
  - Drew Wills (drewwills)
- - James Wennmacher (jameswennmacher)
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
@@ -22,6 +21,7 @@
 ## Committers Emeriti
 
  - Eric Dalquist (edalquist)
+ - James Wennmacher (jameswennmacher)
  - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
 

--- a/docs/fr/COMMITTERS.md
+++ b/docs/fr/COMMITTERS.md
@@ -10,7 +10,6 @@
  - Daniel McCallum (dmccallum)
  - Drew Wills (drewwills)
  - James Wennmacher (jameswennmacher)
- - Jeff Cross (jeffbcross)
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
@@ -23,6 +22,7 @@
 ## Committers Emeriti
 
  - Eric Dalquist (edalquist)
+ - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
 
 ## Qu'est-ce qu'un Committers ?

--- a/docs/fr/COMMITTERS.md
+++ b/docs/fr/COMMITTERS.md
@@ -12,7 +12,6 @@
  - [Jim Helwig] (jimhelwig)
  - Josh Helmer (jhelmer-unicon)
  - Misagh Moayyed (mmoayyed)
- - Nicholas Blair (nblair)
  - Paul Spaude (pspaude)
  - Tim Levett (timlevett)
  - Timothy A Vertein (vertein)
@@ -24,6 +23,7 @@
  - James Wennmacher (jameswennmacher)
  - Jeff Cross (jeffbcross)
  - Jen Bourey (bourey)
+ - Nicholas Blair (nblair)
 
 ## Qu'est-ce qu'un Committers ?
 

--- a/docs/fr/COMMITTERS.md
+++ b/docs/fr/COMMITTERS.md
@@ -20,7 +20,7 @@
  - Timothy A Vertein (vertein)
  - William G. Thompson, Jr. (wgthom)
 
-## Committers Emeritus
+## Committers Emeriti
 
  - Eric Dalquist (edalquist)
  - Jen Bourey (bourey)


### PR DESCRIPTION
uPortal committers [approved this change via up-dev@ vote](https://groups.google.com/a/apereo.org/d/msg/uportal-dev/rkz6aEinw2U/393aldVbAQAJ).

Bumps 3 very inactive committers 

+ Nicholas Blair
+ Jeff Cross
+ James Wennmacher

to committer emeriti status, after a very long foreshadowing of this proposal and Committer vote.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] documentation is updated, in both English and French

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
