### PR TITLE
fix(SmartLdapGroupStore): fix configurable property not used

### DIFF
--- a/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
@@ -69,7 +69,7 @@
 
                 def newChildren=[];
                 if (req.hasAttribute('childGroupKeyRegex')) {
-                    def pattern = req.hasAttribute('pattern') ? req.getAttribute('pattern') : java.util.regex.Pattern.compile(ScriptAttributes.REQUEST.getAttribute("childGroupKeyRegex"));
+                    def pattern = req.hasAttribute('pattern') ? req.getAttribute('pattern') : java.util.regex.Pattern.compile(req.getAttribute("childGroupKeyRegex"));
                     ScriptAttributes.RESPONSE.setAttribute('pattern', pattern);
                         for (String child : record.getKeysOfChildren()) {
                             def matcher = pattern.matcher(child);
@@ -87,7 +87,8 @@
                     int sepPos;
                     boolean stop = false;
                     boolean isGroup = true;
-                    while ((sepPos=current.lastIndexOf(':')) > 0 &amp;&amp; ! stop) {
+                    String sep = req.hasAttribute('groupTreeSeparator') ? req.getAttribute("groupTreeSeparator") : ':';
+                    while ((sepPos=current.lastIndexOf(sep)) > 0 &amp;&amp; !stop) {
                         String previous = current;
                         current = current.substring(0, sepPos);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix init.crn that doesn't use the property that permit to customize (other than ":") the char to decompose group tree in group id/cn.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
