### PR TITLE
Issue #1321: Fix character encoding on form submit

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
@@ -219,7 +219,11 @@
      -->
 
     <!-- FILTER ORDER IS VERY IMPORTANT. DO NOT CHANGE ORDER WITHOUT VERY GOOD REASON -->
-
+    <filter-mapping>
+        <filter-name>CharacterEncodingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
     <filter-mapping>
         <filter-name>corsFilter</filter-name>
         <url-pattern>/*</url-pattern>
@@ -233,14 +237,6 @@
     <filter-mapping>
         <filter-name>ExceptionLoggingFilter</filter-name>
         <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
-    <filter-mapping>
-        <filter-name>CharacterEncodingFilter</filter-name>
-        <servlet-name>AuthenticationDispatcherServlet</servlet-name>
-        <servlet-name>RenderingDispatcherServlet</servlet-name>
-        <servlet-name>JsonRenderingDispatcherServlet</servlet-name>
-        <servlet-name>MVCDispatcherServlet</servlet-name>
     </filter-mapping>
 
     <filter-mapping>


### PR DESCRIPTION
##### Description of change
Fix for issue  #1321. The Character encoding filter has to be applied early in the filter chain to take effect. If another filter touches the request data before it could set the encoding properly, it will just silently do nothing. 

![image](https://user-images.githubusercontent.com/1114220/46570463-ee7ecc80-c964-11e8-927b-9cc22171473b.png)
