### PR TITLE
feat(xsl): don't show mezzanine content on focused mode

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/structure/columns/columns.xsl
+++ b/uPortal-webapp/src/main/resources/layout/structure/columns/columns.xsl
@@ -166,7 +166,7 @@
                     </xsl:when>
                     <xsl:otherwise>
                         <!-- Include all regions EXCEPT 'region-customize' when in FOCUSED mode -->
-                        <xsl:for-each select="child::folder[@type!='customize' and @type!='regular' and @type!='sidebar' and channel]"><!-- Ignores empty folders -->
+                        <xsl:for-each select="child::folder[@type!='customize' and @type!='mezzanine' and @type!='regular' and @type!='sidebar' and channel]"><!-- Ignores empty folders -->
                             <xsl:call-template name="region"/>
                         </xsl:for-each>
                     </xsl:otherwise>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Purposed feature to render only the content of the mezzanine region not in focused mode, it permit to place in this region a content that won't be always rendered when we are focusing on a portlet. it could be a good thing to have a such part (in header) not shown in focused mode.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
