### PR TITLE
feat(LayoutPortlet): parameters as JavaBean accessor of LayoutPortlet

### DIFF
--- a/docs/developer/other/API.md
+++ b/docs/developer/other/API.md
@@ -41,7 +41,7 @@ Naming and describing the portlet:
 About conveying arbitrary configuration:
 
  * `parameters` : a JavaScript map of name-value pairs representing the portlet publishing parameters
-    of the portlet
+    of the portlet (since uPortal 5.2)
 
 About escaping the portlet container:
 

--- a/docs/developer/other/API.md
+++ b/docs/developer/other/API.md
@@ -15,3 +15,94 @@ org.apereo.portal.rest.swagger.SwaggerConfiguration.enabled=true
 After restarting the Tomcat container, you can access the Swagger UI at `/uPortal/api/swagger-ui.html`.
 
 ![Swagger API documentation](../../images/swagger.png)
+
+### Single portlet JSON by fname
+
+`/api/portlet/{fname}.json`
+
+(example: `http://localhost:8080/uPortal/api/portlet/what-is-uportal.json` )
+
+If the requesting user can `BROWSE` the portlet with the requested `fname`, responds with JSON 
+representing the `portlet` with that fname. (Note structure in example below.)
+
+Data elements:
+
+Naming and describing the portlet:
+
+ * `title`: End-user-facing name of the portlet. (Not to be confused with administrator-facing 
+   `name`)
+ * `fname`: technical unique-within-portal identifier for the portlet publication. Typically human 
+   readable.
+ * `description` : End-user-facing description of the portlet.
+ * `iconUrl` : URL to an icon suitable for adorning or representing the portlet registrty entry.
+ * `faIcon` : (may be null) identifier of a Font Awesome uicon suitable for adorning or representing
+    the portlet registry entry.
+
+About conveying arbitrary configuration:
+
+ * `parameters` : a JavaScript map of name-value pairs representing the portlet publishing parameters
+    of the portlet
+
+About escaping the portlet container:
+
+ * `altMaxUrl` : (boolean) true if there is a URL to open in lieu of attempting to render the 
+   portlet in the regular way. Useful for portlet registry entries that are lightweight stubs for 
+   content external to the portlet container. 
+ * `target` : (may be null) indicates what special target, if any, the `altMaxUrl` should open in,
+    e.g. `_blank`
+
+About enabling special handling in `uPortal-home`:
+
+ * `widgetType`: (may be null) indicates a widget type, enabling re-using common widget 
+   templates
+ * `widgetTemplate`: (may be null) indicates a custom template for rendering the widget, used for
+   the `custom` `widgetType`.
+ * `widgetConfig`: (may be null) JSON configuration that informs the rendering of the widget type or
+    custom widget template. This configuration is shared across all usages of the widget in a given 
+    portlet definition.
+ * `widgetURL` : (may be null) URL from which the browser should read additional JSON to inform the 
+   rendering of the widget. Typically this JSON drives the dynamic portions of the custom widget 
+   template or the widget type rendering.
+ * `staticContent` : (may be null) the static HTML content associated with a simple Simple Content
+   Portlet usage, suitable for direct client-side presentation to the user when attempting to render
+   this portlet.
+ * `pithyStaticContent` : (may be null) IN PRACTICE UNUSED.
+ * `renderOnWeb` : (boolean) when true indicates the portlet is suitable for special rendering in
+   `EXCLUSIVE` window state and then direct rendering the resulting markup by injecting it into the 
+   DOM client-side rather than relying upon the full traditional XSLT rendering pipeline.
+
+Data elements not understood offhand by the author of this documentation:
+
+ * `nodeId` : (This is an opportunity to improve this documentation.)
+ * `url` : ditto.
+
+Example response:
+
+```json
+{
+  "portlet": {
+    "nodeId": "-1",
+    "title": "Welcome to uPortal",
+    "description": "Description of uPortal.",
+    "url": null,
+    "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
+    "faIcon": null,
+    "fname": "what-is-uportal",
+    "target": null,
+    "widgetURL": null,
+    "widgetType": null,
+    "widgetTemplate": null,
+    "widgetConfig": null,
+    "staticContent": "\n            \n                <h2>What is uPortal?</h2>\n                \n                <p>\n                    <a href=\"http://www.apereo.org/uportal\" target=\"_blank\">uPortal</a>\n                    is a free and open source Java-implemented web portal \n                    platform developed and maintained by participants drawn \n                    from across higher education under the coordination of \n                    <a href=\"http://www.apereo.org/\" target=\"_blank\">Apereo</a>.\n                    uPortal can aggregate content, present self-service \n                    applications, personalize presentation and content on the \n                    basis of groups and user attributes, drive mobile device applications, and allow advanced\n                    end-user-participatory customization of the portal experience. \n                    uPortal supports the JSR-286 and JSR-168 Java portlet specification for\n                    including your custom applications within the portal.\n                </p>\n                \n                <p>Welcome to uPortal.</p> \n            \n        ",
+    "pithyStaticContent": null,
+    "parameters": {
+      "mobileIconUrl": "/uPortal/media/skins/icons/mobile/feedback.png",
+      "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
+      "disableDynamicTitle": "true",
+      "configurable": "true"
+    },
+    "renderOnWeb": false,
+    "altMaxUrl": false
+  }
+}
+```

--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
@@ -1,0 +1,40 @@
+package org.apereo.portal.portlet.om;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utilities for working with portlet parameters.
+ * @since uPortal 5.2
+ */
+public class PortletParameterUtility {
+
+
+    /**
+     * Converts from Map String->IPortletDefinitionParameter (as offered by IPortletDefinition)
+     * to Map String->String (the view on these parameters that might be simplest for some uses,
+     * e.g. generating JSON.
+     *
+     * @param parametersMap potentially null Map from String name of parameter to
+     *     IPortletDefinitionParameter
+     * @return potentially null Map from String param name to String param value
+     * @since uPortal 5.2
+     */
+    public static Map<String,String> parameterMapToStringStringMap(
+        Map<String,IPortletDefinitionParameter> parametersMap) {
+
+        if (null == parametersMap) {
+            return null;
+        }
+
+        Map<String, String> stringMap = new HashMap<>(parametersMap.size());
+
+        for (String key : parametersMap.keySet()) {
+            stringMap.put(key, parametersMap.get(key).getValue());
+        }
+
+        return stringMap;
+    }
+
+
+}

--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
@@ -11,9 +11,9 @@ import java.util.Map;
 public class PortletParameterUtility {
 
     /**
-     * Converts from Map String->IPortletDefinitionParameter (as offered by IPortletDefinition)
-     * to Map String->String (the view on these parameters that might be simplest for some uses,
-     * e.g. generating JSON.
+     * Converts from Map String->IPortletDefinitionParameter (as offered by IPortletDefinition) to
+     * Map String->String (the view on these parameters that might be simplest for some uses, e.g.
+     * generating JSON.
      *
      * @param parametersMap potentially null Map from String name of parameter to
      *     IPortletDefinitionParameter

--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 /**
  * Utilities for working with portlet parameters.
+ *
  * @since uPortal 5.2
  */
 public class PortletParameterUtility {

--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
@@ -10,7 +10,6 @@ import java.util.Map;
  */
 public class PortletParameterUtility {
 
-
     /**
      * Converts from Map String->IPortletDefinitionParameter (as offered by IPortletDefinition)
      * to Map String->String (the view on these parameters that might be simplest for some uses,
@@ -36,6 +35,4 @@ public class PortletParameterUtility {
 
         return stringMap;
     }
-
-
 }

--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/PortletParameterUtility.java
@@ -20,8 +20,8 @@ public class PortletParameterUtility {
      * @return potentially null Map from String param name to String param value
      * @since uPortal 5.2
      */
-    public static Map<String,String> parameterMapToStringStringMap(
-        Map<String,IPortletDefinitionParameter> parametersMap) {
+    public static Map<String, String> parameterMapToStringStringMap(
+            Map<String, IPortletDefinitionParameter> parametersMap) {
 
         if (null == parametersMap) {
             return null;

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -1,0 +1,75 @@
+package org.apereo.portal.portlet.om;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class PortletParameterUtilityTest {
+
+    @Test
+    public void nullMapConvertsToNullMap() {
+        assertNull(PortletParameterUtility.parameterMapToStringStringMap(null));
+    }
+
+    @Test
+    public void convertsParameterMapToStringMap() {
+        Map<String, IPortletDefinitionParameter> input = new HashMap<>(2);
+
+        IPortletDefinitionParameter iconParam =
+            new PortletDefinitionParameter("icon", "dashboard");
+        IPortletDefinitionParameter altMaxUrlParam =
+            new PortletDefinitionParameter("alternativeMaximizedLink", "https://public.my.wisc.edu");
+
+        input.put("icon", iconParam);
+        input.put("alternativeMaximizedLink", altMaxUrlParam);
+
+        Map<String, String> expected = new HashMap<>(2);
+
+        expected.put("icon", "dashboard");
+        expected.put("alternativeMaximizedLink", "https://public.my.wisc.edu");
+
+        assertEquals(expected, PortletParameterUtility.parameterMapToStringStringMap(input));
+    }
+
+    /**
+     * JavaBean implementation of IPortletDefinitionParameter for use in testing.
+     */
+    class PortletDefinitionParameter implements IPortletDefinitionParameter {
+
+        private String name;
+        private String value;
+
+        public PortletDefinitionParameter(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String getDescription() {
+            return null;
+        }
+
+        @Override
+        public void setValue(String value) {
+
+        }
+
+        @Override
+        public void setDescription(String descr) {
+
+        }
+    }
+
+}

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -63,13 +63,9 @@ public class PortletParameterUtilityTest {
         }
 
         @Override
-        public void setValue(String value) {
-
-        }
+        public void setValue(String value) {}
 
         @Override
-        public void setDescription(String descr) {
-
-        }
+        public void setDescription(String descr) {}
     }
 }

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -20,7 +20,8 @@ public class PortletParameterUtilityTest {
         IPortletDefinitionParameter iconParam =
             new PortletDefinitionParameter("icon", "dashboard");
         IPortletDefinitionParameter altMaxUrlParam =
-            new PortletDefinitionParameter("alternativeMaximizedLink", "https://public.my.wisc.edu");
+                new PortletDefinitionParameter(
+                        "alternativeMaximizedLink", "https://public.my.wisc.edu");
 
         input.put("icon", iconParam);
         input.put("alternativeMaximizedLink", altMaxUrlParam);

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -72,5 +72,4 @@ public class PortletParameterUtilityTest {
 
         }
     }
-
 }

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -34,9 +34,7 @@ public class PortletParameterUtilityTest {
         assertEquals(expected, PortletParameterUtility.parameterMapToStringStringMap(input));
     }
 
-    /**
-     * JavaBean implementation of IPortletDefinitionParameter for use in testing.
-     */
+    /** JavaBean implementation of IPortletDefinitionParameter for use in testing. */
     class PortletDefinitionParameter implements IPortletDefinitionParameter {
 
         private String name;

--- a/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
+++ b/uPortal-core/src/test/java/org/apereo/portal/portlet/om/PortletParameterUtilityTest.java
@@ -17,8 +17,7 @@ public class PortletParameterUtilityTest {
     public void convertsParameterMapToStringMap() {
         Map<String, IPortletDefinitionParameter> input = new HashMap<>(2);
 
-        IPortletDefinitionParameter iconParam =
-            new PortletDefinitionParameter("icon", "dashboard");
+        IPortletDefinitionParameter iconParam = new PortletDefinitionParameter("icon", "dashboard");
         IPortletDefinitionParameter altMaxUrlParam =
                 new PortletDefinitionParameter(
                         "alternativeMaximizedLink", "https://public.my.wisc.edu");

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -263,6 +263,7 @@ public class LayoutPortlet {
 
     /**
      * Get a read-only view on the portlet publishing parameters for this portlet.
+     *
      * @return potentially null read-only Map from paramter name to parameter object
      * @since uPortal 5.2
      */

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apereo.portal.portlet.om.IPortletDefinition;
 import org.apereo.portal.portlet.om.IPortletDefinitionParameter;
 import org.apereo.portal.portlet.om.IPortletPreference;
+import org.apereo.portal.portlet.om.PortletParameterUtility;
 
 public class LayoutPortlet {
 
@@ -46,6 +47,8 @@ public class LayoutPortlet {
     private String widgetType;
     private String widgetTemplate;
     @JsonRawValue private Object widgetConfig;
+
+    private Map<String, String> parameterMap;
 
     private boolean isAltMaxUrl = false;
     private boolean isRenderOnWeb;
@@ -77,6 +80,10 @@ public class LayoutPortlet {
             if (faIconParam != null) {
                 this.setFaIcon(faIconParam.getValue());
             }
+
+            this.parameterMap =
+                PortletParameterUtility.parameterMapToStringStringMap(
+                    portletDef.getParametersAsUnmodifiableMap());
 
             // This single-loop
             // solution traverses the list one time handling each
@@ -252,5 +259,14 @@ public class LayoutPortlet {
 
     public void setRenderOnWeb(boolean setter) {
         this.isRenderOnWeb = setter;
+    }
+
+    /**
+     * Get a read-only view on the portlet publishing parameters for this portlet.
+     * @return potentially null read-only Map from paramter name to parameter object
+     * @since uPortal 5.2
+     */
+    public Map<String, String> getParameters() {
+        return this.parameterMap;
     }
 }

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -17,6 +17,7 @@ package org.apereo.portal.layout;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apereo.portal.portlet.om.IPortletDefinition;
 import org.apereo.portal.portlet.om.IPortletDefinitionParameter;

--- a/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
+++ b/uPortal-layout/uPortal-layout-core/src/main/java/org/apereo/portal/layout/LayoutPortlet.java
@@ -82,8 +82,8 @@ public class LayoutPortlet {
             }
 
             this.parameterMap =
-                PortletParameterUtility.parameterMapToStringStringMap(
-                    portletDef.getParametersAsUnmodifiableMap());
+                    PortletParameterUtility.parameterMapToStringStringMap(
+                            portletDef.getParametersAsUnmodifiableMap());
 
             // This single-loop
             // solution traverses the list one time handling each


### PR DESCRIPTION
Add portlet publishing parameters as a JavaBean accessor of `LayoutPortlet`, thereby including these parameters in some of the JSON APIs.

Adds `PortletParameterUtilities` with a utility method to convert from `IPortletDefinition`'s `Map<String, IPortletDefinitionParameter>` to the `Map<String, String>` that most simply represents the parameters and yields clean JSON.

After: 

`http://localhost:8080/uPortal/api/portlet/what-is-uportal.json` (note `parameters`):

EDIT: updated from the original description to reflect simpler JSON developed in the course of this PR.

```
{
  "portlet": {
    "nodeId": "-1",
    "title": "Welcome to uPortal",
    "description": "Description of uPortal.",
    "url": null,
    "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
    "faIcon": null,
    "fname": "what-is-uportal",
    "target": null,
    "widgetURL": null,
    "widgetType": null,
    "widgetTemplate": null,
    "widgetConfig": null,
    "staticContent": "\n            \n                <h2>What is uPortal?</h2>\n                \n                <p>\n                    <a href=\"http://www.apereo.org/uportal\" target=\"_blank\">uPortal</a>\n                    is a free and open source Java-implemented web portal \n                    platform developed and maintained by participants drawn \n                    from across higher education under the coordination of \n                    <a href=\"http://www.apereo.org/\" target=\"_blank\">Apereo</a>.\n                    uPortal can aggregate content, present self-service \n                    applications, personalize presentation and content on the \n                    basis of groups and user attributes, drive mobile device applications, and allow advanced\n                    end-user-participatory customization of the portal experience. \n                    uPortal supports the JSR-286 and JSR-168 Java portlet specification for\n                    including your custom applications within the portal.\n                </p>\n                \n                <p>Welcome to uPortal.</p> \n            \n        ",
    "pithyStaticContent": null,
    "parameters": {
      "mobileIconUrl": "/uPortal/media/skins/icons/mobile/feedback.png",
      "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
      "disableDynamicTitle": "true",
      "configurable": "true"
    },
    "renderOnWeb": false,
    "altMaxUrl": false
  }
}
```

and likewise in `http://localhost:8080/uPortal/api/marketplace/entry/what-is-uportal.json`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (roughly, conventional commits)
-   [x] tests are included (Alas, `LayoutPortlet` has no unit test; this changeset doesn't help this situation. Does however cover newly introduced utility class with unit tests.)
-   [x] documentation is changed or added
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
