### PR TITLE
Issue #1306:  rename settings for jgroups from 'hibernate.connection.…

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -93,16 +93,20 @@
     <!-- Resolver that can be used to dynamically look up property values at run-time -->
     <bean id="propertyResolver" factory-bean="primaryPropertyPlaceholderConfigurer" factory-method="getPropertyResolver"/>
 
-    <!-- Add properties for jgroups.xml as that is not a Spring context -->
+    <!--
+     | Add properties for jgroups.xml as that is not a Spring context;  prefix DB connection
+     | settings with 'jgroups' instead of 'hibernate' b/c the standard hibernate props may impact
+     | other webapps.
+     +-->
     <bean id="systemPropertySetter" class="org.apereo.portal.spring.context.SystemPropertySetter">
         <property name="systemProperties">
             <props>
                 <prop key="uPortal.cacheManager.jgroups.fd_sock.start_port">${uPortal.cacheManager.jgroups.fd_sock.start_port:}</prop>
                 <prop key="uPortal.cacheManager.jgroups.tcp.bind_port">${uPortal.cacheManager.jgroups.tcp.bind_port:}</prop>
-                <prop key="hibernate.connection.driver_class">${hibernate.connection.driver_class}</prop>
-                <prop key="hibernate.connection.url">${hibernate.connection.url}</prop>
-                <prop key="hibernate.connection.username">${hibernate.connection.username}</prop>
-                <prop key="hibernate.connection.password">${hibernate.connection.password}</prop>
+                <prop key="jgroups.connection.driver_class">${hibernate.connection.driver_class}</prop>
+                <prop key="jgroups.connection.url">${hibernate.connection.url}</prop>
+                <prop key="jgroups.connection.username">${hibernate.connection.username}</prop>
+                <prop key="jgroups.connection.password">${hibernate.connection.password}</prop>
                 <prop key="org.apereo.portal.jgroups.auth.token">${org.apereo.portal.jgroups.auth.token:DEV-345B45TB3}</prop>
             </props>
         </property>

--- a/uPortal-webapp/src/main/resources/properties/jgroups.xml
+++ b/uPortal-webapp/src/main/resources/properties/jgroups.xml
@@ -45,10 +45,10 @@
     <!-- User database for discovery;  initialize_sql to blank prevents
          table creation, which we handle with Hibernate via dbloader -->
     <JDBC_PING
-            connection_url="${hibernate.connection.url}"
-            connection_username="${hibernate.connection.username}"
-            connection_password="${hibernate.connection.password}"
-            connection_driver="${hibernate.connection.driver_class}"
+            connection_url="${jgroups.connection.url}"
+            connection_username="${jgroups.connection.username}"
+            connection_password="${jgroups.connection.password}"
+            connection_driver="${jgroups.connection.driver_class}"
             initialize_sql=""
     />
     <MERGE3  min_interval="5000"


### PR DESCRIPTION
…..' to 'jgroups.connection...' to prevent interference with other Hibernate-powered webapps

fixes #1306 

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
