### PR TITLE
chore: update gradle error prone to version 0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     // Sub project plugins
     id 'com.github.sherter.google-java-format' version '0.7.1' apply false
     id 'nebula.lint' version '9.3.4' apply false
-    id 'net.ltgt.errorprone' version '0.0.13' apply false
+    id 'net.ltgt.errorprone' version '0.6' apply false
 }
 
 description = "Apereo uPortal $version"
@@ -49,7 +49,8 @@ allprojects {
     }
 
     dependencies {
-      errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+      errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+      errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
     }
 
     codenarc {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

https://github.com/tbroyer/gradle-errorprone-plugin/releases/tag/v0.6

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
