### PR TITLE
build: remove unused gradle scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,6 @@ node {
     download = true
 }
 
-/*======== Static Analysis ========*/
-buildScan {
-    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
-    licenseAgree = 'yes'
-}
-
 allprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     // Top level plugins
-    id 'com.gradle.build-scan' version '1.13.1'
     id 'build-announcements'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'com.moowork.node' version '1.2.0'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

scan plugin is now integrated into the gradle platform, plugin is no longer needed.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
