### PR TITLE
docs(badges): characterize code style as "AOSP" rather than "Google"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,9 @@ For a more in-depth description of the git workflow check out the
 
 uPortal uses [Android Open Source Project (AOSP) Java code style][AOSP Java style].
 
+[You can][google-java-format-gradle-plugin_quickstart] check Java style with `./gradlew verGJF`,
+and format Java files with `./gradlew goJF`.
+
 ## Collaborate
 
 Consider pushing your changes to a topic branch in your (public) fork of the repository continually as you work, so that others can see what you are doing and can engage with you on it.  Consider commenting on the JIRA issue and/or on the [uportal-dev@][] email thread letting folks know this branch is available for collaboration.
@@ -104,4 +107,7 @@ If your change is to a user-facing experience, it should not regress support for
 
 [code conventions]: https://wiki.jasig.org/display/UPM41/Code+Styles+and+Conventions
 [AOSP Java style]: https://source.android.com/setup/contribute/code-style
+
+[google-java-format-gradle-plugin_quickstart]: https://github.com/sherter/google-java-format-gradle-plugin#quick-start
+
 [architecture]: https://wiki.jasig.org/pages/viewpage.action?pageId=65274379

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ For a more in-depth description of the git workflow check out the
 *   Apply uPortal [code conventions][] and [architecture][].
 *   Write automated unit tests exercising existing code you are touching and exercising your new code.  If you are fixing a bug, first write a unit test demonstrating the bug so as to stave off future regression.
 
+uPortal uses [Android Open Source Project (AOSP) Java code style][AOSP Java style].
 
 ## Collaborate
 
@@ -102,4 +103,5 @@ If your change is to a user-facing experience, it should not regress support for
 [uportal-user@]: https://wiki.jasig.org/display/JSG/uportal-user
 
 [code conventions]: https://wiki.jasig.org/display/UPM41/Code+Styles+and+Conventions
+[AOSP Java style]: https://source.android.com/setup/contribute/code-style
 [architecture]: https://wiki.jasig.org/pages/viewpage.action?pageId=65274379

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
       </a>
       <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Google-green.svg?style=flat" alt="Google Code Style">
+        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Discover Soffits">

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
       <a href="http://issuestats.com/github/Jasig/uPortal">
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
       </a>
-      <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
+      <a href="https://source.android.com/setup/contribute/code-style">
+        <img src="https://img.shields.io/badge/code_style-AOSP-green.svg?style=flat" alt="AOSP Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Discover Soffits">

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ below.
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
       </a>
       <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Google-green.svg?style=flat" alt="Google Code Style">
+        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Discover Soffits">

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ below.
       <a href="http://issuestats.com/github/Jasig/uPortal">
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Issue Stats">
       </a>
-      <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
+      <a href="https://source.android.com/setup/contribute/code-style">
+        <img src="https://img.shields.io/badge/code_style-AOSP-green.svg?style=flat" alt="AOSP Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Discover Soffits">

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -17,8 +17,8 @@ ci-après.
       <a href="http://issuestats.com/github/Jasig/uPortal">
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Statistiques des Issues">
       </a>
-      <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
+      <a href="https://source.android.com/setup/contribute/code-style">
+        <img src="https://img.shields.io/badge/code_style-AOSP-green.svg?style=flat" alt="AOSP Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Découvrez les Soffits">

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -18,7 +18,7 @@ ci-après.
         <img src="http://issuestats.com/github/Jasig/uPortal/badge/pr" alt="Statistiques des Issues">
       </a>
       <a href="https://google.github.io/styleguide/javaguide.html">
-        <img src="https://img.shields.io/badge/code_style-Google-green.svg?style=flat" alt="Google Code Style">
+        <img src="https://img.shields.io/badge/code_style-Custom-green.svg?style=flat" alt="Custom Code Style">
       </a>
       <a href="https://github.com/search?q=topic%3Auportal+topic%3Asoffit&type=Repositories">
         <img src="https://img.shields.io/badge/discover-soffits-blue.svg?style=flat" alt="Découvrez les Soffits">


### PR DESCRIPTION
Per [Google Style for Java](https://google.github.io/styleguide/javaguide.html)

1. "A Java source file is described as being in Google Style if and only if it adheres to the rules"
2. per 4.2, 2 spaces for block indentation.
3. But uPortal (intentionally) uses 4 spaces for block indentation. (cf. `.editorconfig`)
4. Therefore uPortal is not in Google Style
5. So stop characterizing uPortal as in Google Style.

[Apparently](https://github.com/Jasig/uPortal/pull/1182#pullrequestreview-118394752) uPortal uses [Android Open Source Project Java code style](https://source.android.com/setup/contribute/code-style). So characterize as using that instead.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][]
-   N/A tests are included
-   [x] documentation is changed or added 
    - (could go further on this to describe uPortal custom Java style in e.g. `CONTRIBUTING.md`)
-   N/A [message properties][] have been updated with new phrases
-  N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
