### PR TITLE
UP-5019: Fix 'NotSerializableException' issue when deleting a SELECT_…

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlets/permissionsadmin/PermissionAdministrationHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/permissionsadmin/PermissionAdministrationHelper.java
@@ -29,6 +29,9 @@ import org.jasig.portal.layout.dlm.remoting.IGroupListHelper;
 import org.jasig.portal.layout.dlm.remoting.JsonEntityBean;
 import org.jasig.portal.permission.IPermissionActivity;
 import org.jasig.portal.permission.IPermissionOwner;
+import org.jasig.portal.permission.target.IPermissionTarget;
+import org.jasig.portal.permission.target.IPermissionTargetProvider;
+import org.jasig.portal.permission.target.IPermissionTargetProviderRegistry;
 import org.jasig.portal.security.IAuthorizationPrincipal;
 import org.jasig.portal.security.IPermission;
 import org.jasig.portal.security.IPermissionStore;
@@ -51,17 +54,20 @@ public class PermissionAdministrationHelper implements IPermissionAdministration
     protected final Log log = LogFactory.getLog(getClass());
 
     private IGroupListHelper groupListHelper;
-    
+    private IPermissionStore permissionStore;
+    private IPermissionTargetProviderRegistry permissionTargetProviderRegistry;
+
     @Autowired(required = true)
     public void setGroupListHelper(IGroupListHelper groupListHelper) {
         this.groupListHelper = groupListHelper;
     }
-    
-    private IPermissionStore permissionStore;
-    
     @Autowired(required = true)
     public void setPermissionStore(IPermissionStore permissionStore) {
         this.permissionStore = permissionStore;
+    }
+    @Autowired(required = true)
+    public void setPermissionTargetProviderRegistry(IPermissionTargetProviderRegistry registry) {
+        this.permissionTargetProviderRegistry = registry;
     }
 
     public boolean canEditOwner(IPerson currentUser, String owner) {
@@ -145,6 +151,11 @@ public class PermissionAdministrationHelper implements IPermissionAdministration
         }
 
         return principals;
+    }
+
+    public IPermissionTarget getPermissionTarget(String targetProviderKey, String targetKey) {
+        final IPermissionTargetProvider provider = this.permissionTargetProviderRegistry.getTargetProvider(targetProviderKey);
+        return provider == null ? null : provider.getTarget(targetKey);
     }
 
 }

--- a/uportal-war/src/main/webapp/WEB-INF/flows/permissions-administration/permissions-administration.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/permissions-administration/permissions-administration.xml
@@ -76,8 +76,7 @@
             <evaluate expression="breadcrumbs.put('listActivities', owner.name)"/>
             <evaluate expression="breadcrumbs.put('showActivity', activity.name)"/>
             <set name="flashScope.principals" value="permissionAdministrationHelper.getCurrentPrincipals(owner, activity, requestParameters.target)"/>
-            <set name="flashScope.targetProvider" value="permissionTargetProviderRegistry.getTargetProvider(activity.targetProviderKey)"/>
-            <set name="flashScope.target" value="targetProvider.getTarget(requestParameters.target)"/>
+            <set name="flashScope.target" value="permissionAdministrationHelper.getPermissionTarget(activity.targetProviderKey, requestParameters.target)"/>
         </on-entry>
         
         <input name="owner" value="owner"/>
@@ -116,8 +115,7 @@
             <evaluate expression="breadcrumbs.put('listOwners', 'Categories')"/>
             <evaluate expression="breadcrumbs.put('listActivities', owner.name)"/>
             <evaluate expression="breadcrumbs.put('showActivity', activity.name)"/>
-            <set name="viewScope.targetProvider" value="permissionTargetProviderRegistry.getTargetProvider(activity.targetProviderKey)"/>
-            <set name="viewScope.target" value="targetProvider.getTarget(requestParameters.targetName)"/>
+            <set name="flowScope.target" value="permissionAdministrationHelper.getPermissionTarget(activity.targetProviderKey, requestParameters.targetName)"/>
         </on-entry>
         <transition on="remove" to="showActivity"/>
         <transition on="cancel" to="showActivity"/>


### PR DESCRIPTION
https://apereo.atlassian.net/browse/UP-5019

##### Checklist

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added

##### Description of change

Updated to use flowScope instead of viewScope in Permissions SELECT_PORTLET_TYPE delete flow to prevent NotSerializableException that prevents the operation from completing.  Also, created helper function so that we don't need to store the permission target provider in any scope.  Either of these changes alone fixes the issue.