### PR TITLE
UP-5013:  Several admin tools (framework portlets) return HTTP 405, M…

### DIFF
--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/flow/MultiOutcomeParamaterizableFlowHandler.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/flow/MultiOutcomeParamaterizableFlowHandler.java
@@ -18,8 +18,8 @@ import java.io.IOException;
 import java.util.Map;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.webflow.execution.FlowExecutionOutcome;
 import org.springframework.webflow.mvc.portlet.AbstractFlowHandler;
 
@@ -28,7 +28,7 @@ import org.springframework.webflow.mvc.portlet.AbstractFlowHandler;
  * flows that require different handling on different outcomes.
  */
 public class MultiOutcomeParamaterizableFlowHandler extends AbstractFlowHandler {
-    protected final Log logger = LogFactory.getLog(this.getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private String flowId = "view";
     private Map<String, String> redirectOnEnds;
@@ -37,7 +37,8 @@ public class MultiOutcomeParamaterizableFlowHandler extends AbstractFlowHandler 
     public Map<String, String> getRedirectOnEnds() {
         return this.redirectOnEnds;
     }
-    /** @param redirectOnEnd The location to redirect to at the end of the flow */
+
+    /** @param redirectOnEnds The locations to redirect to at the end of the flow */
     public void setRedirectOnEnds(Map<String, String> redirectOnEnds) {
         this.redirectOnEnds = redirectOnEnds;
     }

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/attribute-swapper/attributesForm.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/attribute-swapper/attributesForm.jsp
@@ -20,10 +20,10 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 
-<portlet:actionURL var="newSearchUrl">
+<portlet:renderURL var="newSearchUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="personLookup" />
-</portlet:actionURL>
+</portlet:renderURL>
 <portlet:actionURL var="attributeSwapUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/cache-manager/cache-list.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/cache-manager/cache-list.jsp
@@ -20,10 +20,10 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
-<portlet:actionURL var="flushAllUrl">
+<portlet:renderURL var="flushAllUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="flush-all"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <!-- Portlet -->
 <div class="fl-widget portlet cache-mgr view-list" role="section">
@@ -35,7 +35,7 @@
             <a class="button btn btn-primary" href="${flushAllUrl}"><span><spring:message code="empty.all.caches" />&nbsp;&nbsp;<i class="fa fa-refresh"></i></span></a>
         </div>
     </div> <!-- end: portlet-titlebar -->
-    
+
   <!-- Portlet Content -->
   <div class="fl-widget-content content portlet-content">
     <!-- Portlet Section -->
@@ -45,10 +45,10 @@
             	<spring:message code="available.caches"/>
             </h3>
         </div>
-      
+
       <div class="content">
         <p class="note" role="note"><spring:message code="select.cache.to.view.stats.and.clear.content"/></p>
-      
+
         <table class="portlet-table table-hover cache-table table table-condensed table-striped">
             <thead>
                 <tr>
@@ -61,15 +61,15 @@
             <c:forEach items="${statisticsMap}" var="statisticsEntry">
                 <tr class="cache-member">
                     <td class="cache-name">
-                        <portlet:actionURL var="viewStatsUrl">
+                        <portlet:renderURL var="viewStatsUrl">
                             <portlet:param name="cacheName" value="${statisticsEntry.key}"/>
                             <portlet:param name="execution" value="${flowExecutionKey}" />
                             <portlet:param name="_eventId" value="view-statistics"/>
-                        </portlet:actionURL>
+                        </portlet:renderURL>
                         <a href="${viewStatsUrl}">${fn:escapeXml(statisticsEntry.key)}</a>
                     </td>
                     <td class="cache-used">
-                        <span><fmt:formatNumber value="${statisticsEntry.value.usage}" pattern="00%" /> </span> 
+                        <span><fmt:formatNumber value="${statisticsEntry.value.usage}" pattern="00%" /> </span>
                         <small>(${fn:escapeXml(statisticsEntry.value.size)} / ${fn:escapeXml(statisticsEntry.value.maxSize)})</small>
                     </td>
                     <td class="cache-effectiveness">
@@ -77,11 +77,11 @@
                         <small>(${fn:escapeXml(statisticsEntry.value.hits)} <spring:message code="hits"/>, ${fn:escapeXml(statisticsEntry.value.misses)} <spring:message code="misses"/>)</small>
                     </td>
                     <td class="cache-flush">
-                        <portlet:actionURL var="flushUrl">
+                        <portlet:renderURL var="flushUrl">
                           <portlet:param name="cacheName" value="${statisticsEntry.key}"/>
                           <portlet:param name="_eventId" value="flush"/>
                           <portlet:param name="execution" value="${flowExecutionKey}" />
-                        </portlet:actionURL>
+                        </portlet:renderURL>
                         <a href="${flushUrl}"><spring:message code="flush"/></a>
                     </td>
                 </tr>
@@ -90,5 +90,5 @@
       </div>
     </div>
   </div>
-  
+
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/cache-manager/cache-statistics.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/cache-manager/cache-statistics.jsp
@@ -19,15 +19,15 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:actionURL var="flushUrl">
+<portlet:renderURL var="flushUrl">
   <portlet:param name="_eventId" value="flush"/>
   <portlet:param name="execution" value="${flowExecutionKey}" />
-</portlet:actionURL>
-<portlet:actionURL var="homeUrl">
+</portlet:renderURL>
+<portlet:renderURL var="homeUrl">
   <portlet:param name="_eventId" value="cache-list"/>
   <portlet:param name="execution" value="${flowExecutionKey}" />
-</portlet:actionURL>
-        
+</portlet:renderURL>
+
 <!-- Portlet -->
 <div class="fl-widget portlet cache-mgr view-statistics" role="section">
   <!-- Portlet Titlebar -->
@@ -38,7 +38,7 @@
 
   <!-- Portlet Content -->
   <div class="fl-widget-content content portlet-content">
-      
+
         <table class="portlet-table table table-hover">
             <thead>
                 <tr><th><spring:message code="cache.property"/></th><th><spring:message code="value"/></th></tr>
@@ -73,7 +73,7 @@
                 </tr>
             </tbody>
         </table>
-        
+
       </div>
     </div>
 
@@ -82,7 +82,7 @@
         <a class="button btn primary" href="${ flushUrl }"><spring:message code="empty.cache"/></a>
         <a class="button btn" href="${ homeUrl }"><spring:message code="cancel"/></a>
     </div>
-    
+
   </div>
-  
+
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-account/editLocalAccount.jsp
@@ -36,11 +36,11 @@
                     <spring:message code="create.new.user"/>
                 </c:when>
                 <c:otherwise>
-                    <portlet:actionURL var="userUrl">
+                    <portlet:renderURL var="userUrl">
                         <portlet:param name="execution" value="${flowExecutionKey}" />
                         <portlet:param name="_eventId" value="finish"/>
-                    </portlet:actionURL>
-                    <a href="${ userUrl }">${ fn:escapeXml(accountForm.username )}</a> >
+                    </portlet:renderURL>
+                    <a href="${ userUrl }">${ fn:escapeXml(accountForm.username )}</a> &gt;
                     <spring:message code="edit.user"/>
                 </c:otherwise>
             </c:choose>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
@@ -21,18 +21,18 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="groupUrl">
+<portlet:renderURL var="groupUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="group"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
-<portlet:actionURL var="editUrl" escapeXml="false">
+<portlet:renderURL var="editUrl" escapeXml="false">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="editPermission"/>
   <portlet:param name="owner" value="OWNER"/>
   <portlet:param name="activity" value="ACTIVITY"/>
   <portlet:param name="target" value="TARGET"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <style>
 #${n}permissionBrowser .dataTables_filter, #${n}permissionBrowser .first.paginate_button, #${n}permissionBrowser .last.paginate_button{
@@ -108,7 +108,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading">
-            <a href="${ groupUrl }">${ fn:escapeXml(group.name )}</a> > 
+            <a href="${ groupUrl }">${ fn:escapeXml(group.name )}</a> >
             <spring:message code="permissions"/>
         </h2>
     </div> <!-- end: portlet-titlebar -->
@@ -163,7 +163,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                     </div>
                 </div>
             </div>
-        </div> 
+        </div>
     </div>
 </div>
 
@@ -224,7 +224,7 @@ up.jQuery(function() {
     }
 
 
-    // Created as its own 
+    // Created as its own
     var initializeTable = function(tableName) {
         var config = null;
         if (tableName == "principal") {
@@ -251,7 +251,7 @@ up.jQuery(function() {
             },
             aoColumns: [
                 { mData: 'ownerName', sType: 'html', sWidth: '25%' },  // Owner
-                { mData: 'principalName', sType: 'html', sWidth: '25%', bVisible: config.showPrincipal },  // Principal 
+                { mData: 'principalName', sType: 'html', sWidth: '25%', bVisible: config.showPrincipal },  // Principal
                 { mData: 'activityName', sType: 'html', sWidth: '25%' },  // Activity
                 { mData: 'targetName', sType: 'html', bSearchable: false, sWidth: '25%', bVisible: config.showTarget },  // Target
                 { mData: 'targetName', sType: 'html', bSearchable: false, sWidth: '25%' }  // Edit Link

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-permission/editPermission.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-permission/editPermission.jsp
@@ -22,13 +22,10 @@
 
 <c:set var="n"><portlet:namespace/></c:set>
 
-<portlet:actionURL var="choosePrinicipalsUrl">
+<portlet:renderURL var="choosePrinicipalsUrl">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="choosePrinicipals"/>
-</portlet:actionURL>
-<portlet:actionURL var="formUrl">
-  <portlet:param name="execution" value="${flowExecutionKey}" />
-</portlet:actionURL>
+</portlet:renderURL>
 
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
@@ -80,9 +77,9 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
             <form method="POST" id="${n}editPermissionForm" action="javascript:;">
 
                 <ul id="assignments"></ul>
-  
+
             </form>
-    
+
     </div> <!-- end: portlet-content -->
 
 </div> <!-- end: portlet -->
@@ -97,13 +94,13 @@ up.jQuery(function() {
     var inheritRegex = /INHERIT_/;
     var addAssignments = function(assignments, list) {
         $(assignments).each(function(idx, assignment) {
-            
+
             // determine the current select menu option
             var type = assignment.type;
             if (type.match(inheritRegex)) {
                 type = "INHERIT";
             }
-            
+
             // determine the text for the inherit option
             var inheritText;
             if (assignment.type == 'INHERIT_GRANT') {
@@ -113,7 +110,7 @@ up.jQuery(function() {
             } else {
                 inheritText = "<spring:message code="inherit"/>";
             }
-            
+
             // build up the markup
             var li = $(document.createElement("li"));
             var span = $(document.createElement("span")).addClass("assignment-wrapper")
@@ -139,19 +136,19 @@ up.jQuery(function() {
 
         });
     };
-    
+
     var updatePermission = function(principal, type) {
         $("#assignments").html("");
         $.get(
-            "<c:url value="/api/updatePermission"/>", 
-            { 
+            "<c:url value="/api/updatePermission"/>",
+            {
                 principal: principal,
                 assignment: type,
                 owner: '${ owner.fname }',
                 activity: '${ activity.fname }',
                 target: '${ target.key }',
                 principals: principals
-                
+
             },
             function(data) {
                 allAssignments = data.assignments;
@@ -160,11 +157,11 @@ up.jQuery(function() {
             "json"
         );
     };
-    
+
     var renderPermissionMap = function() {
         $("#assignments").html("");
         $.get(
-                "<c:url value="/api/permissionAssignmentMap"/>", 
+                "<c:url value="/api/permissionAssignmentMap"/>",
                 {
                     owner: '${ owner.fname }',
                     activity: '${ activity.fname }',
@@ -178,7 +175,7 @@ up.jQuery(function() {
                 "json"
             );
     };
-    
+
     $(document).ready(renderPermissionMap);
 
 

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/entity-selector/selectEntities.jsp
@@ -159,7 +159,7 @@
                         </div>
                         <!--content-->
                         <div class="content">
-                            <form action="${submitUrl}" method="post">
+                            <form action="${submitUrl}" method="POST">
                                 <div id="${n}selectionBasket" class="selection-basket">
                                     <ul>
                                         <c:choose>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/forgot-password/sendTokenSuccess.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/forgot-password/sendTokenSuccess.jsp
@@ -20,10 +20,10 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 
-<portlet:actionURL var="loginUrl">
+<portlet:renderURL var="loginUrl">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="finish"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
@@ -35,18 +35,18 @@
     </div>
 
     <div class="fl-widget-content content portlet-content" data-role="content">
-  
+
     <!-- Portlet Section -->
     <div class="portlet-section" role="region">
 
       <div class="portlet-section-body">
           <p><spring:message code="password.reset.instructions.have.been.sent.to.your.email.address"/></p>
-          
+
           <p><a href="${ loginUrl }"><spring:message code="return.to.log.in.form"/></a></p>
       </div>
 
     </div>
-    
+
   </div>
 
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/fragment-administration/select-fragment-form.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/fragment-administration/select-fragment-form.jsp
@@ -23,20 +23,20 @@
 <!-- Portlet -->
 <div id="portalFragAdminList" class="fl-widget portlet snooper view-main" role="section">
 
-	
+
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
     	<h2 class="title" role="heading"><spring:message code="fragment.administration"/></h2>
     </div>
-    
+
     <!-- Portlet Content -->
 	<div class="fl-widget-content content portlet-content">
-        
+
         <portlet:actionURL var="formUrl">
             <portlet:param name="execution" value="${flowExecutionKey}" />
             <portlet:param name="_eventId" value="selectFragment"/>
         </portlet:actionURL>
-        <form method="post" name="fragmentAdminForm" class="form form-inline" action="${formUrl}">
+        <form method="POST" name="fragmentAdminForm" class="form form-inline" action="${formUrl}">
             <select id="fragmentOwner" class="form-control" name="impersonateUser" title="<spring:message code="choose.fragment.to.edit"/>">
             	<option value="NONE"> -- <spring:message code="fragments"/> -- </option>
                 <c:forEach items="${fragments}" var="item">

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/deletePermission.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/deletePermission.jsp
@@ -23,15 +23,15 @@
 
 <c:set var="n"><portlet:namespace/></c:set>
 
-<portlet:actionURL var="removeUrl">
+<portlet:renderURL var="removeUrl"><!-- Removal uses the REST API;  this URL is merely the page that appears after -->
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="remove"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
-<portlet:actionURL var="cancelUrl">
+<portlet:renderURL var="cancelUrl">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="cancel"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
@@ -43,31 +43,31 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 | and more, refer to:
 | docs/SKINNING_UPORTAL.md
 -->
-    
+
 <!-- Portlet -->
 <div class="fl-widget portlet ptl-mgr view-confirmremove" role="section">
 
   <!-- Portlet Title -->
   <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-  
+
     <div class="breadcrumb">
         <c:forEach items="${ breadcrumbs }" var="breadcrumb" varStatus="status">
-            <portlet:actionURL var="breadcrumbUrl">
+            <portlet:renderURL var="breadcrumbUrl">
                 <portlet:param name="execution" value="${flowExecutionKey}" />
                 <portlet:param name="_eventId" value="${ breadcrumb.key }"/>
-            </portlet:actionURL>
+            </portlet:renderURL>
             <span class="breadcrumb-${ status.index + 1 }">
                 <a href="${ breadcrumbUrl }">${ fn:escapeXml(breadcrumb.value )}</a>
             </span>
             <span class="separator">&gt; </span>
         </c:forEach>
     </div>
-  
+
     <h2 class="title" role="heading">
       <spring:message code="remove.permission"/>
     </h2>
   </div> <!-- end: portlet-titlebar -->
-  
+
   <!-- Portlet Content -->
   <div class="fl-widget-content content portlet-content">
 
@@ -75,24 +75,24 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
     <div class="portlet-section" role="region">
       <div class="titlebar">
          <h3class="title" role="heading"><spring:message code="remove.permission.confirmation" arguments="${permissionType},${ activity.name },  ${target.name }, ${principalName}"/></h3>
-        
+
       </div>
     </div> <!-- end: portlet-section -->
-   
+
     <div class="buttons">
-        <a href="${removeUrl}" class="button btn btn-default" name="_eventId_remove" id="${n}deletePermissionButton"><spring:message code="remove"/></a>
+      <a href="${removeUrl}" class="button btn btn-default" name="_eventId_remove" id="${n}deletePermissionButton"><spring:message code="remove"/></a>
       <a href="${cancelUrl}" class="button btn btn-default"><spring:message code="cancel"/></a>
     </div>
-    
+
 
     </div> <!-- end: portlet-content -->
-        
+
 </div> <!-- end: portlet -->
 
 <script type="text/javascript">
 up.jQuery(function() {
     var $ = up.jQuery;
-    
+
     $(document).ready(function(){
         $('#${n}deletePermissionButton').click(function(e){
             e.preventDefault();
@@ -114,6 +114,6 @@ up.jQuery(function() {
             });
         });
     });
-    
+
 });
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/listActivities.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/listActivities.jsp
@@ -21,10 +21,10 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="backUrl">
+<portlet:renderURL var="backUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="owners"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
@@ -39,8 +39,8 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 
 <!-- Portlet -->
 <div class="fl-widget portlet prm-mgr view-listperms" role="section">
-  
-  
+
+
   <!-- Portlet Titlebar -->
 	<div role="sectionhead" class="fl-widget-titlebar titlebar portlet-titlebar">
 	  	<div class="breadcrumb">
@@ -50,13 +50,13 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 	    <h2 class="title" role="heading"><spring:message code="permissions.in"/> <span class="name">${ fn:escapeXml(owner.name )}</span></h2>
 	    <h3 class="subtitle">${ fn:escapeXml(owner.description )}</h3>
 	</div>
-  
-  
+
+
   <!-- Portlet Content -->
   <div class="fl-widget-content portlet-content">
-  
-    <!-- Portlet Section -->    
-		
+
+    <!-- Portlet Section -->
+
         <table class="portlet-table table table-hover" title="${ fn:escapeXml(owner.description )}">
             <tr>
                 <th><spring:message code="name"/></th>
@@ -66,18 +66,18 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
             <c:forEach items="${ owner.activities }" var="activity">
                 <tr>
                     <td>
-                        <portlet:actionURL var="activityUrl">
+                        <portlet:renderURL var="activityUrl">
                             <portlet:param name="execution" value="${flowExecutionKey}" />
                             <portlet:param name="_eventId" value="showActivity"/>
                             <portlet:param name="activityFname" value="${ activity.fname }"/>
-                        </portlet:actionURL>
+                        </portlet:renderURL>
                         <a href="${ activityUrl }">${ fn:escapeXml(activity.name )}</a>
                     </td>
                     <td>${ fn:escapeXml(activity.fname )}</td>
                     <td>${ fn:escapeXml(activity.description )}</td>
                 </tr>
             </c:forEach>
-        </table>    
+        </table>
 
   </div> <!-- end: portlet-content -->
 

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/listOwners.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/listOwners.jsp
@@ -112,11 +112,11 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                 <div class="permission-owner ${ fn:escapeXml(owner.fname )} panel">
                 	<div class="titlebar">
                         <h2 class="title">
-                            <portlet:actionURL var="ownerUrl">
+                            <portlet:renderURL var="ownerUrl">
                                 <portlet:param name="execution" value="${flowExecutionKey}" />
                                 <portlet:param name="_eventId" value="listActivities"/>
                                 <portlet:param name="ownerFname" value="${ owner.fname }"/>
-                            </portlet:actionURL>
+                            </portlet:renderURL>
                             <a href="${ ownerUrl }">${ fn:escapeXml(owner.name )}</a>
                         </h2>
                         <h3 class="subtitle">${ fn:escapeXml(owner.description )}</h3>
@@ -124,12 +124,12 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                     <div class="content">
                         <span class="link-list">
                             <c:forEach items="${ owner.activities }" var="activity" varStatus="status">
-                                <portlet:actionURL var="activityUrl">
+                                <portlet:renderURL var="activityUrl">
                                     <portlet:param name="execution" value="${ flowExecutionKey }"/>
                                     <portlet:param name="_eventId" value="showActivity"/>
                                     <portlet:param name="ownerFname" value="${ owner.fname }"/>
                                     <portlet:param name="activityFname" value="${ activity.fname }"/>
-                                </portlet:actionURL>
+                                </portlet:renderURL>
                                 <a href="${ activityUrl }">${ fn:escapeXml(activity.name )}</a>${ status.last ? "" : ", " }
                             </c:forEach>
                         </span>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/permissionLookupResult.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/permissionLookupResult.jsp
@@ -21,18 +21,18 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="ownersUrl">
+<portlet:renderURL var="ownersUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="owners"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
-<portlet:actionURL var="editUrl" escapeXml="false">
+<portlet:renderURL var="editUrl" escapeXml="false">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="editPermission"/>
   <portlet:param name="owner" value="OWNER"/>
   <portlet:param name="activity" value="ACTIVITY"/>
   <portlet:param name="target" value="TARGET"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <style>
 #${n}permissionBrowser .dataTables_filter, #${n}permissionBrowser .first.paginate_button, #${n}permissionBrowser .last.paginate_button{
     display: none;
@@ -99,14 +99,14 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 
 <!-- Portlet -->
 <div id="${n}permissionBrowser" class="fl-widget portlet prm-mgr" role="section">
-  
+
   <!-- Portlet Titlebar -->
   <div class="fl-widget-titlebar portlet-titlebar" role="sectionhead">
     <h2 class="title" role="heading">
         <spring:message code="activityName.permissions.assigned.to.principalName" arguments="${ fn:escapeXml(activityDisplayName) }, ${ principalDisplayName }"/>
     </h2>
   </div> <!-- end: portlet-titlebar -->
-  
+
   <!-- Portlet Content -->
   <div class="fl-widget-content portlet-content">
       <div class="titlebar">
@@ -125,7 +125,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
           </table>
       </div>
 
-      <a href="${ ownersUrl }">Back to permission owners</a> 
+      <a href="${ ownersUrl }">Back to permission owners</a>
   </div> <!-- end: portlet-content -->
 </div> <!-- end: portlet -->
 
@@ -162,7 +162,7 @@ up.jQuery(function() {
         }
         return markup;
     };
-    
+
     var initializeTable = function() {
         var table = $("#${n}permissionsTable");
         principalList_configuration.main.table = $("#${n}permissionsTable").dataTable({

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/selectTarget.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/selectTarget.jsp
@@ -24,18 +24,18 @@
 <portlet:actionURL var="formUrl">
   <portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>
-<portlet:actionURL var="ownersUrl">
+<portlet:renderURL var="ownersUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="owners"/>
-</portlet:actionURL>
-<portlet:actionURL var="activitiesUrl">
+</portlet:renderURL>
+<portlet:renderURL var="activitiesUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="activities"/>
-</portlet:actionURL>
-<portlet:actionURL var="permissionsUrl">
+</portlet:renderURL>
+<portlet:renderURL var="permissionsUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="permissions"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
@@ -50,7 +50,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 
 <!-- Portlet -->
 <div class="fl-widget portlet prm-mgr" role="section">
-  
+
 <!-- Portlet Titlebar -->
 	<div role="sectionhead" class="fl-widget-titlebar titlebar portlet-titlebar">
     	<div class="breadcrumb">
@@ -64,12 +64,12 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
         <h2 class="title" role="heading"><spring:message code="add.assignment.to"/> <span class="name">${ fn:escapeXml(activity.name )}</span></h2>
         <h3 class="subtitle">${ fn:escapeXml(activity.description )}</h3>
     </div>
-  
-    
-  
+
+
+
   <!-- Portlet Content -->
   <div class="fl-widget-content portlet-content">
-  
+
     <!-- Portlet Section -->
     <div class="portlet-form">
         <form id="${n}targetForm" action="${ formUrl }" method="POST">
@@ -98,10 +98,10 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                 <input class="button btn primary" type="submit" value="<spring:message code="submit"/>" name="_eventId_editPermission"/>
                 <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
             </div> <!-- end: buttons -->
-            
+
         </form>
 	</div>
-    
+
   </div> <!-- end: portlet-content -->
 
 </div> <!-- end: portlet -->
@@ -117,7 +117,7 @@ up.jQuery(function() {
     };
 
     var targetSuggest = up.Autocomplete(
-            "#${n}targetSuggest", 
+            "#${n}targetSuggest",
             {
                 initialText: '<spring:message code="target" htmlEscape="false" javaScriptEscape="true"/>',
                 searchFunction: function(searchterm) {
@@ -138,10 +138,10 @@ up.jQuery(function() {
         );
 
     $(document).ready(function(){
-        
-        
+
+
         $("#${n}targetForm").submit(submitForm);
     });
-    
+
 });
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/showActivity.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/permissions-administration/showActivity.jsp
@@ -21,27 +21,27 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="ownersUrl">
+<portlet:renderURL var="ownersUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="owners"/>
-</portlet:actionURL>
-<portlet:actionURL var="activitiesUrl">
+</portlet:renderURL>
+<portlet:renderURL var="activitiesUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="activities"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
-<portlet:actionURL var="createUrl">
+<portlet:renderURL var="createUrl">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="createPermission"/>
-</portlet:actionURL>
-<portlet:actionURL var="editUrl" escapeXml="false">
+</portlet:renderURL>
+<portlet:renderURL var="editUrl" escapeXml="false">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="editPermission"/>
   <portlet:param name="owner" value="OWNER"/>
   <portlet:param name="activity" value="ACTIVITY"/>
   <portlet:param name="target" value="TARGET"/>
-</portlet:actionURL>
-<portlet:actionURL var="deleteUrl" escapeXml="false">
+</portlet:renderURL>
+<portlet:renderURL var="deleteUrl" escapeXml="false"><!-- Actual delete happens on the next screen -->
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="delete"/>
   <portlet:param name="owner" value="OWNER"/>
@@ -50,7 +50,7 @@
   <portlet:param name="activity" value="ACTIVITY"/>
   <portlet:param name="targetName" value="TARGET"/>
   <portlet:param name="permissionType" value="PERMISSIONTYPE"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <style>
 #${n}activityBrowser .dataTables_filter, #${n}activityBrowser .first.paginate_button, #${n}activityBrowser .last.paginate_button{
@@ -118,7 +118,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 
 <!-- Portlet -->
 <div id="${n}activityBrowser" class="fl-widget portlet prm-mgr" role="section">
-  
+
   <!-- Portlet Titlebar -->
     <div role="sectionhead" class="fl-widget-titlebar titlebar portlet-titlebar">
         <div class="breadcrumb">
@@ -126,7 +126,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
             <span class="separator">&gt; </span>
             <span class="breadcrumb-2"><a href="${ activitiesUrl }">${ fn:escapeXml(owner.name )}</a></span>
             <span class="separator">&gt; </span>
-            
+
         </div>
         <h2 class="title" role="heading"><spring:message code="assignments.for"/> <span class="name">${ fn:escapeXml(activity.name )}</span></h2>
         <h3 class="subtitle">${ fn:escapeXml(activity.description )}</h3>
@@ -136,10 +136,10 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
             </ul>
         </div>
     </div>
-  
+
   <!-- Portlet Content -->
   <div class="fl-widget-content portlet-content">
-  
+
     <!-- Portlet Section -->
     <div id="${n}permissionAddingTabs" class="portlet-section" role="region">
         <table class="portlet-table table table-hover" id="${n}permissionsTable" title='<spring:message code="assignments.of.this.permission"/>'>
@@ -227,9 +227,9 @@ up.jQuery(function() {
             fnServerData: function (sUrl, aoData, fnCallback, oSettings) {
                 oSettings.jqXHR = $.ajax({
                     url: sUrl,
-                    data: { 
-                        owner: '<spring:escapeBody htmlEscape="false" javaScriptEscape="true">${ owner.fname }</spring:escapeBody>', 
-                        activity: '<spring:escapeBody htmlEscape="false" javaScriptEscape="true">${ activity.fname }</spring:escapeBody>' 
+                    data: {
+                        owner: '<spring:escapeBody htmlEscape="false" javaScriptEscape="true">${ owner.fname }</spring:escapeBody>',
+                        activity: '<spring:escapeBody htmlEscape="false" javaScriptEscape="true">${ activity.fname }</spring:escapeBody>'
                     },
                     dataType: "json",
                     cache: false,

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/person-lookup/personLookup.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/person-lookup/personLookup.jsp
@@ -20,11 +20,11 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 
-<portlet:actionURL var="selectPersonUrl" escapeXml="false">
+<portlet:renderURL var="selectPersonUrl" escapeXml="false">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="select"/>
     <portlet:param name="username" value="USERNAME"/>
-</portlet:actionURL>
+</portlet:renderURL>
 
 <portlet:renderURL var="cancelUrl">
     <portlet:param name="execution" value="${flowExecutionKey}"/>
@@ -121,9 +121,9 @@
                     <!-- Buttons -->
                     <div class="buttons">
                         <spring:message var="searchButtonText" code="search" />
-                        <input class="button primary btn" type="submit" value="${searchButtonText}" />
+                        <input class="button btn btn-primary" type="submit" value="${searchButtonText}" />
 
-                        <a class="button btn" href="${ cancelUrl }">
+                        <a class="button btn btn-default" href="${ cancelUrl }">
                             <spring:message code="cancel" />
                         </a>
                     </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/portlet-manager/listChannels.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/portlet-manager/listChannels.jsp
@@ -27,20 +27,20 @@
 
 <c:set var="n"><portlet:namespace/></c:set>
 
-<portlet:actionURL var="newPortletUrl" >
+<portlet:renderURL var="newPortletUrl" >
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="createPortlet"/>
-</portlet:actionURL>
-<portlet:actionURL var="editPortletUrl" escapeXml="false">
+</portlet:renderURL>
+<portlet:renderURL var="editPortletUrl" escapeXml="false">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="editPortlet"/>
   <portlet:param name="portletId" value="PORTLETID"/>
-</portlet:actionURL>
-<portlet:actionURL var="removePortletUrl" escapeXml="false">
+</portlet:renderURL>
+<portlet:renderURL var="removePortletUrl" escapeXml="false">
   <portlet:param name="execution" value="${flowExecutionKey}" />
   <portlet:param name="_eventId" value="removePortlet"/>
   <portlet:param name="portletId" value="PORTLETID"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <!-- END: VALUES BEING PASSED FROM BACKEND -->
 
 <!--

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-password/createPasswordSuccess.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-password/createPasswordSuccess.jsp
@@ -19,10 +19,10 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:actionURL var="loginFormUrl">
+<portlet:renderURL var="loginFormUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="login"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
@@ -32,17 +32,17 @@
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead" data-role="header">
         <h2 class="title" role="heading"><spring:message code="success"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" data-role="content">
 
         <p>
             <spring:message code="your.password.has.been.updated.successfully"/>
         </p>
-            
+
         <p>
             <a href="${ loginFormUrl }"><spring:message code="login"/></a>
         </p>
-        
+
     </div>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-password/invalidLoginToken.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-password/invalidLoginToken.jsp
@@ -19,10 +19,10 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:actionURL var="newTokenUrl">
+<portlet:renderURL var="newTokenUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="newToken"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
@@ -32,17 +32,17 @@
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead" data-role="header">
         <h2 class="title" role="heading"><spring:message code="invalid.password.reset.url"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content" data-role="content">
 
         <p>
             <spring:message code="we.were.unable.to.validate.your.password.reset.url"/>
         </p>
-            
+
         <p>
             <a href="${ newTokenUrl }"><spring:message code="send.a.new.password.reset.email"/></a>
         </p>
-        
+
     </div>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-confirm.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/reset-user-layout/reset-confirm.jsp
@@ -23,11 +23,11 @@
   <portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>
 
-<portlet:actionURL var="userUrl">
+<portlet:renderURL var="userUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="cancel"/>
-</portlet:actionURL>
-        
+</portlet:renderURL>
+
 <!-- Portlet -->
 <div class="fl-widget portlet reset-layout view-result" role="section">
 
@@ -38,7 +38,7 @@
     	    <spring:message code="reset.user.layout"/>
     	</h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Content -->
 	<div class="fl-widget-content content portlet-content">
 
@@ -62,7 +62,7 @@
         </div>
 
         </form>
-    
+
     </div> <!-- end: portlet-content -->
 
 </div> <!-- end:portlet -->

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/self-edit-account/success.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/self-edit-account/success.jsp
@@ -19,34 +19,29 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:actionURL var="finishUrl">
-    <portlet:param name="execution" value="${flowExecutionKey}" />
-    <portlet:param name="_eventId" value="finish"/>
-</portlet:actionURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
-<div class="fl-widget portlet user-mgr view-reviewuser" role="section">
+<div id="${n}" class="fl-widget portlet user-mgr view-reviewuser" role="section">
 
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="account.updated"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content">
 
-            <!-- Portlet Section -->
-            <div class="portlet-section" role="region">
-                <div class="content">
-                
-                    <p>
-                        <spring:message code="your.account.has.been.successfully.updated.your.changes.will.be.visible.upon.your.next.login"/>
-                    </p>
+        <!-- Portlet Section -->
+        <div class="portlet-section" role="region">
+            <div class="content">
 
-                </div>
+                <p>
+                    <spring:message code="your.account.has.been.successfully.updated.your.changes.will.be.visible.upon.your.next.login"/>
+                </p>
+
             </div>
-            
-        
+        </div>
+
     </div>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/update-password/success.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/update-password/success.jsp
@@ -19,32 +19,30 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:actionURL var="finishUrl">
+<portlet:renderURL var="finishUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="finish"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
-<div class="fl-widget portlet user-mgr view-reviewuser" role="section">
+<div id="${n}" class="fl-widget portlet user-mgr view-reviewuser" role="section">
 
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
         <h2 class="title" role="heading"><spring:message code="update.my.password"/></h2>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content">
 
             <!-- Portlet Section -->
             <div class="portlet-section" role="region">
                 <div class="content">
-                
                     <p>Your password has been successfully updated.</p>
-
+                    <a class="button btn btn-primary" href="${finishUrl}"><spring:message code="done" /></a>
                 </div>
             </div>
-            
-        
+
     </div>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/confirmRemove.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/confirmRemove.jsp
@@ -24,10 +24,10 @@
 <portlet:actionURL var="submitUrl">
 	<portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>
-<portlet:actionURL var="userUrl">
+<portlet:renderURL var="userUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="cancel"/>
-</portlet:actionURL>
+</portlet:renderURL>
 <!-- END: VALUES BEING PASSED FROM BACKEND -->
 
 <!--
@@ -40,7 +40,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
 | and more, refer to:
 | docs/SKINNING_UPORTAL.md
 -->
-    
+
 <!-- Portlet -->
 <div class="fl-widget portlet ptl-mgr view-confirmremove" role="section">
 
@@ -51,7 +51,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
       <spring:message code="remove.user"/>
     </h2>
   </div> <!-- end: portlet-titlebar -->
-  
+
   <!-- Portlet Content -->
   <div class="fl-widget-content content portlet-content">
 
@@ -73,15 +73,15 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
         <spring:message code="remove.user.confirmation" arguments="${ person.name }"/>
 	  </div>
 	</div> <!-- end: portlet-section -->
-    
+
     <!-- Portlet Buttons -->
     <div class="buttons">
       <input class="button primary btn" type="submit" value="<spring:message code="remove"/>" name="_eventId_remove"/>
       <input class="button btn" type="submit" value="<spring:message code="cancel"/>" name="_eventId_cancel"/>
     </div>
-    
+
     </form:form> <!-- End Form -->
-            
+
 	</div> <!-- end: portlet-content -->
-        
+
 </div> <!-- end: portlet -->

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
@@ -21,32 +21,18 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="userUrl">
+<portlet:renderURL var="userUrl">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="viewUserDetails"/>
-</portlet:actionURL>
-
-<portlet:actionURL var="createUrl">
-    <portlet:param name="execution" value="${flowExecutionKey}" />
-    <portlet:param name="_eventId" value="createPermission"/>
-</portlet:actionURL>
-<portlet:actionURL var="editUrl" escapeXml="false">
+</portlet:renderURL>
+<portlet:renderURL var="editUrl" escapeXml="false">
     <portlet:param name="execution" value="${flowExecutionKey}" />
     <portlet:param name="_eventId" value="editPermission"/>
     <portlet:param name="owner" value="OWNER"/>
     <portlet:param name="activity" value="ACTIVITY"/>
     <portlet:param name="target" value="TARGET"/>
-</portlet:actionURL>
-<portlet:actionURL var="deleteUrl" escapeXml="false">
-    <portlet:param name="execution" value="${flowExecutionKey}" />
-    <portlet:param name="_eventId" value="deletePermission"/>
-    <portlet:param name="owner" value="OWNER"/>
-    <portlet:param name="principalType" value="PRINCIPALTYPE"/>
-    <portlet:param name="principalName" value="PRINCIPALNAME"/>
-    <portlet:param name="activity" value="ACTIVITY"/>
-    <portlet:param name="target" value="TARGET"/>
-    <portlet:param name="permissionType" value="PERMISSIONTYPE"/>
-</portlet:actionURL>
+</portlet:renderURL>
+
 <style>
 #${n}permissionBrowser .dataTables_filter, #${n}permissionBrowser .first.paginate_button, #${n}permissionBrowser .last.paginate_button{
     display: none;
@@ -163,7 +149,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
                 </div>
             </c:forTokens>
             </div>
-        </div> 
+        </div>
     </div>
 </div>
 
@@ -223,7 +209,7 @@ up.jQuery(function() {
         return markup;
     }
 
-    // Created as its own 
+    // Created as its own
     var initializeTable = function(tableName) {
         var config = null;
         if (tableName == "principal") {
@@ -250,7 +236,7 @@ up.jQuery(function() {
             },
             aoColumns: [
                 { mData: 'ownerName', sType: 'html', sWidth: '25%' },  // Owner
-                { mData: 'principalName', sType: 'html', sWidth: '25%', bVisible: config.showPrincipal },  // Principal 
+                { mData: 'principalName', sType: 'html', sWidth: '25%', bVisible: config.showPrincipal },  // Principal
                 { mData: 'activityName', sType: 'html', sWidth: '25%' },  // Activity
                 { mData: 'targetName', sType: 'html', bSearchable: false, sWidth: '25%', bVisible: config.showTarget },  // Target
                 { mData: 'targetName', sType: 'html', bSearchable: false, sWidth: '25%' }  // Edit Link

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/viewUserDetails.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/user-manager/viewUserDetails.jsp
@@ -46,7 +46,7 @@
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- Portlet -->
-<div class="fl-widget portlet user-mgr view-reviewuser" role="section">
+<div id="${n}" class="fl-widget portlet user-mgr view-reviewuser" role="section">
 
     <!-- Portlet Titlebar -->
     <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
@@ -65,21 +65,21 @@
                     <spring:message code="impersonate" text="Impersonate"/>
                     <span class="caret"></span>
                     </a>
-                    <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuImpersonate">
-                      <li role="presentation"><a role="menuitem" tabindex="-1" href="${ impersonateUrl }"><spring:message code="label.default.profile" text="Default Profile"/></a></li>
+                    <ul class="dropdown-menu dropdown-menu-right up-impersonation-menu" role="menu" aria-labelledby="dropdownMenuImpersonate">
+                      <li role="presentation"><a role="menuitem" tabindex="-1" data-href="${ impersonateUrl }" href="javascript:void(0)"><spring:message code="label.default.profile" text="Default Profile"/></a></li>
                       <c:forEach var="profile" items="${profiles}">
                         <portlet:actionURL var="swapDynamicURL">
                             <portlet:param name="execution" value="${flowExecutionKey}" />
                             <portlet:param name="_eventId" value="swapDynamic"/>
                             <portlet:param name="profile" value="${profile.value.profileFname}" />
                         </portlet:actionURL>
-                        <li role="presentation"><a role="menuitem" tabindex="-1" href="${ swapDynamicURL }">${profile.value.profileName}</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" data-href="${ swapDynamicURL }" href="javascript:void(0)">${profile.value.profileName}</a></li>
                       </c:forEach>
                     </ul>
                 </c:if>
         </div>
     </div> <!-- end: portlet-titlebar -->
-    
+
     <!-- Portlet Body -->
     <div class="fl-widget-content content portlet-content">
 
@@ -129,7 +129,22 @@
         </div>
 
         <div class="buttons">
-            <a class="button btn" href="${ backUrl }"><spring:message code="back" text="Back" /></a>
+            <a class="button btn btn-default" href="${ backUrl }"><spring:message code="back" text="Back" /></a>
         </div>
     </div>
 </div>
+
+<script type="text/javascript">
+(function($) {
+    // Impersonation requests must be an actionURL and a POST...
+    $('#${n} .up-impersonation-menu a').click(function() {
+        var url = $(this).attr('data-href');
+        var form = $('<form />', {
+            action: url,
+            method: 'POST',
+            style: 'display: none;'
+        });
+        form.appendTo('body').submit();
+    });
+})(up.jQuery);
+</script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
@@ -140,7 +140,7 @@
             </a>
         </c:forEach>
     </div>
-    <form class="background-edit-form" action="${savePreferencesUrl}" method="post">
+    <form class="background-edit-form" action="${savePreferencesUrl}" method="POST">
         <input class="background-value" type="hidden" name="backgroundImage" value="${backgroundImage}" />
    </form>
 </div>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Favorites/edit.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Favorites/edit.jsp
@@ -66,8 +66,8 @@
           </c:if>
           <c:choose>
             <c:when test="${collection.deleteAllowed}">
-              <a href="${unFavoriteCollectionUrl}">
-                <span class="glyphicon glyphicon-trash pull-right"></span>
+              <a class="up-remove-favorite" data-href="${unFavoriteCollectionUrl}" href="javascript:void(0)">
+                <span class="glyphicon glyphicon-trash pull-right" aria-label="Remove favorite collection"></span>
               </a>
               <a href="${renderRequest.contextPath}/f/${collection.id}/render.uP">
                 ${collection.name}
@@ -100,8 +100,8 @@
           </c:if>
           <c:choose>
             <c:when test="${favorite.deleteAllowed}">
-              <a href="${unFavoritePortletUrl}">
-                <span class="glyphicon glyphicon-trash pull-right"></span>
+              <a class="up-remove-favorite" data-href="${unFavoritePortletUrl}" href="javascript:void(0)">
+                <span class="glyphicon glyphicon-trash pull-right" aria-label="Remove favorite"></span>
               </a>
               <a href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP">
                 ${favorite.name}
@@ -119,7 +119,6 @@
         </li>
       </c:forEach>
     </ul>
-
 
     <c:if test="${lockedItemListed}">
       <span class="help-block"><spring:message
@@ -161,6 +160,19 @@ up.jQuery(function() {
             }
         });
         $('#${n}fav_edit li').disableSelection();
+
+        // Removing a favorite requires an actionURL and a POST...
+        $('#${n}fav_edit a.up-remove-favorite').click(function() {
+            var url = $(this).attr('data-href');
+            var form = $('<form />', {
+                action: url,
+                method: 'POST',
+                style: 'display: none;'
+            });
+            form.appendTo('body').submit();
+        });
     });
 });
 </script>
+
+

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/GoogleAnalytics/config.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/GoogleAnalytics/config.jsp
@@ -328,7 +328,13 @@ up.analytics.config.view = up.analytics.config.view || {};
           });
       },
       completeConfig : function() {
-          window.location.href = "${configDoneUrl}";
+          // The 'done' button requires an actionURL and a POST...
+          var form = $('<form />', {
+              action: '${configDoneUrl}',
+              method: 'POST',
+              style: 'display: none;'
+          });
+          form.appendTo('body').submit();
       }
    });
 

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PopularPortlets/listPortlets.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PopularPortlets/listPortlets.jsp
@@ -130,10 +130,10 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
       <c:if test="${showAdminFeatures}">
         <!-- Portlet Buttons -->
         <div class="portlet-button-group">
-          <portlet:actionURL var="doneUrl">
+          <portlet:renderURL var="doneUrl">
             <portlet:param name="execution" value="${flowExecutionKey}" />
             <portlet:param name="_eventId" value="done" />
-          </portlet:actionURL>
+          </portlet:renderURL>
           <a class="portlet-button portlet-button-primary" href="${doneUrl}"><spring:message code="done"/></a>
         </div>
       </c:if>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PortletError/detailed.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PortletError/detailed.jsp
@@ -20,44 +20,55 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 <c:set var="n"><portlet:namespace/>-${portletWindowId}-</c:set>
-<div class="fl-widget portlet error view-detailed" role="section">
 
-<div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-<p><spring:message code="errorportlet.main"/></p>
-<div class="breadcrumb">
-<portlet:actionURL var="userResetUrl">
-<portlet:param name="failedPortletWindowId" value="${ portletWindowId.stringId}"/>
-</portlet:actionURL>
-<span class="breadcrumb-1"><a href="${ adminRetryUrl }"><spring:message code="errorportlet.retry"/></a></span>
-<span class="breadcrumb-2"><a href="${ userResetUrl }"><spring:message code="errorportlet.reset"/> (User Facing)</a></span> 
-</div> <!-- end breadcrumbs -->
-</div> <!-- end section head -->
+<div id="${n}" class="fl-widget portlet error view-detailed" role="section">
 
-<div class="fl-widget-content fl-fix up-portlet-content-wrapper">
-<ul>
-<li>Portlet Window ID: ${fn:escapeXml(portletWindowId)}</li>
-<li>Channel Definition Name: ${fn:escapeXml(channelDefinition.name)}</li>
-<li><spring:message code="errorportlet.causemessage.admin"/>: <i>${fn:escapeXml(rootCauseMessage)}</i></li>
-</ul>
-<div id="${n}stacktracecontainer">
-<p><button class="stacktracetoggle"><spring:message code="errorportlet.toggleshow"/></button></p>
-<div class="stacktrace" >
-<pre>${fn:escapeXml(stackTrace)}</pre>
-</div>
-</div>
-</div> <!-- end content -->
+    <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
+        <p><spring:message code="errorportlet.main"/></p>
+        <div class="breadcrumb">
+            <portlet:actionURL var="userResetUrl">
+                <portlet:param name="failedPortletWindowId" value="${ portletWindowId.stringId}"/>
+            </portlet:actionURL>
+            <span class="breadcrumb-1"><a href="${ adminRetryUrl }"><spring:message code="errorportlet.retry"/></a></span>
+            <span class="breadcrumb-2"><a data-href="${ userResetUrl }" href="javascript:void(0)"><spring:message code="errorportlet.reset"/> (User Facing)</a></span>
+        </div> <!-- end breadcrumbs -->
+    </div> <!-- end section head -->
+
+    <div class="fl-widget-content fl-fix up-portlet-content-wrapper">
+        <ul>
+            <li>Portlet Window ID: ${fn:escapeXml(portletWindowId)}</li>
+            <li>Channel Definition Name: ${fn:escapeXml(channelDefinition.name)}</li>
+            <li><spring:message code="errorportlet.causemessage.admin"/>: <i>${fn:escapeXml(rootCauseMessage)}</i></li>
+        </ul>
+        <div id="${n}stacktracecontainer">
+            <p><button class="stacktracetoggle"><spring:message code="errorportlet.toggleshow"/></button></p>
+            <div class="stacktrace" >
+                <pre>${fn:escapeXml(stackTrace)}</pre>
+            </div>
+        </div>
+    </div> <!-- end content -->
 
 </div> <!-- end portlet -->
+
 <script type="text/javascript">
-up.jQuery(function() {
-    var $ = up.jQuery;
+(function($) {
 
     $(document).ready(function(){
-    	up.showHideToggle('#${n}stacktracecontainer', { 
+    	up.showHideToggle('#${n}stacktracecontainer', {
         	showmessage: '<spring:message code="errorportlet.toggleshow" htmlEscape="false" javaScriptEscape="true"/>',
         	hidemessage: '<spring:message code="errorportlet.togglehide" htmlEscape="false" javaScriptEscape="true"/>'
     	});
     });
 
-});
+    // Reset requests must be an actionURL and a POST...
+    $('#${n} .breadcrumb a').click(function() {
+        var url = $(this).attr('data-href');
+        var form = $('<form />', {
+            action: url,
+            method: 'POST',
+            style: 'display: none;'
+        });
+        form.appendTo('body').submit();
+    });
+})(up.jQuery);
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PortletError/generic.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/PortletError/generic.jsp
@@ -19,18 +19,36 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
-<div class="fl-widget portlet error view-detailed" role="section">
+<c:set var="n"><portlet:namespace/></c:set>
 
-<div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-<p><spring:message code="errorportlet.main"/></p>
+<div id="${n}" class="fl-widget portlet error view-detailed" role="section">
 
-<div class="breadcrumb">
-<portlet:actionURL var="userResetUrl">
-<portlet:param name="failedPortletWindowId" value="${ portletWindowId.stringId}"/>
-</portlet:actionURL>
-<span class="breadcrumb-1"><a href="${ userResetUrl }"><spring:message code="errorportlet.reset"/></a></span>
-</div> <!-- end breadcrumbs -->
+    <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
+        <p><spring:message code="errorportlet.main"/></p>
 
-</div> <!-- end sectionhead -->
+        <div class="breadcrumb">
+            <portlet:actionURL var="userResetUrl">
+                <portlet:param name="failedPortletWindowId" value="${ portletWindowId.stringId}"/>
+            </portlet:actionURL>
+            <span class="breadcrumb-1"><a data-href="${ userResetUrl }" href="javascript:void(0)"><spring:message code="errorportlet.reset"/></a></span>
+        </div> <!-- end breadcrumbs -->
+
+    </div> <!-- end sectionhead -->
 
 </div> <!--  end portlet -->
+
+<script type="text/javascript">
+(function($) {
+    // Reset requests must be an actionURL and a POST...
+    $('#${n} .breadcrumb a').click(function() {
+        var url = $(this).attr('data-href');
+        var form = $('<form />', {
+            action: url,
+            method: 'POST',
+            style: 'display: none;'
+        });
+        form.appendTo('body').submit();
+    });
+})(up.jQuery);
+</script>
+

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
@@ -33,7 +33,7 @@
     <div class="fl-widget-inner">
       <div class="fl-widget-content">
         <c:set var="searchLabel"><spring:message code="search"/></c:set>
-        <form class="form-search" role="form" method="post" action="${searchLaunchUrl}" id="${n}webSearchForm">
+        <form class="form-search" role="form" method="POST" action="${searchLaunchUrl}" id="${n}webSearchForm">
           <div class="input-group">
             <spring:message code="search" var="searchPlaceholder" />
             <spring:message code="search.terms" var="searchTitle" />

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/addTenant.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/addTenant.jsp
@@ -51,7 +51,7 @@
 
 <div id="${n}tenantManager">
     <h2><spring:message code="tenant.manager.add" /></h2>
-    <form id="addTenantForm" role="form" class="form-horizontal" action="${doAddTenantUrl}" method="post">
+    <form id="addTenantForm" role="form" class="form-horizontal" action="${doAddTenantUrl}" method="POST">
         <c:set var="errorCssClass">
             <c:choose>
                 <c:when test="${invalidFields['name'] ne null}">has-error</c:when>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/tenantDetails.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/tenantDetails.jsp
@@ -47,7 +47,7 @@
 
 <div id="${n}tenantDetails">
     <h2><spring:message code="tenant.details" /> <c:out value="${tenant.name}" /></h2>
-    <form id="updateTenantForm" role="form" class="form-horizontal" action="${doUpdateTenantUrl}" method="post">
+    <form id="updateTenantForm" role="form" class="form-horizontal" action="${doUpdateTenantUrl}" method="POST">
         <c:forEach items="${tenantManagerAttributes}" var="attribute">
             <c:set var="errorCssClass">
                 <c:choose>
@@ -76,10 +76,27 @@
                     <portlet:param name="action" value="doListenerAction"/>
                     <portlet:param name="fname" value="${listenerAction.fname}"/>
                 </portlet:actionURL>
-                <a class="btn btn-default" href="${listenerActionUrl}" onclick="return confirm('<spring:message code="tenant.manager.invoke.action.confirm" />')" role="button"><spring:message code="${listenerAction.messageCode}" htmlEscape="false" /></a>
+                <a class="btn btn-default up-tenant-listener-action" data-href="${listenerActionUrl}" href="javascript:void(0)" role="button"><spring:message code="${listenerAction.messageCode}" htmlEscape="false" /></a>
             </c:forEach>
             <button class="btn btn-primary" type="submit" onclick="return confirm('<spring:message code="tenant.manager.update.attributes.confirm" arguments="${tenant.name}" />')"><spring:message code="tenant.manager.update.attributes" htmlEscape="false" /></button>
             <a class="btn btn-link" href="<portlet:renderURL />" role="button"><spring:message code="cancel" /></a>
         </div>
     </form>
 </div>
+
+<script type="text/javascript">
+(function($) {
+    // Tenant operations listener actions must be invoked with an actionURL and a POST...
+    $('#${n}tenantDetails a.up-tenant-listener-action').click(function() {
+        if (confirm('<spring:message code="tenant.manager.invoke.action.confirm" />')) {
+            var url = $(this).attr('data-href');
+            var form = $('<form />', {
+                action: url,
+                method: 'POST',
+                style: 'display: none;'
+            });
+            form.appendTo('body').submit();
+        }
+    });
+})(up.jQuery);
+</script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/tenantManager.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/TenantManager/tenantManager.jsp
@@ -73,7 +73,7 @@
                                     <td><a href="${detailsUrl}" title="<spring:message code="tenant.manager.edit" /> ${tenant.name}"><c:out value="${tenant.name}" /></a></td>
                                     <td><c:out value="${tenant.fname}" /></td>
                                     <td><a href="mailto:${tenant.attributesMap['adminContactEmail']}" title="<spring:message code="tenant.manager.email.address.link" />">${tenant.attributesMap['adminContactUsername']}</a></td>
-                                    <td class="text-right"><a href="${removeUrl}" onclick="return confirm('<spring:message code="tenant.manager.remove.tenant.confirm" arguments="${tenant.name}" />')" title="<spring:message code="tenant.manager.remove.tenant" />" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash"></span> <spring:message code="tenant.manager.remove" /></a></td>
+                                    <td class="text-right"><a class="btn btn-xs btn-danger up-tenant-remove" data-href="${removeUrl}" data-confirm="<spring:message code="tenant.manager.remove.tenant.confirm" arguments="${tenant.name}" />" title="<spring:message code="tenant.manager.remove.tenant" />" href="javascript:void(0)"><span class="glyphicon glyphicon-trash"></span> <spring:message code="tenant.manager.remove" /></a></td>
                                 </tr>
                             </c:forEach>
                         </tbody>
@@ -86,3 +86,21 @@
         </div>
     </div>
 </div>
+
+<script type="text/javascript">
+(function($) {
+    // Deleting a tenant requires an actionURL and a POST...
+    $('#${n}tenantManager a.up-tenant-remove').click(function() {
+        var confirmText = $(this).attr('data-confirm');
+        if (confirm(confirmText)) {
+            var url = $(this).attr('data-href');
+            var form = $('<form />', {
+                action: url,
+                method: 'POST',
+                style: 'display: none;'
+            });
+            form.appendTo('body').submit();
+        }
+    });
+})(up.jQuery);
+</script>


### PR DESCRIPTION
…ethod Not Allowed

https://issues.jasig.org/browse/UP-5013

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

There were several portlet actionURLs -- particularly in the Webflow-based admin portlets -- that were being sent as an HTTP GET.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
