### PR TITLE
Gh 1331

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -57,3 +57,5 @@ include 'uPortal-hibernate:uPortal-hibernate4-dialects'
 
 include 'uPortal-utils:uPortal-utils-core'
 include 'uPortal-utils:uPortal-utils-jmx'
+include 'uPortal-health'
+

--- a/uPortal-health/build.gradle
+++ b/uPortal-health/build.gradle
@@ -1,0 +1,7 @@
+description = "Apereo uPortal Health Check"
+
+dependencies {
+    compile project(':uPortal-spring')
+
+    compileOnly "${servletApiDependency}"
+}

--- a/uPortal-health/src/main/java/org/apereo/portal/health/HealthCheckController.java
+++ b/uPortal-health/src/main/java/org/apereo/portal/health/HealthCheckController.java
@@ -21,5 +21,4 @@ public class HealthCheckController {
         // Do nothing, just return HTTP 200, OK
         logger.debug("Doing a health check. Returning HTTP 200, OK");
     }
-
 }

--- a/uPortal-health/src/main/java/org/apereo/portal/health/HealthCheckController.java
+++ b/uPortal-health/src/main/java/org/apereo/portal/health/HealthCheckController.java
@@ -1,0 +1,25 @@
+package org.apereo.portal.health;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Controller
+public class HealthCheckController {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseStatus(HttpStatus.OK)
+    public void healthCheck(HttpServletRequest request, HttpServletResponse response) {
+        // Do nothing, just return HTTP 200, OK
+        logger.debug("Doing a health check. Returning HTTP 200, OK");
+    }
+
+}

--- a/uPortal-web/build.gradle
+++ b/uPortal-web/build.gradle
@@ -8,6 +8,7 @@ ext {
 dependencies {
     compile project(':uPortal-api:uPortal-api-platform-impl')
     compile project(':uPortal-api:uPortal-api-rest')
+    compile project(':uPortal-health')
     compile project(':uPortal-events')
     compile project(':uPortal-layout:uPortal-layout-impl')
     compile project(':uPortal-rendering')

--- a/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/applicationContext.xml
@@ -53,6 +53,7 @@
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.rest\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.mvc\..+"/>
         <context:exclude-filter type="regex" expression="org\.apereo\.portal\.security\.remoting\..+"/>
+        <context:exclude-filter type="regex" expression="org\.apereo\.portal\.health\..+"/>
     </context:component-scan>
 
     <bean id="primaryPropertyPlaceholderConfigurer" class="org.springframework.context.support.PortalPropertySourcesPlaceholderConfigurer">

--- a/uPortal-webapp/src/main/resources/properties/contexts/servlet/healthCheckServletContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/servlet/healthCheckServletContext.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
+           http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd">
+
+    <!--
+     | Registers a RequestMappingHandlerMapping, a RequestMappingHandlerAdapter, and an
+     | ExceptionHandlerExceptionResolver (among others) in support of processing requests with
+     | annotated controller methods using annotations such as @RequestMapping, @ExceptionHandler,
+     | etc.
+     +-->
+    <mvc:annotation-driven />
+
+    <!--
+     | For access to properties in *.properties files (see applicationContext.xml):
+     | portal.properties, rdbm.properties, security.properties, global.properties, uPortal.properties
+     +-->
+    <bean parent="primaryPropertyPlaceholderConfigurer" />
+
+    <!--
+     | Even though context:component-scan is defined in applicationContext, we need an additional
+     | reference for this context as it's unique to the DispatcherServlet
+     +-->
+    <context:component-scan base-package="org.apereo.portal.health"/>
+
+</beans>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
@@ -359,6 +359,16 @@
     </servlet>
 
     <servlet>
+        <servlet-name>HealthCheckServlet</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>classpath:properties/contexts/servlet/healthCheckServletContext.xml</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet>
         <servlet-name>RenderingDispatcherServlet</servlet-name>
         <servlet-class>org.apereo.portal.spring.web.servlet.NoMultipartDispatcherServlet</servlet-class>
         <init-param>
@@ -435,6 +445,11 @@
         <servlet-name>AuthenticationDispatcherServlet</servlet-name>
         <url-pattern>/Login</url-pattern>
         <url-pattern>/Logout</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>HealthCheckServlet</servlet-name>
+        <url-pattern>/health-check</url-pattern>
     </servlet-mapping>
 
     <mime-mapping>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x ] the [individual contributor license agreement][] is signed
-   [x ] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

(NOTE: removed extra newline causing pull request to fail :verifyGoogleJavaFormat gradle task)

Added uPortal/health-check endpoint that simply returns an HTTPS 200 (OK) status to an HTTP GET request. This facilitates deploying behind load balancers that check the health of application servers and shut down and start new ones as they become unhealthy, a strategy that is often used by cloud-based services. See Issue #1331.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
