### PR TITLE
docs: reflect that uPortal 5 released

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ detailed documentation for each uPortal release.
 
 Additional information about uPortal is available in the Manual.
 
-*   [uPortal 5.2 Manual](https://jasig.github.io/uPortal)
+*   [uPortal 5.2 Manual][latest uPortal manual]
 *   [uPortal 5.1 Manual](https://github.com/Jasig/uPortal/tree/v5.1.0/docs)
 *   [uPortal 5.0 Manual](https://github.com/Jasig/uPortal/tree/v5.0.7/docs)
 *   [uPortal 4.3 Manual](https://wiki.jasig.org/display/UPM43/Home)
@@ -234,7 +234,7 @@ uPortal is now meant to be deployed via uPortal-start, which is responsible for
 servlet container (ie Tomcat), DB, and portal configurations. uPortal-start
 deals with the low-level configurations and setup, while letting the adopter
 focus on the business configuration side of the deployment. However, it is
-possible to run uPortal without uPortal-start. The uPortal 5.0 manual explains
+possible to run uPortal without uPortal-start. The [uPortal manual][latest uPortal manual] explains
 how.
 
 ## Building and Deploying
@@ -246,3 +246,5 @@ comes with a Gradle wrapper if you don't want to install the build tool
 ### Gradle tasks
 
 For a full list of Gradle tasks run `./gradlew tasks` from the root directory.
+
+[latest uPortal manual]: (https://jasig.github.io/uPortal)

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Additional information about uPortal is available in the Manual.
 
 ## uPortal-start
 
-uPortal is now meant to be deployed via uPortal-start, which is responsible for
+uPortal is now meant to be deployed via [uPortal-start][], which is responsible for
 servlet container (ie Tomcat), DB, and portal configurations. uPortal-start
 deals with the low-level configurations and setup, while letting the adopter
 focus on the business configuration side of the deployment. However, it is
@@ -248,3 +248,4 @@ comes with a Gradle wrapper if you don't want to install the build tool
 For a full list of Gradle tasks run `./gradlew tasks` from the root directory.
 
 [latest uPortal manual]: (https://jasig.github.io/uPortal)
+[uPortal-start]: https://github.com/Jasig/uPortal-start

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 # uPortal Documentation
 
 **NOTE:** This area is a work-in-progress. It is intended to serve as primary
-documentation for uPortal version 5.0 (expected mid-2017) and above.
+documentation for uPortal version 5 and above.
 Documentation for earlier versions of uPortal is available in
 [Confluence](https://wiki.jasig.org). See _Documentation for Previous Releases_
 below.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -3,7 +3,7 @@
 # Documentation uPortal
 
 **NOTE :** Cette partie est en construction. Son intention est de servir de base
-pour la documentation d'uPortal version 5.0 (sortie fin 2017) et supérieures.
+pour la documentation d'uPortal version 5 et supérieures.
 Les documentations pour les versions antérieures sont disponibles dans
 [Confluence](https://wiki.jasig.org).  Référez vous à *Documentation des précédentes versions* \[en\]
 ci-après.


### PR DESCRIPTION
Modest documentation improvements:

+ Removes language about expecting uPortal 5 release in 2017 (it's released)
+ Hyperlnks `uPortal-start`
+ Clarifies what manual to look at for how to avoid relying upon `uPortal-start`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (roughly, conventional commits)
-   N/A tests are included
-   [x] documentation is changed or added
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
