### PR TITLE
fix:  correct a mistake in JDBC code when new users are provisioned

### DIFF
--- a/uPortal-persondir/src/main/java/org/apereo/portal/RDBMUserIdentityStore.java
+++ b/uPortal-persondir/src/main/java/org/apereo/portal/RDBMUserIdentityStore.java
@@ -446,7 +446,7 @@ public class RDBMUserIdentityStore implements IUserIdentityStore {
                                             insertStmt = con.prepareStatement(insert);
                                             insertStmt.setInt(1, newUID);
                                             insertStmt.setString(2, userName);
-                                            insertStmt.setInt(4, USER_DFLT_LAY_ID);
+                                            insertStmt.setInt(3, USER_DFLT_LAY_ID);
 
                                             if (log.isDebugEnabled())
                                                 log.debug(

--- a/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTest.java
@@ -116,13 +116,11 @@ public class IdentityImportExportTest extends BasePortalJpaDaoTest {
                         + "(\n"
                         + "   USER_ID integer,\n"
                         + "   USER_NAME varchar(1000),\n"
-                        + "   USER_DFLT_USR_ID integer,\n"
                         + "   USER_DFLT_LAY_ID integer,\n"
                         + "   NEXT_STRUCT_ID integer,\n"
                         + "   LST_CHAN_UPDT_DT timestamp,\n"
                         + "   CONSTRAINT SYS_IDX_01 PRIMARY KEY (USER_ID)\n"
                         + ");");
-        runSql("CREATE INDEX UPU_DFLT_ID_IDX ON UP_USER(USER_DFLT_USR_ID);");
         runSql(
                 "CREATE TABLE UP_LAYOUT_STRUCT\n"
                         + "(\n"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR fixes a small mistake in JDBC code that affects the ability of the portal to provision new users when they authenticate for the first time.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
