### PR TITLE
Issue #1291: add permissionsadmin package to component scanning

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/flowsContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/flowsContext.xml
@@ -29,7 +29,7 @@
            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-    <context:component-scan base-package="org.apereo.portal.portlets.groupadmin, org.apereo.portal.portlets.portletadmin, org.apereo.portal.portlets.fragmentadmin"/>
+    <context:component-scan base-package="org.apereo.portal.portlets.groupadmin, org.apereo.portal.portlets.portletadmin, org.apereo.portal.portlets.fragmentadmin, org.apereo.portal.portlets.permissionsadmin"/>
 
     <!-- Generic Web-Flow helper beans -->
     <bean id="portletUrlFlowHelper" class="org.apereo.portal.portlets.flow.PortletUrlFlowHelper" />


### PR DESCRIPTION
##### Description of change
Made the `org.apereo.portal.portlets.permissionsadmin` package available for `component-scan` in the flow context, to make the `PermissionAdministrationHelper` available.

fixes #1291 
