### PR TITLE
Using xsl:attribute to build the <body>'s class attribute

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -652,7 +652,11 @@
             -->
             <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
         </head>
-        <body class="up dashboard portal fl-theme-mist">
+        <body>
+          <xsl:attribute name="class">
+            <xsl:text>up dashboard portal fl-theme-mist</xsl:text>
+            <xsl:if test="$PORTAL_VIEW='focused'"> focused</xsl:if>
+          </xsl:attribute>
           <xsl:call-template name="skipnav" />
           <div class="row-offcanvas">
             <div id="up-notification"></div>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -655,7 +655,7 @@
         <body>
           <xsl:attribute name="class">
             <xsl:text>up dashboard portal fl-theme-mist</xsl:text>
-            <xsl:if test="$PORTAL_VIEW='focused'"> focused</xsl:if>
+            <xsl:if test="$PORTAL_VIEW='focused'"> up-focused</xsl:if>
           </xsl:attribute>
           <xsl:call-template name="skipnav" />
           <div class="row-offcanvas">


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
We have a need to style the portal a little differently when viewing portlets in maximized mode. Building the `<body>`'s `class` attribute was inspired by WordPress [body_class()](https://developer.wordpress.org/reference/functions/body_class/).

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
