### PR TITLE
docs: lead with radical welcoming of participation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,4 +6,13 @@ The [Apereo Foundation Welcoming Policy][] therefore applies.
 
 In addition to reporting mechanisms under that Policy, participants may at any time contact the uPortal Steering Committee ( `uportal-steering-committee@apereo.org` ) about any matter, and may designate their contact as confidential if they prefer. All contact will be acknowledged. Contacts regarding issues covered by the Welcoming Policy will be handled in a manner consistent with that policy.
 
+In addition to the commitments under Apereo Foundation policy generally, uPortal is committed to 
+welcoming participation and contribution. The contributing guidelines for this repository lead with
+this:
+
+> If you're unsure or afraid of _anything_, just ask or submit the issue or pull request anyways. 
+  You won't be yelled at for giving your best effort. The worst that can happen is that you'll be 
+  politely asked to change something. We appreciate any sort of contributions, and don't want a wall
+  of rules to get in the way of that.
+
 [Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Contributions from the community are essential in keeping uPortal (any Open Source project really) strong and successful.  While we try to keep requirements for contributing to a minimum, there are a few guidelines we ask that you mind.
 
+## Most importantly
+
+If you're unsure or afraid of _anything_, just ask or submit the issue or pull request anyways. You 
+won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely
+asked to change something. We appreciate any sort of contributions, and don't want a wall of rules 
+to get in the way of that.
+
+However, for those individuals who want a bit more guidance on the best way to contribute to the 
+project, read on. This document will cover what we're looking for. By addressing all the points 
+we're looking for, it raises the chances we can quickly merge or address your contributions.
 
 ## Individual Contributor License Agreement
 
@@ -95,6 +105,11 @@ If your change is to a user-facing experience, it should not regress support for
 *   Update the JIRA issue, adding a comment including a link to the created pull request.  If the problem or improvement came to be better understood through implementation, update the description and add comments to communicate what was learned.  A release engineer will rely upon the JIRA to summarize release notes for the release including your change and those release notes will link to the JIRA issue, so the JIRA issue as a good place to communicate clearly about _what_ was changed _why_ and _how_.
 
 
+## Acknowledgements
+
+* Portions of these contributing guidelines inspired by 
+  [HashiCorp packer contributing guidelines][].
+
 [Apereo licensing generally]: http://www.apereo.org/licensing
 [contributor licensing agreements specifically]: http://www.apereo.org/licensing/agreements
 [Contributor License Agreement]: http://www.apereo.org/licensing/agreements
@@ -111,3 +126,5 @@ If your change is to a user-facing experience, it should not regress support for
 [google-java-format-gradle-plugin_quickstart]: https://github.com/sherter/google-java-format-gradle-plugin#quick-start
 
 [architecture]: https://wiki.jasig.org/pages/viewpage.action?pageId=65274379
+
+[HashiCorp packer contributing guidelines]: https://github.com/hashicorp/packer/commit/87edf671771680e0989798a3460ff00453b9aa89#diff-6a3371457528722a734f3c51d9238c13


### PR DESCRIPTION
Let's be more radically welcoming of participation and contribution. [HashiCorp's example](https://github.com/hashicorp/packer/commit/87edf671771680e0989798a3460ff00453b9aa89#diff-6a3371457528722a734f3c51d9238c13R3) [inspires](https://twitter.com/ScribblingOn/status/995715231300050944).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [ ] commit message follows [commit guidelines][] (roughly follows conventional commits)
-   N/A tests are included
-   [x] documentation is changed or added
-   N/A [message properties][] have been updated with new phrases
-   N/A view conforms with [WCAG 2.0 AA][]

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
