### PR TITLE
docs: adding paragraph on conflict resolution

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,7 +15,7 @@ this:
   politely asked to change something. We appreciate any sort of contributions, and don't want a wall
   of rules to get in the way of that.
 
-The uPortal Community is a global community. Because conversations are time-shifted and geo-separated, it is especially important to use appropriate care when communicating. uPortal has a strong tradition of operating through consensus and compromise; flexibility is appreciated and a fair bit of deference is given to the person actually making the contribution. Keeping in mind an emphasis on respect, compassion, and empathy for others helps us avoid or resolve conflicts. When conflicts do arise, we encourage direct communication towards a mutually satisfactory resolution. Ideally we can harness the passion within the community towards effective change and growth. The [uPortal Steering Committee][] acts as a final arbiter for conflict resolution.
+The uPortal Community is a global community. Because conversations are time-shifted and geo-separated, it is especially important to use appropriate care when communicating. uPortal has a strong tradition of operating through consensus and compromise; flexibility is appreciated. Keeping in mind an emphasis on respect, compassion, and empathy for others helps us avoid or resolve conflicts. When conflicts do arise, we encourage direct communication towards a mutually satisfactory resolution. Ideally we can harness the passion within the community towards effective change and growth. The [uPortal Steering Committee][] acts as a final arbiter for conflict resolution.
 
 [Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy
 [uPortal Steering Committee]: mailto:uportal-steering-committee@apereo.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,4 +15,6 @@ this:
   politely asked to change something. We appreciate any sort of contributions, and don't want a wall
   of rules to get in the way of that.
 
+The uPortal Community is a global community. Because conversations are time-shifted and geo-separated, it is especially important to use appropriate care when communicating. uPortal has a strong tradition of operating through consensus and compromise; flexibility is appreciated and a fair bit of deference is given to the person actually making the contribution. Keeping in mind an emphasis on respect, compassion, and empathy for others helps us avoid or resolve conflicts. When conflicts do arise, we encourage direct communication towards a mutually satisfactory resolution. Ideally we can harness the passion within the community towards effective change and growth. The uPortal Steering Committee acts as a final arbiter for conflict resolution.
+
 [Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ uPortal is an Apereo Foundation sponsored project.
 
 The [Apereo Foundation Welcoming Policy][] therefore applies.
 
-In addition to reporting mechanisms under that Policy, participants may at any time contact the uPortal Steering Committee ( `uportal-steering-committee@apereo.org` ) about any matter, and may designate their contact as confidential if they prefer. All contact will be acknowledged. Contacts regarding issues covered by the Welcoming Policy will be handled in a manner consistent with that policy.
+In addition to reporting mechanisms under that Policy, participants may at any time contact the [uPortal Steering Committee][] about any matter, and may designate their contact as confidential if they prefer. All contact will be acknowledged. Contacts regarding issues covered by the Welcoming Policy will be handled in a manner consistent with that policy.
 
 In addition to the commitments under Apereo Foundation policy generally, uPortal is committed to 
 welcoming participation and contribution. The contributing guidelines for this repository lead with
@@ -15,6 +15,7 @@ this:
   politely asked to change something. We appreciate any sort of contributions, and don't want a wall
   of rules to get in the way of that.
 
-The uPortal Community is a global community. Because conversations are time-shifted and geo-separated, it is especially important to use appropriate care when communicating. uPortal has a strong tradition of operating through consensus and compromise; flexibility is appreciated and a fair bit of deference is given to the person actually making the contribution. Keeping in mind an emphasis on respect, compassion, and empathy for others helps us avoid or resolve conflicts. When conflicts do arise, we encourage direct communication towards a mutually satisfactory resolution. Ideally we can harness the passion within the community towards effective change and growth. The uPortal Steering Committee acts as a final arbiter for conflict resolution.
+The uPortal Community is a global community. Because conversations are time-shifted and geo-separated, it is especially important to use appropriate care when communicating. uPortal has a strong tradition of operating through consensus and compromise; flexibility is appreciated and a fair bit of deference is given to the person actually making the contribution. Keeping in mind an emphasis on respect, compassion, and empathy for others helps us avoid or resolve conflicts. When conflicts do arise, we encourage direct communication towards a mutually satisfactory resolution. Ideally we can harness the passion within the community towards effective change and growth. The [uPortal Steering Committee][] acts as a final arbiter for conflict resolution.
 
 [Apereo Foundation Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy
+[uPortal Steering Committee]: mailto:uportal-steering-committee@apereo.org


### PR DESCRIPTION
The current incubation exit criteria require a conflict resolution policy. Projects like uPortal Home defer to the uPortal code of conduct and with the addition of this conflict resolution policy, they can satisfy that criteria.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ x] the [individual contributor license agreement][] is signed
-   [ x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [x ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
