### PR TITLE
test: JUnit assertTrue not keyword assert in PortalSpELServiceImplTest

### DIFF
--- a/uPortal-utils/uPortal-utils-core/src/test/java/org/apereo/portal/spring/spel/PortalSpELServiceImplTest.java
+++ b/uPortal-utils/uPortal-utils-core/src/test/java/org/apereo/portal/spring/spel/PortalSpELServiceImplTest.java
@@ -14,6 +14,7 @@
  */
 package org.apereo.portal.spring.spel;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,12 +56,12 @@ public class PortalSpELServiceImplTest {
     @Test
     public void testParser() {
         String replaced = provider.parseString("${1+1}", request);
-        assert "2".equals(replaced);
+        assertTrue(("2").equals(replaced));
 
         replaced = provider.parseString("${1+1}/${3+4}", request);
-        assert "2/7".equals(replaced);
+        assertTrue("2/7".equals(replaced));
 
         replaced = provider.parseString("${1+1}/${3+4}/path", request);
-        assert "2/7/path".equals(replaced);
+        assertTrue("2/7/path".equals(replaced));
     }
 }


### PR DESCRIPTION
Addresses:

```
/Users/travis/build/Jasig/uPortal/uPortal-utils/uPortal-utils-core/src/test/java/org/apereo/portal/spring/spel/PortalSpELServiceImplTest.java:56: warning: [UseCorrectAssertInTests] Java assert is used in test. For testing purposes Assert.* matchers should be used.

    public void testParser() {

                ^

    (see http://errorprone.info/bugpattern/UseCorrectAssertInTests)

  Did you mean 'assertThat("2").isEqualTo(replaced);'?
```

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (roughly, conventional commits)
-   [x] tests are included (the change is a normalization of a unit test)
-   N/A documentation is changed or added
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
