### PR TITLE
UP-4727 : Managing uPortal running on several servername with CAS

### DIFF
--- a/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/security/mvc/LogoutController.java
+++ b/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/security/mvc/LogoutController.java
@@ -24,6 +24,7 @@ import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.ISecurityContext;
 import org.apereo.portal.security.IdentitySwapperManager;
+import org.apereo.portal.url.UrlAuthCustomizerRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,7 @@ public class LogoutController {
     private IPortalAuthEventFactory portalEventFactory;
     private IPersonManager personManager;
     private IdentitySwapperManager identitySwapperManager;
+    private UrlAuthCustomizerRegistry urlCustomizer;
 
     @Autowired
     public void setIdentitySwapperManager(IdentitySwapperManager identitySwapperManager) {
@@ -61,6 +63,11 @@ public class LogoutController {
     @Autowired
     public void setPortalEventFactory(IPortalAuthEventFactory portalEventFactory) {
         this.portalEventFactory = portalEventFactory;
+    }
+
+    @Autowired
+    public void setUrlCustomizer(UrlAuthCustomizerRegistry urlCustomizer) {
+        this.urlCustomizer = urlCustomizer;
     }
 
     /**
@@ -127,6 +134,8 @@ public class LogoutController {
      */
     private String selectRedirectionUrl(HttpServletRequest request) {
 
+        final String defaultRedirect = request.getContextPath() + "/";
+
         String rslt = null; // default
 
         // Get the person object associated with the request
@@ -142,7 +151,10 @@ public class LogoutController {
         }
 
         // Otherwise use a sensible default...
-        rslt = rslt != null ? rslt : request.getContextPath() + "/";
+        rslt =
+                rslt != null
+                        ? urlCustomizer.customizeUrl(request, rslt)
+                        : urlCustomizer.customizeUrl(request, defaultRedirect);
 
         logger.debug("Calculated redirectionURL='{}' for user='{}'", rslt, username);
 

--- a/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/url/CasLoginRefUrlEncoder.java
+++ b/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/url/CasLoginRefUrlEncoder.java
@@ -18,6 +18,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.security.mvc.LoginController;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 
 /**
@@ -30,13 +31,20 @@ public class CasLoginRefUrlEncoder implements LoginRefUrlEncoder {
 
     private String casLoginUrl;
 
+    private UrlAuthCustomizerRegistry urlCustomizer;
+
     @Required
     public void setCasLoginUrl(String casLoginUrl) {
         this.casLoginUrl = casLoginUrl;
     }
 
-    public String getCasLoginUrl() {
-        return casLoginUrl;
+    @Autowired
+    public void setUrlCustomizer(UrlAuthCustomizerRegistry urlCustomizer) {
+        this.urlCustomizer = urlCustomizer;
+    }
+
+    public String getCasLoginUrl(final HttpServletRequest request) {
+        return urlCustomizer.customizeUrl(request, this.casLoginUrl);
     }
 
     @Override
@@ -58,6 +66,6 @@ public class CasLoginRefUrlEncoder implements LoginRefUrlEncoder {
             loginRedirect.append(URLEncoder.encode(firstEncoding, requestEncoding));
         }
 
-        return loginRedirect.toString();
+        return urlCustomizer.customizeUrl(request, loginRedirect.toString());
     }
 }

--- a/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
+++ b/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
@@ -16,12 +16,15 @@ package org.apereo.portal.url;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Sets;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-/** @Author James Wennmacher, jwennmacher@unicon.net */
+/** Some Testing on CasLoginRefUrlEncoder class. */
 public class CasLoginRefUrlEncoderTest {
 
     CasLoginRefUrlEncoder encoder;
@@ -30,9 +33,20 @@ public class CasLoginRefUrlEncoderTest {
     @Before
     public void setUp() throws UnsupportedEncodingException {
         encoder = new CasLoginRefUrlEncoder();
-        encoder.setCasLoginUrl("https://cas:80/cas/login?service=myhost:8080/uPortal/Login");
+        encoder.setCasLoginUrl(
+                "https://cas:80/cas/login?service=_CURRENT_SERVER_NAME_/uPortal/Login");
+        UrlMultiServerNameCustomizer urlCustomizer = new UrlMultiServerNameCustomizer();
+        urlCustomizer.setAllServerNames(Sets.newHashSet("myhost:8080", "theirhost:8443"));
+        List<IAuthUrlCustomizer> customizers = new ArrayList<>();
+        customizers.add(urlCustomizer);
+        UrlAuthCustomizerRegistry registry = new UrlAuthCustomizerRegistry();
+        registry.setRegistry(customizers);
+        encoder.setUrlCustomizer(registry);
         request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setCharacterEncoding("UTF-8");
+        request.setServerName("myhost");
+        request.setServerPort(8080);
+        request.addHeader("Host", "myhost:8080");
     }
 
     @Test

--- a/uPortal-url/src/main/java/org/apereo/portal/url/IAuthUrlCustomizer.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/IAuthUrlCustomizer.java
@@ -1,0 +1,24 @@
+package org.apereo.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+
+/** Customize CAS or any other authentication URL. */
+public interface IAuthUrlCustomizer {
+    /**
+     * Does this customizer supports the current HTTP request.
+     *
+     * @param request The current servlet request
+     * @param url The url to customize
+     * @return True if the customizer apply, else false.
+     */
+    boolean supports(HttpServletRequest request, String url);
+
+    /**
+     * Customize the supplied external login URL.
+     *
+     * @param request The current servlet request
+     * @param url The url to customize
+     * @return The url customized.
+     */
+    String customizeUrl(HttpServletRequest request, String url);
+}

--- a/uPortal-url/src/main/java/org/apereo/portal/url/UrlAuthCustomizerRegistry.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/UrlAuthCustomizerRegistry.java
@@ -1,0 +1,39 @@
+package org.apereo.portal.url;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Class to register all login/logout IAuthUrlCustomizer. */
+public class UrlAuthCustomizerRegistry {
+
+    /** Logger. */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private List<IAuthUrlCustomizer> registry;
+
+    public void setRegistry(List<IAuthUrlCustomizer> registry) {
+        this.registry = registry;
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        String customizedUrl = url;
+        if (registry != null && !registry.isEmpty()) {
+            for (IAuthUrlCustomizer customizer : this.registry) {
+                if (customizer != null && customizer.supports(request, customizedUrl)) {
+                    customizedUrl = customizer.customizeUrl(request, customizedUrl);
+                }
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("The url returned after customization is " + customizedUrl);
+            }
+            return customizedUrl;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "No IAuthUrlCustomizer was set, the url " + customizedUrl + " wasn't modified");
+        }
+        return customizedUrl;
+    }
+}

--- a/uPortal-url/src/main/java/org/apereo/portal/url/UrlCasParamAppenderCustomizer.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/UrlCasParamAppenderCustomizer.java
@@ -1,0 +1,51 @@
+package org.apereo.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/** Customizer to append CAS params to service url. */
+public class UrlCasParamAppenderCustomizer implements IAuthUrlCustomizer, InitializingBean {
+
+    /** Logger. */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /** Regex condition to apply Customization. */
+    private String applyCondition = ".*login\\?service=https?://.*";
+
+    /** Param name with equal and value to append to url. */
+    private String paramToAppend;
+
+    public void setApplyCondition(final String applyCondition) {
+        this.applyCondition = applyCondition;
+    }
+
+    public void setParamToAppend(final String paramToAppend) {
+        this.paramToAppend = paramToAppend;
+    }
+
+    public boolean supports(final HttpServletRequest request, final String url) {
+        return url != null && url.matches(applyCondition);
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        if (url != null && !url.isEmpty() && supports(request, url)) {
+            final String updatedUrl = url + "&" + paramToAppend;
+
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        String.format("Modifying Url Domain from [%s] to [%s]", url, updatedUrl));
+            }
+            return updatedUrl;
+        }
+        return url;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.hasText(this.applyCondition, "No applyCondition supplied !");
+        Assert.hasText(this.paramToAppend, "No paramToAppend supplied !");
+    }
+}

--- a/uPortal-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
@@ -1,0 +1,66 @@
+package org.apereo.portal.url;
+
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.util.Assert;
+
+/** Customizer to replace a text by a serverName. */
+public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
+
+    /** Logger. */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private Set<String> allServerNames = new HashSet<>();
+
+    private String serverNameTextReplacement = "_CURRENT_SERVER_NAME_";
+
+    @Required
+    public void setAllServerNames(final Set<String> serverNames) {
+        this.allServerNames = Sets.newHashSet(serverNames);
+        Assert.notEmpty(this.allServerNames, "The attribute serverNames should not be empty");
+    }
+
+    public void setServerNameTextReplacement(final String serverNameTextReplacement) {
+        Assert.hasText(
+                serverNameTextReplacement,
+                "The serverNameTextReplacement attribute should not be empty");
+        this.serverNameTextReplacement = serverNameTextReplacement;
+    }
+
+    public boolean supports(final HttpServletRequest request, final String url) {
+        return url != null && url.contains(serverNameTextReplacement);
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        if (url != null && !url.isEmpty() && supports(request, url)) {
+            final String updateUrl =
+                    url.replaceFirst(serverNameTextReplacement, findMatchingServerName(request));
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Modifying Url Domain from [{}] to [{}]", url, updateUrl);
+            }
+            return updateUrl;
+        }
+        return url;
+    }
+
+    protected String findMatchingServerName(final HttpServletRequest request) {
+        if (request != null) {
+            final String comparisonHost = request.getHeader("Host");
+            if (comparisonHost != null && !comparisonHost.isEmpty()) {
+                for (final String server : this.allServerNames) {
+                    if (server.contains(comparisonHost)) {
+                        return server;
+                    }
+                }
+            }
+        }
+
+        return this.allServerNames.iterator().next();
+    }
+}

--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/StringToSetUtils.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/StringToSetUtils.java
@@ -1,0 +1,13 @@
+package org.apereo.portal.utils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Utils class to load a String property into Set with space separator. */
+public abstract class StringToSetUtils {
+
+    public static Set<String> delimitedSpaceListToSet(final String entry) {
+        return new HashSet<>(Arrays.asList(entry.split("\\s+")));
+    }
+}

--- a/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
+++ b/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
@@ -417,6 +417,8 @@ public class RenderingPipelineConfiguration {
         parameterExpressions.put("CONTEXT_PATH", "request.contextPath");
         parameterExpressions.put("HOST_NAME", "request.nativeRequest.serverName");
         parameterExpressions.put("AUTHENTICATED", "!person.guest");
+        parameterExpressions.put(
+                "EXTERNAL_LOGIN_URL", "@casRefUrlEncoder.getCasLoginUrl(request.nativeRequest)");
         parameterExpressions.put("userName", "person.fullName");
         parameterExpressions.put("USER_ID", "person.userName");
         parameterExpressions.put("SERVER_NAME", "@portalInfoProvider.serverName");

--- a/uPortal-webapp/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/jsonRenderingPipelineContext.xml
@@ -20,7 +20,7 @@
 
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://www.springframework.org/schema/beans" 
+       xmlns="http://www.springframework.org/schema/beans"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
@@ -40,7 +40,7 @@
         <property name="logFullDocument" value="true" />
         <property name="stepIdentifier" value="jsonPreStructureTransformLogger"/>
     </bean>
-    
+
     <!-- structure transformation -->
     <bean id="jsonStructureTransformComponent" class="org.apereo.portal.rendering.xslt.XSLTComponent">
         <property name="wrappedComponent" ref="jsonPreStructureTransformLogger" />
@@ -63,7 +63,7 @@
             </bean>
         </property>
     </bean>
-    
+
     <bean id="jsonPostStructureTransformLogger" class="org.apereo.portal.rendering.LoggingStAXComponent">
         <property name="wrappedComponent" ref="jsonStructureTransformComponent" />
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_STRUCTURE" />
@@ -71,12 +71,12 @@
         <property name="logFullDocument" value="true" />
         <property name="stepIdentifier" value="jsonPostStructureTransformLogger"/>
     </bean>
-    
+
     <bean id="jsonStructureCachingComponent" class="org.apereo.portal.rendering.cache.CachingStAXPipelineComponent">
         <property name="wrappedComponent" ref="jsonPostStructureTransformLogger" />
         <property name="cache" ref="org.apereo.portal.rendering.STRUCTURE_TRANSFORM" />
     </bean>
-    
+
     <!-- portlet window attribute incorporation -->
     <bean id="jsonPortletWindowAttributeIncorporationComponent" class="org.apereo.portal.rendering.StAXAttributeIncorporationComponent">
         <property name="wrappedComponent" ref="jsonStructureCachingComponent" />
@@ -95,7 +95,7 @@
     <!--<bean id="jsonPortletRenderingInitiationComponent" class="org.apereo.portal.rendering.PortletRenderingInitiationStAXComponent">-->
         <!--<property name="wrappedComponent" ref="jsonPortletWindowAttributeIncorporationComponent" />-->
     <!--</bean>-->
-    
+
     <!-- theme attribute incorporation -->
     <bean id="jsonThemeAttributeIncorporationComponent" class="org.apereo.portal.rendering.StAXAttributeIncorporationComponent">
         <property name="wrappedComponent" ref="jsonPortletDefinitionAttributeIncorporationComponent" />
@@ -109,11 +109,11 @@
         <property name="logFullDocument" value="true" />
         <property name="stepIdentifier" value="jsonPreThemeTransformLogger"/>
     </bean>
-     
+
     <!-- theme transformation -->
     <bean id="jsonThemeTransformComponent" class="org.apereo.portal.rendering.xslt.XSLTComponent">
         <property name="wrappedComponent" ref="jsonPreThemeTransformLogger" />
-        <property name="transformerSource" ref="themeTransformSource"/> 
+        <property name="transformerSource" ref="themeTransformSource"/>
         <property name="xsltParameterSource">
             <bean class="org.apereo.portal.rendering.xslt.MergingTransformerConfigurationSource">
                 <property name="sources">
@@ -136,6 +136,7 @@
                                     <entry key="CURRENT_REQUEST" value="request.nativeRequest" />
                                     <entry key="CONTEXT_PATH" value="request.contextPath" />
                                     <entry key="AUTHENTICATED" value="!person.guest" />
+                                    <entry key="EXTERNAL_LOGIN_URL" value="@casRefUrlEncoder.getCasLoginUrl(request.nativeRequest)" />
                                     <entry key="HOST_NAME" value="request.nativeRequest.serverName" />
                                     <entry key="userName" value="person.fullName" />
                                     <entry key="USER_ID" value="person.userName" />
@@ -156,7 +157,7 @@
             </bean>
         </property>
     </bean>
-    
+
     <bean id="jsonPostThemeTransformLogger" class="org.apereo.portal.rendering.LoggingStAXComponent">
         <property name="wrappedComponent" ref="jsonThemeTransformComponent" />
         <property name="loggerName" value="org.apereo.portal.rendering.LoggingStAXComponent.POST_THEME" />
@@ -165,7 +166,7 @@
         <property name="logFullDocumentAsHtml" value="true" />
         <property name="stepIdentifier" value="jsonPostThemeTransformLogger"/>
     </bean>
-    
+
     <!-- StAX to String serialization -->
     <bean id="jsonStaxSerializingComponent" class="org.apereo.portal.rendering.StAXSerializingComponent">
         <property name="wrappedComponent" ref="jsonPostThemeTransformLogger" />
@@ -182,11 +183,11 @@
             <map/>
         </property>
     </bean>
-    
+
     <bean id="jsonWrapperFilteringCharacterPipelineComponent" class="org.apereo.portal.json.rendering.JsonWrapperFilteringCharacterPipelineComponent">
         <property name="wrappedComponent" ref="jsonStaxSerializingComponent" />
     </bean>
-    
+
     <bean id="jsonThemeCachingComponent" class="org.apereo.portal.rendering.cache.CachingCharacterPipelineComponent">
         <property name="wrappedComponent" ref="jsonWrapperFilteringCharacterPipelineComponent" />
         <property name="cache" ref="org.apereo.portal.rendering.THEME_TRANSFORM" />
@@ -197,7 +198,7 @@
     <!--<bean id="jsonPortletRenderingInitiationCharacterComponent" class="org.apereo.portal.rendering.PortletRenderingInitiationCharacterComponent">-->
         <!--<property name="wrappedComponent" ref="jsonThemeCachingComponent" />-->
     <!--</bean>-->
-    
+
     <!-- portlet content incorporation -->
     <!-- portlet rendering initiation.  Not needed for JSON layout.  We don't want to actually render the portlets
          since we don't need to incorporate the portlet's output into the response.  -->
@@ -208,5 +209,5 @@
         <qualifier value="json"/>
         <property name="pipeline" ref="jsonThemeCachingComponent" />
     </bean>
-    
+
 </beans>

--- a/uPortal-webapp/src/main/resources/properties/contexts/mvcContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/mvcContext.xml
@@ -24,7 +24,7 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
-           
+
     <bean id="minimizedStateHandlerInterceptor" class="org.apereo.portal.portlets.MinimizedStateHandlerInterceptor" />
 
     <bean id="requireValidSessionFilter" class="org.apereo.portal.url.RequireValidSessionFilter" />
@@ -40,22 +40,37 @@
     </bean>
     <bean id="multipartResolver"
         class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-    
+
         <!-- one of the properties available; the maximum file size in bytes -->
         <property name="maxUploadSize" value="100000"/>
     </bean>
 
-    <!-- The urlCanonicalizingFilter can (will) attempt to deep-link users, 
-         through authentication, to the content they are requesting, provided 
+    <!-- A Helper bean to update Cas login/logout url when the service can be accessed on different serverName -->
+    <bean id="authUrlCustomizer" class="org.apereo.portal.url.UrlAuthCustomizerRegistry">
+        <property name="registry">
+            <list>
+                <bean class="org.apereo.portal.url.UrlMultiServerNameCustomizer">
+                    <property name="allServerNames">
+                        <bean class="org.apereo.portal.utils.StringToSetUtils" factory-method="delimitedSpaceListToSet">
+                            <constructor-arg type="java.lang.String" value="${portal.allServerNames}"/>
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <!-- The urlCanonicalizingFilter can (will) attempt to deep-link users,
+         through authentication, to the content they are requesting, provided
          that...
            - (1) the user is a guest
-           - (2) the canonicalUrl (place the portal wants to send the user) is 
+           - (2) the canonicalUrl (place the portal wants to send the user) is
                  not the requested content
-           - (3) there is a strategy for external login (LoginRefUrlEncoder 
+           - (3) there is a strategy for external login (LoginRefUrlEncoder
                  bean) configured
     -->
     <bean id="casRefUrlEncoder" class="org.apereo.portal.url.CasLoginRefUrlEncoder"
-        p:casLoginUrl="${org.apereo.portal.channels.CLogin.CasLoginUrl}" />
+        p:casLoginUrl="${org.apereo.portal.channels.CLogin.CasLoginUrl}" p:urlCustomizer-ref="authUrlCustomizer"/>
 
     <!--
      | Message source for this context, loaded from localized "messages_xx" files
@@ -74,7 +89,7 @@
                 <value>/WEB-INF/flows/person-lookup/person-lookup</value>
                 <value>/WEB-INF/flows/register-portal/register-portal</value>
             </list>
-        </property>                                     
+        </property>
     </bean>
 
     <!--
@@ -84,8 +99,8 @@
         <property name="order" value="1"/>
         <property name="location" value="classpath:properties/contexts/views/mvcViews.xml"/>
     </bean>
-    
-    <!-- 
+
+    <!--
      | Standard JSP view resolver
      +-->
     <bean id="jspViewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
@@ -95,6 +110,6 @@
         <property name="suffix" value=".jsp"/>
         <property name="order" value="2"/>
     </bean>
-    
+
     <bean id="localeResolver" class="org.apereo.portal.i18n.LocaleManagerLocaleResolver" />
 </beans>

--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -118,7 +118,7 @@
      | source configuration settings from the primaryPropertyPlaceholderConfigurer.)
      +-->
     <bean name="ticketValidationFilter" class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter">
-        <property name="serverName" value="${portal.protocol.server.context}" />
+        <property name="serverName" value="${portal.allServerNames}" />
         <property name="encodeServiceUrl" value="false" />
         <property name="proxyReceptorUrl" value="${cas.ticketValidationFilter.proxyReceptorUrl:}" />
         <property name="ticketValidator">

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -38,6 +38,10 @@ portal.context=/uPortal
 portal.protocol.server.context=${portal.protocol}://_CURRENT_SERVER_NAME_${portal.context}
 portal.login.url=${portal.protocol.server.context}/Login
 
+# Needed for proxy-cas in load-balanced system like apache to give back the proxy-ticket on the server that requested it
+# it requires that the load-balanced instance has his serverName.
+portal.lbServerName=${portal.server}
+
 portal.otherServers=
 
 # All server names values for multi server name management, separator is a space
@@ -68,7 +72,7 @@ cas.authenticationFilter.cas.login.url=${cas.protocol.server.context}/login
 ## special permission in the CAS Service Manager.
 #
 #cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
-#cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol.server.context}/CasProxyServlet
+#cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.lbServerName}${portal.context}${cas.ticketValidationFilter.proxyReceptorUrl}
 
 ## Simple (database)
 #

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -35,8 +35,13 @@
 portal.protocol=http
 portal.server=localhost:8080
 portal.context=/uPortal
-portal.protocol.server.context=${portal.protocol}://${portal.server}${portal.context}
+portal.protocol.server.context=${portal.protocol}://_CURRENT_SERVER_NAME_${portal.context}
 portal.login.url=${portal.protocol.server.context}/Login
+
+portal.otherServers=
+
+# All server names values for multi server name management, separator is a space
+portal.allServerNames=${portal.server} ${portal.otherServers}
 
 ##
 ## Authentication Strategies Available in the Portal.

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/login.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/login.jsp
@@ -19,12 +19,13 @@
 
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
+<c:set var="request" value="${pageContext.request}" />
 
 <div id="webLoginContainer" class="fl-widget portal-login">
   <div class="fl-widget-inner">
     <div class="fl-widget-content">
         <div id="portalCASLogin" class="fl-widget-content">
-            <a id="portalCASLoginLink" class="btn" title="<spring:message code="sign.in.via.cas"/>" href="${casRefUrlEncoder.casLoginUrl}">
+            <a id="portalCASLoginLink" class="btn" title="<spring:message code="sign.in.via.cas"/>" href="${casRefUrlEncoder.getCasLoginUrl(request)}}">
                 <i class="fa fa-sign-in" aria-hidden="true"></i>
                 <spring:message code="sign.in"/>
             </a>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [*] the [individual contributor license agreement][] is signed
-   [*] commit message follows [commit guidelines][]
-   [*] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Upgrade from the previous Pull Request: https://github.com/Jasig/uPortal/pull/689

This PR is needed when you are deploying a multi-tenant uPortal instance working on several server name. In that case the connexion URL should be adapted to the serverName accessed. As example when the user access to https://servername.edu/uPortal the cas auth url is like https://cas.servername.edu/cas/login?service=https://servername.edu/uPortal/login.
But on an other servername like https://othername.edu/uPortal the service should change to https://cas.servername.edu/cas/login?service=https://othername.edu/uPortal/login.

So this PR:
- Provide a configurable way to set the current uPortal serverName to cas service URL:
- Providing also a decorator to be able to set WAYF parameters depending on condition like current serverName. I'm using a such decorator on some serverName where we need to bypass the WAYF. or to add a generated token (this token generator is not provided as internal, but could be added by bean configuration)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
