### PR TITLE
implemented the post-content region

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -273,6 +273,25 @@
         </xsl:if>
     </xsl:template>
 
+    <!-- ========== TEMPLATE: POST-CONTENT ========== -->
+    <!-- =========================================== -->
+    <!--
+     | This template renders portlets in the area just below content (columns or focused portlet).
+    -->
+    <xsl:template name="region.post-content">
+        <xsl:if test="//region[@name='post-content']/channel">
+            <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
+            <div id="region-post-content" class="row">
+                <div class="col-md-12">
+                    <xsl:for-each select="//region[@name='post-content']/channel">
+                        <xsl:call-template name="regions.portlet.decorator" />
+                    </xsl:for-each>
+                </div>
+            </div>
+            <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
+        </xsl:if>
+    </xsl:template>
+
     <!-- ========== TEMPLATE: SIDEBAR-RIGHT ========== -->
     <!-- ============================================= -->
     <!--

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -740,6 +740,8 @@
                                 </xsl:choose>
                                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
 
+                                <!--add post content here-->
+                                <xsl:call-template name="region.post-content" />
                                 <!-- /USE FLUID ROWS -->
                             </div>
                             <xsl:call-template name="region.sidebar-right" />

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less
@@ -283,6 +283,13 @@
         margin-top: 8px;
     }
 
+    /* ==========================================================================
+       Namespace: .region-post-content
+       ========================================================================== */
+    #region-post-content {
+      margin-bottom: 8px;
+    }
+
 }
 
 @media only screen and (min-width: @screen-sm-min) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
changed three files to implement the post-content region for uPortal-5
Drew Willis asked me to make these changes when we found that the post-content region was not usable.

changed uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl to include the call to the region.post-content template found in regions.xsl file

changed uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl to include the region.post-content template to put the portlets in the right space with the correct css

changed uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/regions.less to include the #region-post-content css

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
