### PR TITLE
docs: annotate with @Override

### DIFF
--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/DistributedLayoutManager.java
@@ -295,10 +295,12 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         }
     }
 
+    @Override
     public synchronized void loadUserLayout() throws PortalException {
         this.loadUserLayout(false);
     }
 
+    @Override
     public synchronized void loadUserLayout(boolean reload) throws PortalException {
         Document uli = null;
         try {
@@ -330,6 +332,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         }
     }
 
+    @Override
     public synchronized void saveUserLayout() throws PortalException {
         Document uld = this.getUserLayoutDOM();
 
@@ -377,6 +380,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return allSubscribedChannels;
     }
 
+    @Override
     public IUserLayoutNodeDescription getNode(String nodeId) throws PortalException {
         if (nodeId == null) return null;
 
@@ -403,6 +407,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return desc;
     }
 
+    @Override
     public IUserLayoutNodeDescription addNode(
             IUserLayoutNodeDescription node, String parentId, String nextSiblingId)
             throws PortalException {
@@ -459,6 +464,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return null;
     }
 
+    @Override
     public boolean moveNode(String nodeId, String parentId, String nextSiblingId)
             throws PortalException {
         IUserLayoutNodeDescription parent = this.getNode(parentId);
@@ -496,6 +502,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return false;
     }
 
+    @Override
     public boolean deleteNode(String nodeId) throws PortalException {
         if (canDeleteNode(nodeId)) {
             IUserLayoutNodeDescription nodeDescription = this.getNode(nodeId);
@@ -550,6 +557,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      * the owning fragment. If the node is a user owned node then the changes are applied directly
      * to the corresponding node in the PLF.
      */
+    @Override
     public synchronized boolean updateNode(IUserLayoutNodeDescription node) throws PortalException {
         if (canUpdateNode(node)) {
             String nodeId = node.getId();
@@ -908,6 +916,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         }
     }
 
+    @Override
     public boolean canAddNode(
             IUserLayoutNodeDescription node, String parentId, String nextSiblingId)
             throws PortalException {
@@ -978,6 +987,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return false; // oops never found the sib
     }
 
+    @Override
     public boolean canMoveNode(String nodeId, String parentId, String nextSiblingId)
             throws PortalException {
         return this.canMoveNode(this.getNode(nodeId), this.getNode(parentId), nextSiblingId);
@@ -1057,6 +1067,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return false; // oops never found the sib
     }
 
+    @Override
     public boolean canDeleteNode(String nodeId) throws PortalException {
         return canDeleteNode(this.getNode(nodeId));
     }
@@ -1079,6 +1090,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      * Returns true if we are dealing with a fragment layout or if editing of attributes is allowed,
      * or the node is a channel since ad-hoc parameters can always be added.
      */
+    @Override
     public boolean canUpdateNode(IUserLayoutNodeDescription node) {
         if (node == null) return false;
 
@@ -1091,6 +1103,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      * Unsupported operation in DLM. This feature is handled by pluggable processors in the DLM
      * processing pipe. See properties/dlmContext.xml.
      */
+    @Override
     public void markAddTargets(IUserLayoutNodeDescription node) {
         throw new UnsupportedOperationException(
                 "Use an appropriate " + "processor for adding targets.");
@@ -1100,11 +1113,13 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      * Unsupported operation in DLM. This feature is handled by pluggable processors in the DLM
      * processing pipe. See properties/dlmContext.xml.
      */
+    @Override
     public void markMoveTargets(String nodeId) throws PortalException {
         throw new UnsupportedOperationException(
                 "Use an appropriate " + "processor for adding targets.");
     }
 
+    @Override
     public String getParentId(String nodeId) throws PortalException {
         Document uld = this.getUserLayoutDOM();
         Element nelement = uld.getElementById(nodeId);
@@ -1130,6 +1145,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
                         + ".");
     }
 
+    @Override
     public String getNextSiblingId(String nodeId) throws PortalException {
         Document uld = this.getUserLayoutDOM();
         Element nelement = uld.getElementById(nodeId);
@@ -1154,6 +1170,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
                         + ".");
     }
 
+    @Override
     public String getPreviousSiblingId(String nodeId) throws PortalException {
         Document uld = this.getUserLayoutDOM();
         Element nelement = uld.getElementById(nodeId);
@@ -1177,6 +1194,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
                         + ".");
     }
 
+    @Override
     public Enumeration<String> getChildIds(String nodeId) throws PortalException {
         return getChildIds(nodeId, false);
     }
@@ -1225,6 +1243,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         this.cacheKey = Long.toString(rnd.nextLong());
     }
 
+    @Override
     public int getLayoutId() {
         return profile.getLayoutId();
     }
@@ -1239,6 +1258,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
         return new PortletSubscribeIdResolver(fname).traverseDocument(userLayout);
     }
 
+    @Override
     public String getSubscribeId(String parentFolderId, String fname) {
         final Map<String, String> variables = new HashMap<String, String>();
         variables.put("parentFolderId", parentFolderId);
@@ -1261,6 +1281,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
     /* (non-Javadoc)
      * @see org.apereo.portal.layout.IUserLayoutManager#getUserLayout()
      */
+    @Override
     public IUserLayout getUserLayout() throws PortalException {
         // Copied from SimpleLayoutManager since our layouts are regular
         // simple layouts, ie Documents.
@@ -1274,6 +1295,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      * @see org.apereo.portal.layout.IUserLayoutManager#getRootFolderId()
      * @see org.apereo.portal.layout.dlm.RootLocator
      */
+    @Override
     public String getRootFolderId() {
         if (rootNodeId == null) {
             Document layout = getUserLayoutDOM();
@@ -1311,6 +1333,7 @@ public class DistributedLayoutManager implements IUserLayoutManager, Initializin
      *
      * @see org.apereo.portal.layout.IUserLayoutManager#getDepth(java.lang.String)
      */
+    @Override
     public int getDepth(String nodeId) throws PortalException {
         // can't see what it calling this anywhere so ignoring for now.
         // TODO waiting to hear back from peter/michael

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentComparator.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/FragmentComparator.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
  */
 public class FragmentComparator implements Comparator<FragmentDefinition> {
 
+    @Override
     public int compare(FragmentDefinition frag1, FragmentDefinition frag2) {
         if (frag1.getPrecedence() == frag2.getPrecedence()) {
             return (int) (frag1.getId() - frag2.getId());

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAAddParameter.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAAddParameter.java
@@ -39,6 +39,7 @@ public class LPAAddParameter implements ILayoutProcessingAction {
      * Add a parameter for a channel in both the ILF and PLF using the appropriate mechanisms for
      * incorporated nodes versus owned nodes.
      */
+    @Override
     public void perform() throws PortalException {
         // push the change into the PLF
         if (nodeId.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAChangeAttribute.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAChangeAttribute.java
@@ -36,6 +36,7 @@ public class LPAChangeAttribute implements ILayoutProcessingAction {
     }
 
     /** Apply the attribute change. */
+    @Override
     public void perform() throws PortalException {
         // push the change into the PLF
         if (nodeId.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAChangeParameter.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAChangeParameter.java
@@ -40,6 +40,7 @@ public class LPAChangeParameter implements ILayoutProcessingAction {
      * Change the parameter for a channel in both the ILF and PLF using the appropriate mechanisms
      * for incorporated nodes versus owned nodes.
      */
+    @Override
     public void perform() throws PortalException {
         // push the change into the PLF
         if (nodeId.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAEditRestriction.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAEditRestriction.java
@@ -46,6 +46,7 @@ public class LPAEditRestriction implements ILayoutProcessingAction {
      * Pushes the indicated restriction attribute changes into both the ILF and PLF versions of the
      * layouts since this will only be done when editing a fragment.
      */
+    @Override
     public void perform() throws PortalException {
         Element plfNode = HandlerUtils.getPLFNode(ilfNode, person, false, false);
 

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPARemoveParameter.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPARemoveParameter.java
@@ -37,6 +37,7 @@ public class LPARemoveParameter implements ILayoutProcessingAction {
      * Remove the parameter from a channel in both the ILF and PLF using the appropriate mechanisms
      * for incorporated nodes versus owned nodes.
      */
+    @Override
     public void perform() throws PortalException {
         // push the change into the PLF
         if (nodeId.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAResetAttribute.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAResetAttribute.java
@@ -39,6 +39,7 @@ public class LPAResetAttribute implements ILayoutProcessingAction {
      * Reset a parameter to not override the value specified by a fragment. This is done by removing
      * the parm edit in the PLF and setting the value in the ILF to the passed-in fragment value.
      */
+    @Override
     public void perform() throws PortalException {
         /*
          * push the change into the PLF

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAResetParameter.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/LPAResetParameter.java
@@ -40,6 +40,7 @@ public class LPAResetParameter implements ILayoutProcessingAction {
      * removing the parm edit in the PLF and setting the value in the ILF to the passed-in fragment
      * value.
      */
+    @Override
     public void perform() throws PortalException {
         // push the change into the PLF
         if (nodeId.startsWith(Constants.FRAGMENT_ID_USER_PREFIX)) {

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/MissingPortletDefinition.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/MissingPortletDefinition.java
@@ -320,6 +320,7 @@ public class MissingPortletDefinition implements IPortletDefinition {
             return null;
         }
 
+        @Override
         public void setDescription(String descr) {}
 
         @Override

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/MissingPortletDefinition.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/MissingPortletDefinition.java
@@ -219,6 +219,7 @@ public class MissingPortletDefinition implements IPortletDefinition {
         return new MissingPortletType();
     }
 
+    @Override
     public void setType(IPortletType channelType) {}
 
     @Override

--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/Precedence.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/Precedence.java
@@ -30,6 +30,7 @@ public final class Precedence {
         return new Precedence(fragmentIdx);
     }
 
+    @Override
     public String toString() {
         return "p[" + precedence + ", " + fragmentId + "]";
     }

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/statistics/BasePortletLayoutStatisticsController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/statistics/BasePortletLayoutStatisticsController.java
@@ -130,6 +130,7 @@ public abstract class BasePortletLayoutStatisticsController<F extends BasePortle
         return PortletLayoutAggregationDiscriminatorImpl.Comparator.INSTANCE;
     }
 
+    @Override
     protected Map<PortletLayoutAggregationDiscriminator, SortedSet<PortletLayoutAggregation>>
             createColumnDiscriminatorMap(F form) {
         // Collections used to track the queried groups and the results

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/statistics/TabRenderStatisticsController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/statistics/TabRenderStatisticsController.java
@@ -155,6 +155,7 @@ public class TabRenderStatisticsController
         return TabRenderAggregationDiscriminatorImpl.Comparator.INSTANCE;
     }
 
+    @Override
     protected Map<TabRenderAggregationDiscriminator, SortedSet<TabRenderAggregation>>
             createColumnDiscriminatorMap(TabRenderReportForm form) {
         // Collections used to track the queried groups and the results


### PR DESCRIPTION
The build logs have a bunch of `warning: [MissingOverride]` noise. Add the suggested `@Override` annotations and thereby reduce the noise.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (roughly, conventional commits)
-   N/A tests are included (retains existing tests, which still pass, because this is a no-op)
-   [x] documentation is changed or added (documents overridden methods as `@Override`
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
