### PR TITLE
chore: limit concurrent renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
   "gradle": {
     "enabled": true
   },
-  "renovateFork": true
+  "renovateFork": true,
+  "prConcurrentLimit": 5
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

with the incoming fixes and improvements coming to renovate, it can
discover all of uPortal's dependencies and recommend updates.
On a test run on this, it opened 54 pull requests.
To avoid bombarding uPortal with far too many PRs, setting a limit on
how many PRs renovate will open.

This setting tells renovate to open up to 5 pull requests, and wait
until those requests are merged or declined before opening more to
replace the closed PR.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
