### PR TITLE
fix: Set default value of portal.allServerNames to ${portal.server}

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -38,14 +38,16 @@ portal.context=/uPortal
 portal.protocol.server.context=${portal.protocol}://_CURRENT_SERVER_NAME_${portal.context}
 portal.login.url=${portal.protocol.server.context}/Login
 
-# Needed for proxy-cas in load-balanced system like apache to give back the proxy-ticket on the server that requested it
-# it requires that the load-balanced instance has his serverName.
+# Needed for proxy-cas in load-balanced system like Apache to return the
+# proxy-ticket to the requesting server. It requires that the load-balanced
+# instance has his serverName
+# Example: my.univ.edu
 portal.lbServerName=${portal.server}
 
-portal.otherServers=
-
 # All server names values for multi server name management, separator is a space
-portal.allServerNames=${portal.server} ${portal.otherServers}
+# This property should be set/overridden in PORTAL_HOME/uPortal.properties
+# Example: portal1.univ.edu portal2.univ.edu
+portal.allServerNames=${portal.server}
 
 ##
 ## Authentication Strategies Available in the Portal.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Set the default value of `portal.allServerNames` to `${portal.server}`

Resolves #1372 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
