### PR TITLE
fix: use wc bundle instead of loader

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -110,8 +110,8 @@
     <js included="aggregated" resource="true">/webjars/whatwg-fetch/dist/fetch.umd.js</js>
 
     <!-- web component polyfill -->
-    <js included="plain" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-loader.js</js>
-    <js included="aggregated" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-loader.js</js>
+    <js included="plain" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-bundle.js</js>
+    <js included="aggregated" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-bundle.js</js>
 
     <js included="plain" resource="true">/rs/conflict-resolution/js/resolve-conflicts.js</js>
     <js included="aggregated" resource="true">/rs/conflict-resolution/js/resolve-conflicts.min.js</js>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

loader can run into url construction and network issues when run on IE

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
