### PR TITLE
refactor: trade away modest optimization to reduce LayoutPortlet complexity

### DIFF
--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -85,12 +85,12 @@ public class LayoutPortlet {
                 if (CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                     && pref.getValues().length == 1 && portletDef.getPortletDescriptorKey() != null
                     && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
-                        portletDef.getPortletDescriptorKey().getWebAppName())) {
+                    portletDef.getPortletDescriptorKey().getWebAppName())) {
                     // the extra check of web app name avoids accidentally interpretting some other
                     // kind of portlet's content portlet-preference as static content.
                     this.setStaticContent(pref.getValues()[0]);
                 } else if ( PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
-                        && 1 == pref.getValues().length) {
+                    && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
                 } else if ( WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
@@ -101,7 +101,7 @@ public class LayoutPortlet {
                         this.setWidgetConfig(pref.getValues()[0]);
                     } else {
                         this.setWidgetConfig(
-                                "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
+                            "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
                 } else if ( WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -23,6 +23,7 @@ import org.apereo.portal.portlet.om.IPortletDefinitionParameter;
 import org.apereo.portal.portlet.om.IPortletPreference;
 
 public class LayoutPortlet {
+
     private static final String CONTENT_PORTLET_PREFERENCE = "content";
     private static final String PITHY_CONTENT_PORTLET_PREFERENCE = "pithyContent";
     private static final String WIDGET_URL_PORTLET_PREFERENCE = "widgetURL";
@@ -43,24 +44,18 @@ public class LayoutPortlet {
     private String widgetURL;
     private String widgetType;
     private String widgetTemplate;
-    @JsonRawValue
-    private Object widgetConfig;
+    @JsonRawValue private Object widgetConfig;
 
     private boolean isAltMaxUrl = false;
     private boolean isRenderOnWeb;
 
-    /**
-     * Fuller static content that you might display in a lightbox or so.
-     */
+    /** Fuller static content that you might display in a lightbox or so. */
     private String staticContent;
 
-    /**
-     * Pithy static content that you might display on a dashboard mosaic view or so.
-     */
+    /** Pithy static content that you might display on a dashboard mosaic view or so. */
     private String pithyStaticContent;
 
-    public LayoutPortlet() {
-    }
+    public LayoutPortlet() {}
 
     public LayoutPortlet(IPortletDefinition portletDef) {
         if (portletDef != null) {
@@ -89,14 +84,15 @@ public class LayoutPortlet {
 
             for (IPortletPreference pref : portletDef.getPortletPreferences()) {
                 if (CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
-                    && pref.getValues().length == 1 && portletDef.getPortletDescriptorKey() != null
-                    && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
-                    portletDef.getPortletDescriptorKey().getWebAppName())) {
+                        && pref.getValues().length == 1
+                        && portletDef.getPortletDescriptorKey() != null
+                        && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
+                                portletDef.getPortletDescriptorKey().getWebAppName())) {
                     // the extra check of web app name avoids accidentally interpretting some other
                     // kind of portlet's content portlet-preference as static content.
                     this.setStaticContent(pref.getValues()[0]);
                 } else if (PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
-                    && 1 == pref.getValues().length) {
+                        && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
                 } else if (WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
@@ -107,7 +103,7 @@ public class LayoutPortlet {
                         this.setWidgetConfig(pref.getValues()[0]);
                     } else {
                         this.setWidgetConfig(
-                            "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
+                                "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
                 } else if (WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
@@ -119,18 +115,14 @@ public class LayoutPortlet {
     }
 
     private boolean isValidJSON(final String json) {
-        boolean valid = false;
         try {
             final JsonParser parser = new ObjectMapper().getFactory().createParser(json);
-            while (parser.nextToken() != null) {
-            }
-            valid = true;
+            while (parser.nextToken() != null) {}
+            return true;
         } catch (Exception jpe) {
             // eat error
-            valid = false;
+            return false;
         }
-
-        return valid;
     }
 
     public String getNodeId() {

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -58,7 +58,8 @@ public class LayoutPortlet {
      */
     private String pithyStaticContent;
 
-    public LayoutPortlet() {}
+    public LayoutPortlet() {
+    }
 
     public LayoutPortlet(IPortletDefinition portletDef) {
         if (portletDef != null) {
@@ -120,7 +121,8 @@ public class LayoutPortlet {
         boolean valid = false;
         try {
             final JsonParser parser = new ObjectMapper().getFactory().createParser(json);
-            while (parser.nextToken() != null) {}
+            while (parser.nextToken() != null) {
+            }
             valid = true;
         } catch (Exception jpe) {
             // eat error

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -48,10 +48,14 @@ public class LayoutPortlet {
     private boolean isAltMaxUrl = false;
     private boolean isRenderOnWeb;
 
-    /** Fuller static content that you might display in a lightbox or so. */
+    /**
+     * Fuller static content that you might display in a lightbox or so.
+     */
     private String staticContent;
 
-    /** Pithy static content that you might display on a dashboard mosaic view or so. */
+    /**
+     * Pithy static content that you might display on a dashboard mosaic view or so.
+     */
     private String pithyStaticContent;
 
     public LayoutPortlet() {}

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -93,23 +93,23 @@ public class LayoutPortlet {
                     // the extra check of web app name avoids accidentally interpretting some other
                     // kind of portlet's content portlet-preference as static content.
                     this.setStaticContent(pref.getValues()[0]);
-                } else if ( PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
+                } else if (PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                     && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
-                } else if ( WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if (WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
-                } else if ( WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if (WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
-                } else if ( WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if (WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
                     if (isValidJSON(pref.getValues()[0])) {
                         this.setWidgetConfig(pref.getValues()[0]);
                     } else {
                         this.setWidgetConfig(
                             "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
-                } else if ( WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if (WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
-                } else if ( RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if (RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
                 }
             }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -43,7 +43,8 @@ public class LayoutPortlet {
     private String widgetURL;
     private String widgetType;
     private String widgetTemplate;
-    @JsonRawValue private Object widgetConfig;
+    @JsonRawValue
+    private Object widgetConfig;
 
     private boolean isAltMaxUrl = false;
     private boolean isRenderOnWeb;

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -76,7 +76,18 @@ public class LayoutPortlet {
                 this.setFaIcon(faIconParam.getValue());
             }
 
+            // this "efficencyFlag" is an attempt to make more efficient the harvesting of portlet
+            // preferences into JavaBean properties, since portlet preferences are available here
+            // only as a list for iteration and not as a map for efficient lookup. This solution
+            // allows O(N) computation by traversing the list one time rather than O(N^2)
+            // by potentially having to traverse the list N times.
+
             boolean[] efficencyFlag = {false, false, false, false, false, false, false};
+
+            // flag 0: true if staticContent JavaBean property setting is fulfilled
+            // either by the portlet not being a static content portlet so there's nothing to do
+            // or by the portlet being a static content portlet and the content portlet preference
+            // having been copied into the
             efficencyFlag[0] =
                     !(portletDef.getPortletDescriptorKey() != null
                             && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
@@ -91,14 +102,18 @@ public class LayoutPortlet {
                         && PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                         && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
+
+                    // flag 1: pithyStaticContent JavaBean property set
                     efficencyFlag[1] = true;
                 } else if (!efficencyFlag[2]
                         && WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
+                    // flag 2: widgetUrl JavaBean property set
                     efficencyFlag[2] = true;
                 } else if (!efficencyFlag[3]
                         && WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
+                    // flag 3: widgetType JavaBean property set
                     efficencyFlag[3] = true;
                 } else if (!efficencyFlag[4]
                         && WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
@@ -108,18 +123,26 @@ public class LayoutPortlet {
                         this.setWidgetConfig(
                                 "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
+                    // flag 4: widgetConfig JavaBean property sets
                     efficencyFlag[4] = true;
                 } else if (!efficencyFlag[5]
                         && WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
+                    // flag 5: widgetTemplate JavaBean property set
                     efficencyFlag[5] = true;
                 } else if (!efficencyFlag[6]
                         && RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
+                    // flag 6: renderOnWeb JavaBean property set
                     efficencyFlag[6] = true;
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
                 }
 
                 if (allTrue(efficencyFlag)) {
+                    // if all the Portlet Preferences that might be harvested into JavaBean
+                    // properties have been harvested, then there's nothing more to harvest so stop
+                    // iterating through portlet preferences. However, since in particular
+                    // pithyStaticContent is not widely adopted, this shortcut will almost never
+                    // obtain
                     break;
                 }
             }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -89,7 +89,6 @@ public class LayoutPortlet {
             boolean staticContentParsed = false;
             boolean pithyStaticContentParsed = false;
             boolean widgetTypeParsed = false;
-            boolean widgetConfigParsed = false;
             boolean widgetTemplateParsed = false;
             boolean renderOnWebParsed = false;
 
@@ -119,7 +118,7 @@ public class LayoutPortlet {
                         && WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
                     widgetTypeParsed = true;
-                } else if (!widgetConfigParsed
+                } else if ( (this.widgetConfig == null)
                         && WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
                     if (isValidJSON(pref.getValues()[0])) {
                         this.setWidgetConfig(pref.getValues()[0]);
@@ -127,7 +126,6 @@ public class LayoutPortlet {
                         this.setWidgetConfig(
                                 "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
-                    widgetConfigParsed = true;
                 } else if (!widgetTemplateParsed
                         && WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
@@ -139,7 +137,7 @@ public class LayoutPortlet {
                 }
 
                 if (staticContentParsed && pithyStaticContentParsed && (this.widgetURL != null)
-                    && widgetTypeParsed && widgetConfigParsed && widgetTemplateParsed
+                    && widgetTypeParsed && (this.widgetConfig != null) && widgetTemplateParsed
                     && renderOnWebParsed) {
                     // if all the Portlet Preferences that might be harvested into JavaBean
                     // properties have been harvested, then there's nothing more to harvest so stop

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -76,18 +76,12 @@ public class LayoutPortlet {
                 this.setFaIcon(faIconParam.getValue());
             }
 
-            // flags tracking which portlet preferences have already been parsed are an attempt
-            // to make more efficient the harvesting of portlet
-            // preferences into JavaBean properties, since portlet preferences are available here
-            // only as a list for iteration and not as a map for efficient lookup. This single-loop
+            // This single-loop
             // solution traverses the list one time handling each
             // preference as it is encountered rather than looping through the preferences for each
-            // preference sought. The flags potentially
-            // further expedite this process by short-circuiting once all the relevant portlet
-            // preferences have been parsed.
+            // preference sought.
 
             boolean staticContentParsed = false;
-            boolean widgetTypeParsed = false;
             boolean renderOnWebParsed = false;
 
             // flag 0: true if staticContent JavaBean property setting is fulfilled
@@ -111,10 +105,9 @@ public class LayoutPortlet {
                 } else if ( (this.widgetURL == null)
                         && WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
-                } else if (!widgetTypeParsed
+                } else if ( (this.widgetType == null)
                         && WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
-                    widgetTypeParsed = true;
                 } else if ( (this.widgetConfig == null)
                         && WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
                     if (isValidJSON(pref.getValues()[0])) {
@@ -130,18 +123,6 @@ public class LayoutPortlet {
                         && RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
                     renderOnWebParsed = true;
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
-                }
-
-                if (staticContentParsed && (this.pithyStaticContent != null)
-                    && (this.widgetURL != null) && widgetTypeParsed && (this.widgetConfig != null)
-                    && (this.widgetTemplate != null) && renderOnWebParsed) {
-                    // if all the Portlet Preferences that might be harvested into JavaBean
-                    // properties have been harvested, then there's nothing more to harvest so stop
-                    // iterating through portlet preferences. However, since in particular
-                    // pithyStaticContent is not widely adopted and many widgets will use a
-                    // type rather than a custom template, this shortcut will almost never
-                    // obtain
-                    break;
                 }
             }
         }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -89,7 +89,6 @@ public class LayoutPortlet {
             boolean staticContentParsed = false;
             boolean pithyStaticContentParsed = false;
             boolean widgetTypeParsed = false;
-            boolean widgetTemplateParsed = false;
             boolean renderOnWebParsed = false;
 
             // flag 0: true if staticContent JavaBean property setting is fulfilled
@@ -126,10 +125,9 @@ public class LayoutPortlet {
                         this.setWidgetConfig(
                                 "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
-                } else if (!widgetTemplateParsed
+                } else if ( (this.widgetTemplate == null)
                         && WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
-                    widgetTemplateParsed = true;
                 } else if (!renderOnWebParsed
                         && RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
                     renderOnWebParsed = true;
@@ -137,8 +135,8 @@ public class LayoutPortlet {
                 }
 
                 if (staticContentParsed && pithyStaticContentParsed && (this.widgetURL != null)
-                    && widgetTypeParsed && (this.widgetConfig != null) && widgetTemplateParsed
-                    && renderOnWebParsed) {
+                    && widgetTypeParsed && (this.widgetConfig != null)
+                    && (this.widgetTemplate != null) && renderOnWebParsed) {
                     // if all the Portlet Preferences that might be harvested into JavaBean
                     // properties have been harvested, then there's nothing more to harvest so stop
                     // iterating through portlet preferences. However, since in particular

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -88,7 +88,6 @@ public class LayoutPortlet {
 
             boolean staticContentParsed = false;
             boolean pithyStaticContentParsed = false;
-            boolean widgetUrlParsed = false;
             boolean widgetTypeParsed = false;
             boolean widgetConfigParsed = false;
             boolean widgetTemplateParsed = false;
@@ -113,10 +112,9 @@ public class LayoutPortlet {
                         && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
                     pithyStaticContentParsed = true;
-                } else if (!widgetUrlParsed
+                } else if ( (this.widgetURL == null)
                         && WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
-                    widgetUrlParsed = true;
                 } else if (!widgetTypeParsed
                         && WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
@@ -140,7 +138,7 @@ public class LayoutPortlet {
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
                 }
 
-                if (staticContentParsed && pithyStaticContentParsed && widgetUrlParsed
+                if (staticContentParsed && pithyStaticContentParsed && (this.widgetURL != null)
                     && widgetTypeParsed && widgetConfigParsed && widgetTemplateParsed
                     && renderOnWebParsed) {
                     // if all the Portlet Preferences that might be harvested into JavaBean

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -87,7 +87,6 @@ public class LayoutPortlet {
             // preferences have been parsed.
 
             boolean staticContentParsed = false;
-            boolean pithyStaticContentParsed = false;
             boolean widgetTypeParsed = false;
             boolean renderOnWebParsed = false;
 
@@ -105,11 +104,10 @@ public class LayoutPortlet {
                         && pref.getValues().length == 1) {
                     this.setStaticContent(pref.getValues()[0]);
                     staticContentParsed = true;
-                } else if (!pithyStaticContentParsed
+                } else if ( (this.pithyStaticContent == null)
                         && PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                         && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
-                    pithyStaticContentParsed = true;
                 } else if ( (this.widgetURL == null)
                         && WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
@@ -134,8 +132,8 @@ public class LayoutPortlet {
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
                 }
 
-                if (staticContentParsed && pithyStaticContentParsed && (this.widgetURL != null)
-                    && widgetTypeParsed && (this.widgetConfig != null)
+                if (staticContentParsed && (this.pithyStaticContent != null)
+                    && (this.widgetURL != null) && widgetTypeParsed && (this.widgetConfig != null)
                     && (this.widgetTemplate != null) && renderOnWebParsed) {
                     // if all the Portlet Preferences that might be harvested into JavaBean
                     // properties have been harvested, then there's nothing more to harvest so stop

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -82,7 +82,6 @@ public class LayoutPortlet {
             // preference sought.
 
             boolean staticContentParsed = false;
-            boolean renderOnWebParsed = false;
 
             // flag 0: true if staticContent JavaBean property setting is fulfilled
             // either by the portlet not being a static content portlet so there's nothing to do
@@ -98,30 +97,23 @@ public class LayoutPortlet {
                         && pref.getValues().length == 1) {
                     this.setStaticContent(pref.getValues()[0]);
                     staticContentParsed = true;
-                } else if ( (this.pithyStaticContent == null)
-                        && PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
+                } else if ( PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                         && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);
-                } else if ( (this.widgetURL == null)
-                        && WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if ( WIDGET_URL_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetURL(pref.getValues()[0]);
-                } else if ( (this.widgetType == null)
-                        && WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if ( WIDGET_TYPE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetType(pref.getValues()[0]);
-                } else if ( (this.widgetConfig == null)
-                        && WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if ( WIDGET_CONFIG_PORTLET_PREFERENCE.equals(pref.getName())) {
                     if (isValidJSON(pref.getValues()[0])) {
                         this.setWidgetConfig(pref.getValues()[0]);
                     } else {
                         this.setWidgetConfig(
                                 "{\"error\" : \"config JSON not valid, syntax error? Double quotes not escaped?\"}");
                     }
-                } else if ( (this.widgetTemplate == null)
-                        && WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
+                } else if ( WIDGET_TEMPLATE_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setWidgetTemplate(pref.getValues()[0]);
-                } else if (!renderOnWebParsed
-                        && RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
-                    renderOnWebParsed = true;
+                } else if ( RENDER_ON_WEB_PORTLET_PREFERENCE.equals(pref.getName())) {
                     this.setRenderOnWeb(Boolean.valueOf(pref.getValues()[0]));
                 }
             }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -81,22 +81,14 @@ public class LayoutPortlet {
             // preference as it is encountered rather than looping through the preferences for each
             // preference sought.
 
-            boolean staticContentParsed = false;
-
-            // flag 0: true if staticContent JavaBean property setting is fulfilled
-            // either by the portlet not being a static content portlet so there's nothing to do
-            // or by the portlet being a static content portlet and the content portlet preference
-            // having been copied into the JavaBean property
-            staticContentParsed =
-                    !(portletDef.getPortletDescriptorKey() != null
-                            && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
-                                    portletDef.getPortletDescriptorKey().getWebAppName()));
             for (IPortletPreference pref : portletDef.getPortletPreferences()) {
-                if (!staticContentParsed
-                        && CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
-                        && pref.getValues().length == 1) {
+                if (CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
+                    && pref.getValues().length == 1 && portletDef.getPortletDescriptorKey() != null
+                    && STATIC_CONTENT_PORTLET_WEBAPP_NAME.equals(
+                        portletDef.getPortletDescriptorKey().getWebAppName())) {
+                    // the extra check of web app name avoids accidentally interpretting some other
+                    // kind of portlet's content portlet-preference as static content.
                     this.setStaticContent(pref.getValues()[0]);
-                    staticContentParsed = true;
                 } else if ( PITHY_CONTENT_PORTLET_PREFERENCE.equals(pref.getName())
                         && 1 == pref.getValues().length) {
                     this.setPithyStaticContent(pref.getValues()[0]);


### PR DESCRIPTION
The `efficencyFlag` _(sic)_ array of booleans in `LayoutPortlet` was adding more complexity than it was increasing efficiency. Drop it.

Simplifies `LayoutPortlet` in advance of expected changes to add feature of exposing portlet publishing parameters.

This pull request is best understood through its succession of commits.

Alas `LayoutPortlet` is not covered by unit tests. This changeset doesn't add any.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (they're roughly Conventional Commits)
-   [ ] tests are included (`LayoutPortlet` wasn't covered with unit tests; this changeset doesn't help).
-   [ ] documentation is changed or added (inline code comments added/changed)
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
