### PR TITLE
UP-5014 - Moving dialects into specifics submodule to avoid dependency problems

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -52,5 +52,8 @@ include 'uPortal-soffit:uPortal-soffit-core'
 include 'uPortal-soffit:uPortal-soffit-connector'
 include 'uPortal-soffit:uPortal-soffit-renderer'
 
+include 'uPortal-hibernate:uPortal-hibernate3-dialects'
+include 'uPortal-hibernate:uPortal-hibernate4-dialects'
+
 include 'uPortal-utils:uPortal-utils-core'
 include 'uPortal-utils:uPortal-utils-jmx'

--- a/uPortal-hibernate/uPortal-hibernate3-dialects/build.gradle
+++ b/uPortal-hibernate/uPortal-hibernate3-dialects/build.gradle
@@ -1,0 +1,37 @@
+description = "Apereo uPortal Usefull Dialects for hibernate 3"
+
+ext {
+    // Solution for JPA Modelgen based on http://stackoverflow.com/a/23218255/1651116
+    generatedSourcesDir = file("${buildDir}/generated-sources/javac/main/java")
+}
+
+dependencies {
+    compileOnly ('org.hibernate:hibernate:3.2.+') {
+        transitive=false
+    }
+}
+
+/*
+ * This section is the key to IDE integration.  IDE will look for source files in both...
+ *
+ *   - src/main/java
+ *   - build/generated-sources/javac/main/java
+ */
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+            srcDir generatedSourcesDir
+        }
+    }
+}
+
+// These are the only modifications to build process that are required.
+compileJava {
+    doFirst {
+        // Generated sources directory should be present & empty before compilation
+        generatedSourcesDir.deleteDir()
+        generatedSourcesDir.mkdirs()
+    }
+    options.compilerArgs += ['-s', generatedSourcesDir]
+}

--- a/uPortal-hibernate/uPortal-hibernate3-dialects/src/main/java/org/apereo/portal/utils/hibernate3/dialects/MySQL5InnoDBCompressedDialect.java
+++ b/uPortal-hibernate/uPortal-hibernate3-dialects/src/main/java/org/apereo/portal/utils/hibernate3/dialects/MySQL5InnoDBCompressedDialect.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.utils.hibernate3.dialects;
+
+import org.hibernate.dialect.MySQL5InnoDBDialect;
+
+/** Uses the COMPRESSED row format in an InnoDB engine, needed for long index support with UTF-8 */
+public class MySQL5InnoDBCompressedDialect extends MySQL5InnoDBDialect {
+
+    public MySQL5InnoDBCompressedDialect() {
+        super();
+    }
+
+    @Override
+    public String getTableTypeString() {
+        return super.getTableTypeString() + " ROW_FORMAT=COMPRESSED";
+    }
+}

--- a/uPortal-hibernate/uPortal-hibernate3-dialects/src/main/java/org/apereo/portal/utils/hibernate3/dialects/PostgreSQL81Dialect.java
+++ b/uPortal-hibernate/uPortal-hibernate3-dialects/src/main/java/org/apereo/portal/utils/hibernate3/dialects/PostgreSQL81Dialect.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.utils.hibernate3.dialects;
+
+import org.hibernate.dialect.PostgreSQLDialect;
+
+/** */
+public class PostgreSQL81Dialect extends PostgreSQLDialect {
+    @Override
+    public boolean supportsIfExistsBeforeTableName() {
+        return false;
+    }
+}

--- a/uPortal-hibernate/uPortal-hibernate4-dialects/build.gradle
+++ b/uPortal-hibernate/uPortal-hibernate4-dialects/build.gradle
@@ -1,0 +1,20 @@
+description = "Apereo uPortal Usefull Dialects for hibernate 4"
+
+
+dependencies {
+    compileOnly 'org.hibernate:hibernate-core:4.2.+'
+    compileOnly "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
+}
+
+/*
+ * This section is the key to IDE integration.  IDE will look for source files in both...
+ *
+ *   - src/main/java
+ */
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+        }
+    }
+}

--- a/uPortal-hibernate/uPortal-hibernate4-dialects/src/main/java/org/apereo/portal/utils/hibernate4/dialects/MySQL5InnoDBCompressedDialect.java
+++ b/uPortal-hibernate/uPortal-hibernate4-dialects/src/main/java/org/apereo/portal/utils/hibernate4/dialects/MySQL5InnoDBCompressedDialect.java
@@ -12,7 +12,7 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apereo.portal.utils;
+package org.apereo.portal.utils.hibernate4.dialects;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -36,7 +36,7 @@ public class MySQL5InnoDBCompressedDialect extends MySQL5InnoDBDialect {
 
     @Override
     public String getTableTypeString() {
-        return " ENGINE=InnoDB ROW_FORMAT=COMPRESSED";
+        return super.getTableTypeString() + " ROW_FORMAT=COMPRESSED";
     }
 
     @Override

--- a/uPortal-hibernate/uPortal-hibernate4-dialects/src/main/java/org/apereo/portal/utils/hibernate4/dialects/PostgreSQL81Dialect.java
+++ b/uPortal-hibernate/uPortal-hibernate4-dialects/src/main/java/org/apereo/portal/utils/hibernate4/dialects/PostgreSQL81Dialect.java
@@ -12,11 +12,11 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apereo.portal.utils;
+package org.apereo.portal.utils.hibernate4.dialects;
 
 import org.hibernate.dialect.PostgreSQLDialect;
 
-/** */
+/** Specific Dialect for PostgreSQL 8.1 */
 public class PostgreSQL81Dialect extends PostgreSQLDialect {
     @Override
     public boolean supportsIfExistsBeforeTableName() {

--- a/uPortal-utils/uPortal-utils-core/build.gradle
+++ b/uPortal-utils/uPortal-utils-core/build.gradle
@@ -7,6 +7,7 @@ ext {
 
 dependencies {
     compile project(':uPortal-concurrency')
+    compile project(':uPortal-hibernate:uPortal-hibernate4-dialects')
 
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"

--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/PortalDialectResolver.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/PortalDialectResolver.java
@@ -16,6 +16,8 @@ package org.apereo.portal.utils;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import org.apereo.portal.utils.hibernate4.dialects.MySQL5InnoDBCompressedDialect;
+import org.apereo.portal.utils.hibernate4.dialects.PostgreSQL81Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 import org.hibernate.service.jdbc.dialect.internal.AbstractDialectResolver;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

I moved into 2 submodules the dialects, one module is for portlets having hibernate 3.2 as dependency, and the second is for uPortal and portlets with hibernate 4.x dependency. (the documentation about the use will be documented into uPortal-start).

I needed these two different dependencies because hibernate 3 doesn't manage and import same needs/feature, so i removed a part. (After testing i didn't find any problems).

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
