### PR TITLE
chore:  eliminate dataTypeImportOrder, exportAllPortalDataTypes, and …

### DIFF
--- a/uPortal-core/src/main/java/org/apereo/portal/portlet/om/IPortletType.java
+++ b/uPortal-core/src/main/java/org/apereo/portal/portlet/om/IPortletType.java
@@ -30,21 +30,21 @@ public interface IPortletType extends IPortalData {
      *
      * @return unique id
      */
-    public int getId();
+    int getId();
 
     /**
      * Get the name of this channel type
      *
      * @return channel type name
      */
-    public String getName();
+    String getName();
 
     /**
      * Get a description of this channel type
      *
      * @return channel type description
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * Get the URI of the ChannelPublishingDocument associated with this channel type. This CPD will
@@ -52,7 +52,7 @@ public interface IPortletType extends IPortalData {
      *
      * @return ChannelPublishingDocument URI
      */
-    public String getCpdUri();
+    String getCpdUri();
 
     // Setter methods
 
@@ -61,7 +61,7 @@ public interface IPortletType extends IPortalData {
      *
      * @param descr
      */
-    public void setDescription(String descr);
+    void setDescription(String descr);
 
     /**
      * Set the URI of the ChannelPublishingDocument associated with this channel type. This CPD will
@@ -69,5 +69,5 @@ public interface IPortletType extends IPortalData {
      *
      * @param cpdUri ChannelPublishingDocument URI
      */
-    public void setCpdUri(String cpdUri);
+    void setCpdUri(String cpdUri);
 }

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/AbstractJaxbDataHandler.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/AbstractJaxbDataHandler.java
@@ -55,7 +55,7 @@ public abstract class AbstractJaxbDataHandler<T>
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        final Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        final Map<String, Object> properties = new LinkedHashMap<>();
         properties.put(javax.xml.bind.Marshaller.JAXB_ENCODING, "UTF-8");
         properties.put(javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, true);
         if (this.schemaLocation != null) {

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/AbstractPortalDataType.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/AbstractPortalDataType.java
@@ -24,42 +24,39 @@ import org.slf4j.LoggerFactory;
 
 /** Base IPortalDataType implementation that should simplify most implementations */
 public abstract class AbstractPortalDataType implements IPortalDataType {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final int order;
 
     private final QName defaultQName;
 
-    public AbstractPortalDataType(QName defaultQName) {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public AbstractPortalDataType(int order, QName defaultQName) {
         Validate.notNull(defaultQName);
+        this.order = order;
         this.defaultQName = defaultQName;
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getTypeId()
-     */
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
     @Override
     public String getTypeId() {
         return this.defaultQName.getLocalPart();
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getTitle()
-     */
     @Override
     public String getTitleCode() {
         return this.defaultQName.getLocalPart();
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getDescription()
-     */
     @Override
     public String getDescriptionCode() {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#postProcessPortalDataKey(org.springframework.core.io.Resource, org.apereo.portal.io.xml.PortalDataKey, javax.xml.stream.XMLEventReader)
-     */
     @Override
     public Set<PortalDataKey> postProcessPortalDataKey(
             String systemId, PortalDataKey portalDataKey, XMLEventReader reader) {

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IExportAllPortalDataType.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IExportAllPortalDataType.java
@@ -1,6 +1,7 @@
 package org.apereo.portal.io.xml;
 
 /**
- * Tag interface for {@link IPortalDataType} beans that should be included in an "export al" operation.
+ * Tag interface for {@link IPortalDataType} beans that should be included in an "export al"
+ * operation.
  */
 public interface IExportAllPortalDataType extends IPortalDataType {}

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IExportAllPortalDataType.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IExportAllPortalDataType.java
@@ -1,0 +1,6 @@
+package org.apereo.portal.io.xml;
+
+/**
+ * Tag interface for {@link IPortalDataType} beans that should be included in an "export al" operation.
+ */
+public interface IExportAllPortalDataType extends IPortalDataType {}

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IPortalDataType.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IPortalDataType.java
@@ -14,29 +14,37 @@
  */
 package org.apereo.portal.io.xml;
 
+import org.springframework.core.Ordered;
+
 import java.util.List;
 import java.util.Set;
 import javax.xml.stream.XMLEventReader;
 
 /**
  * Describes a type of portal data that can be imported, exported, or deleted via the {@link
- * IPortalDataHandlerService}
+ * IPortalDataHandlerService}.  Beans that implement this interface have a natural order based on
+ * the sequence in which they must be imported into a "fresh" portal database.  This order preserves
+ * foreign key relationships.
  */
-public interface IPortalDataType {
+public interface IPortalDataType extends Ordered {
+
     /** @return The unique name of this portal data type, must be a valid XML element name. */
-    public String getTypeId();
+    String getTypeId();
+
     /** @return Message code to use for displaying the user readable title of this data type */
-    public String getTitleCode();
+    String getTitleCode();
+
     /**
      * @return Message code to use for displaying the user readable description of this data type
      */
-    public String getDescriptionCode();
+    String getDescriptionCode();
+
     /**
      * @return The {@link PortalDataKey}s that can be imported for this data type and the order that
      *     the must be imported in. All data for each {@link PortalDataKey} will be imported in
      *     parallel.
      */
-    public List<PortalDataKey> getDataKeyImportOrder();
+    List<PortalDataKey> getDataKeyImportOrder();
 
     /**
      * Post processes the resolved {@link PortalDataKey}, allows for data that needs to be retyped
@@ -50,6 +58,6 @@ public interface IPortalDataType {
      *     processing the input
      * @return One or more PortalDataKeys that represent the data
      */
-    public Set<PortalDataKey> postProcessPortalDataKey(
+    Set<PortalDataKey> postProcessPortalDataKey(
             String systemId, PortalDataKey portalDataKey, XMLEventReader reader);
 }

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IPortalDataType.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/IPortalDataType.java
@@ -14,16 +14,15 @@
  */
 package org.apereo.portal.io.xml;
 
-import org.springframework.core.Ordered;
-
 import java.util.List;
 import java.util.Set;
 import javax.xml.stream.XMLEventReader;
+import org.springframework.core.Ordered;
 
 /**
  * Describes a type of portal data that can be imported, exported, or deleted via the {@link
- * IPortalDataHandlerService}.  Beans that implement this interface have a natural order based on
- * the sequence in which they must be imported into a "fresh" portal database.  This order preserves
+ * IPortalDataHandlerService}. Beans that implement this interface have a natural order based on the
+ * sequence in which they must be imported into a "fresh" portal database. This order preserves
  * foreign key relationships.
  */
 public interface IPortalDataType extends Ordered {

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerService.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerService.java
@@ -131,9 +131,9 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
      * they will be wired by the Spring Application Context and then used in @PostConstruct
      * method(s) to build other member variables.
      */
-    private Collection<IDataImporter<? extends Object>> dataImporters = Collections.emptySet();
-    private Collection<IDataExporter<? extends Object>> dataExporters = Collections.emptySet();
-    private Collection<IDataDeleter<? extends Object>> dataDeleters = Collections.emptySet();
+    private Collection<IDataImporter<?>> dataImporters = Collections.emptySet();
+    private Collection<IDataExporter<?>> dataExporters = Collections.emptySet();
+    private Collection<IDataDeleter<?>> dataDeleters = Collections.emptySet();
     private Collection<IDataUpgrader> dataUpgraders = Collections.emptySet();
 
     // Order in which data must be imported
@@ -193,7 +193,10 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         this.maxWaitTimeUnit = maxWaitTimeUnit;
     }
 
-    /** The <code>@Autowired</code> list will reflect the order in which data types should be imported. */
+    /**
+     * The <code>@Autowired</code> list will reflect the order in which data types should be
+     * imported.
+     */
     @Autowired
     public void setDataTypeImportOrder(List<IPortalDataType> dataTypeImportOrder) {
         final ArrayList<PortalDataKey> dataKeyImportOrder =
@@ -257,7 +260,8 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
      * types will be listed.
      */
     @Autowired
-    public void setExportAllPortalDataTypes(Set<IExportAllPortalDataType> exportAllPortalDataTypes) {
+    public void setExportAllPortalDataTypes(
+            Set<IExportAllPortalDataType> exportAllPortalDataTypes) {
         this.exportAllPortalDataTypes = ImmutableSet.copyOf(exportAllPortalDataTypes);
     }
 
@@ -270,7 +274,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     @SuppressWarnings("unchecked")
-    public void initDataImporters() {
+    private void initDataImporters() {
         final Map<PortalDataKey, IDataImporter<Object>> dataImportersMap = new LinkedHashMap<>();
 
         for (final IDataImporter<?> dataImporter : dataImporters) {
@@ -289,7 +293,9 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
                     if (existing != null) {
                         this.logger.warn(
                                 "Duplicate IDataImporter PortalDataKey for {} Replacing {} with {}",
-                                new Object[] {importDataKey, existing, dataImporter});
+                                importDataKey,
+                                existing,
+                                dataImporter);
                     }
                 }
 
@@ -302,7 +308,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     @SuppressWarnings("unchecked")
-    public void initDataExporters() {
+    private void initDataExporters() {
         final Map<String, IDataExporter<Object>> dataExportersMap = new LinkedHashMap<>();
 
         final Set<IPortalDataType> portalDataTypes = new LinkedHashSet<>();
@@ -322,7 +328,9 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
                 if (existing != null) {
                     this.logger.warn(
                             "Duplicate IDataExporter typeId for {} Replacing {} with {}",
-                            new Object[] {typeId, existing, dataExporter});
+                            typeId,
+                            existing,
+                            dataExporter);
                 }
 
                 portalDataTypes.add(portalDataType);
@@ -337,7 +345,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     @SuppressWarnings("unchecked")
-    public void initDataDeleters() {
+    private void initDataDeleters() {
         final Map<String, IDataDeleter<Object>> dataDeletersMap = new LinkedHashMap<>();
 
         final Set<IPortalDataType> portalDataTypes = new LinkedHashSet<>();
@@ -357,7 +365,9 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
                 if (existing != null) {
                     this.logger.warn(
                             "Duplicate IDataDeleter typeId for {} Replacing {} with {}",
-                            new Object[] {typeId, existing, dataDeleter});
+                            typeId,
+                            existing,
+                            dataDeleter);
                 }
 
                 portalDataTypes.add(portalDataType);
@@ -372,7 +382,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     /** {@link IDataUpgrader} implementations to delegate upgrade operations to. */
-    public void initDataUpgraders() {
+    private void initDataUpgraders() {
         final Map<PortalDataKey, IDataUpgrader> dataUpgraderMap = new LinkedHashMap<>();
 
         for (final IDataUpgrader dataUpgrader : dataUpgraders) {
@@ -390,7 +400,9 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
                     if (existing != null) {
                         this.logger.warn(
                                 "Duplicate IDataUpgrader PortalDataKey for {} Replacing {} with {}",
-                                new Object[] {upgradeDataKey, existing, dataUpgrader});
+                                upgradeDataKey,
+                                existing,
+                                dataUpgrader);
                     }
                 }
 
@@ -411,7 +423,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         }
     }
 
-    protected void importDataArchive(
+    private void importDataArchive(
             Resource archive, InputStream resourceStream, BatchImportOptions options) {
         BufferedInputStream bufferedResourceStream = null;
         try {
@@ -475,7 +487,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     /** Extracts the archive resource and then runs the batch-import process on it. */
-    protected void importDataArchive(
+    private void importDataArchive(
             final Resource resource,
             final ArchiveInputStream resourceStream,
             BatchImportOptions options) {
@@ -507,7 +519,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         }
     }
 
-    protected MediaType getMediaType(BufferedInputStream inputStream, String fileName)
+    private MediaType getMediaType(BufferedInputStream inputStream, String fileName)
             throws IOException {
         final TikaInputStream tikaInputStreamStream =
                 TikaInputStream.get(new CloseShieldInputStream(inputStream));
@@ -762,7 +774,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         }
     }
 
-    protected String getPartialSystemId(String systemId) {
+    private String getPartialSystemId(String systemId) {
         final String directoryUriStr = IMPORT_BASE_DIR.get();
         if (directoryUriStr == null) {
             return systemId;
@@ -776,7 +788,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
     }
 
     /** Run the import/update process on the data */
-    protected final void importOrUpgradeData(
+    private void importOrUpgradeData(
             String systemId, PortalDataKey portalDataKey, XMLEventReader xmlEventReader) {
         // See if there is a registered importer for the data, if so import
         final IDataImporter<Object> dataImporterExporter =
@@ -843,7 +855,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
                         + systemId);
     }
 
-    protected Object unmarshallData(
+    private Object unmarshallData(
             final XMLEventReader bufferedXmlEventReader,
             final IDataImporter<Object> dataImporterExporter) {
         final Unmarshaller unmarshaller = dataImporterExporter.getUnmarshaller();
@@ -860,7 +872,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         }
     }
 
-    protected BufferedXMLEventReader createSourceXmlEventReader(final Source source) {
+    private BufferedXMLEventReader createSourceXmlEventReader(final Source source) {
         // If it is a StAXSource see if we can do better handling of it
         if (source instanceof StAXSource) {
             final StAXSource staxSource = (StAXSource) source;
@@ -1075,7 +1087,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         this.exportAllDataOfType(typeIds, directory, options);
     }
 
-    protected IDataExporter<Object> getPortalDataExporter(String typeId) {
+    private IDataExporter<Object> getPortalDataExporter(String typeId) {
         final IDataExporter<Object> dataExporter = this.portalDataExporters.get(typeId);
         if (dataExporter == null) {
             throw new IllegalArgumentException("No IDataExporter exists for: " + typeId);
@@ -1108,7 +1120,7 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
      *     completed futures
      * @return a list of futures that either threw exceptions or timed out
      */
-    protected List<FutureHolder<?>> waitForFutures(
+    private List<FutureHolder<?>> waitForFutures(
             final Queue<? extends FutureHolder<?>> futures,
             final PrintWriter reportWriter,
             final File reportDirectory,

--- a/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerService.java
+++ b/uPortal-io/uPortal-io-core/src/main/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerService.java
@@ -193,8 +193,8 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
         this.maxWaitTimeUnit = maxWaitTimeUnit;
     }
 
-    /** Order in which data types should be imported. */
-    @javax.annotation.Resource(name = "dataTypeImportOrder")
+    /** The <code>@Autowired</code> list will reflect the order in which data types should be imported. */
+    @Autowired
     public void setDataTypeImportOrder(List<IPortalDataType> dataTypeImportOrder) {
         final ArrayList<PortalDataKey> dataKeyImportOrder =
                 new ArrayList<>(dataTypeImportOrder.size() * 2);
@@ -256,8 +256,8 @@ public class JaxbPortalDataHandlerService implements IPortalDataHandlerService {
      * Optional set of all portal data types to export. If not specified all available portal data
      * types will be listed.
      */
-    @javax.annotation.Resource(name = "exportAllPortalDataTypes")
-    public void setExportAllPortalDataTypes(Set<IPortalDataType> exportAllPortalDataTypes) {
+    @Autowired
+    public void setExportAllPortalDataTypes(Set<IExportAllPortalDataType> exportAllPortalDataTypes) {
         this.exportAllPortalDataTypes = ImmutableSet.copyOf(exportAllPortalDataTypes);
     }
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/PropertiesFilesIsIncludedUser.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/PropertiesFilesIsIncludedUser.java
@@ -49,9 +49,6 @@ public class PropertiesFilesIsIncludedUser implements Function<String, Boolean> 
         this.allUsers = this.userNames.contains("*");
     }
 
-    /* (non-Javadoc)
-     * @see com.google.common.base.Function#apply(java.lang.Object)
-     */
     @Override
     public Boolean apply(String username) {
         if (this.allUsers) {

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/dlm/FragmentDefinitionPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/dlm/FragmentDefinitionPortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes an entity-type data type in the portal */
-public class FragmentDefinitionPortalDataType extends AbstractPortalDataType {
+@Component("fragmentDefinitionPortalDataType")
+public class FragmentDefinitionPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 140;
+
     public static final QName LEGACY_ENTITY_TYPE_QNAME = new QName("fragment-definition");
 
     public static final PortalDataKey IMPORT_31_DATA_KEY =
@@ -33,7 +39,7 @@ public class FragmentDefinitionPortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_31_DATA_KEY);
 
     public FragmentDefinitionPortalDataType() {
-        super(LEGACY_ENTITY_TYPE_QNAME);
+        super(ORDER, LEGACY_ENTITY_TYPE_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/dlm/FragmentDefinitionPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/dlm/FragmentDefinitionPortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes an entity-type data type in the portal */
 @Component("fragmentDefinitionPortalDataType")
-public class FragmentDefinitionPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class FragmentDefinitionPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 140;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/entitytype/EntityTypePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/entitytype/EntityTypePortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes an entity-type data type in the portal */
 @Component("entityTypePortalDataType")
-public class EntityTypePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class EntityTypePortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 20;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/entitytype/EntityTypePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/entitytype/EntityTypePortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes an entity-type data type in the portal */
-public class EntityTypePortalDataType extends AbstractPortalDataType {
+@Component("entityTypePortalDataType")
+public class EntityTypePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 20;
+
     public static final QName LEGACY_ENTITY_TYPE_QNAME = new QName("entity-type");
 
     /** @deprecated used for importing old data files */
@@ -42,7 +48,7 @@ public class EntityTypePortalDataType extends AbstractPortalDataType {
             Arrays.asList(IMPORT_26_DATA_KEY, IMPORT_32_DATA_KEY);
 
     public EntityTypePortalDataType() {
-        super(LEGACY_ENTITY_TYPE_QNAME);
+        super(ORDER, LEGACY_ENTITY_TYPE_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/eventaggr/EventAggregationConfigurationPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/eventaggr/EventAggregationConfigurationPortalDataType.java
@@ -23,7 +23,8 @@ import org.apereo.portal.io.xml.PortalDataKey;
 import org.springframework.stereotype.Component;
 
 @Component("eventAggregationConfigurationPortalDataType")
-public class EventAggregationConfigurationPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class EventAggregationConfigurationPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 170;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/eventaggr/EventAggregationConfigurationPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/eventaggr/EventAggregationConfigurationPortalDataType.java
@@ -18,9 +18,15 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
-public class EventAggregationConfigurationPortalDataType extends AbstractPortalDataType {
+@Component("eventAggregationConfigurationPortalDataType")
+public class EventAggregationConfigurationPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 170;
+
     public static final QName EVENT_AGGREGATION_QNAME =
             new QName(
                     "https://source.jasig.org/schemas/uportal/io/event-aggregation",
@@ -32,7 +38,7 @@ public class EventAggregationConfigurationPortalDataType extends AbstractPortalD
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_40_DATA_KEY);
 
     public EventAggregationConfigurationPortalDataType() {
-        super(EVENT_AGGREGATION_QNAME);
+        super(ORDER, EVENT_AGGREGATION_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupMembershipPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupMembershipPortalDataType.java
@@ -22,11 +22,18 @@ import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a group with members in the portal */
-public class GroupMembershipPortalDataType extends AbstractPortalDataType {
+@Component("groupMembershipPortalDataType")
+public class GroupMembershipPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 60;
+
     public static final QName LEGACY_GROUP_QNAME = new QName("group");
+
     public static final String TYPE_ID = "group-membership";
 
     /** @deprecated used for importing old data files */
@@ -116,7 +123,7 @@ public class GroupMembershipPortalDataType extends AbstractPortalDataType {
             ImmutableSet.of(IMPORT_GROUP_50_DATA_KEY, IMPORT_MEMBERS_50_DATA_KEY);
 
     public GroupMembershipPortalDataType() {
-        super(LEGACY_GROUP_QNAME);
+        super(ORDER, LEGACY_GROUP_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupMembershipPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupMembershipPortalDataType.java
@@ -28,7 +28,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a group with members in the portal */
 @Component("groupMembershipPortalDataType")
-public class GroupMembershipPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class GroupMembershipPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 60;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/GroupPortalDataType.java
@@ -19,9 +19,14 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a portal group */
+@Component("groupPortalDataType")
 public class GroupPortalDataType extends AbstractPortalDataType {
+
+    public static final int ORDER = 50;
+
     public static final QName LEGACY_GROUP_QNAME = new QName("group");
 
     public static final PortalDataKey IMPORT_26_DATA_KEY =
@@ -33,7 +38,7 @@ public class GroupPortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_26_DATA_KEY);
 
     public GroupPortalDataType() {
-        super(LEGACY_GROUP_QNAME);
+        super(ORDER, LEGACY_GROUP_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/MembershipPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/group/MembershipPortalDataType.java
@@ -19,9 +19,14 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a member of a group */
+@Component("membershipPortalDataType")
 public class MembershipPortalDataType extends AbstractPortalDataType {
+
+    public static final int ORDER = 70;
+
     public static final QName LEGACY_MEMBERSHIP_QNAME = new QName("membership");
 
     public static final PortalDataKey IMPORT_26_DATA_KEY =
@@ -33,7 +38,7 @@ public class MembershipPortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_26_DATA_KEY);
 
     public MembershipPortalDataType() {
-        super(LEGACY_MEMBERSHIP_QNAME);
+        super(ORDER, LEGACY_MEMBERSHIP_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/FragmentLayoutPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/FragmentLayoutPortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a fragment owner's layout in the portal */
 @Component("fragmentLayoutPortalDataType")
-public class FragmentLayoutPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class FragmentLayoutPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 150;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/FragmentLayoutPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/FragmentLayoutPortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a fragment owner's layout in the portal */
-public class FragmentLayoutPortalDataType extends AbstractPortalDataType {
+@Component("fragmentLayoutPortalDataType")
+public class FragmentLayoutPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 150;
+
     public static final QName LEGACY_LAYOUT_QNAME = new QName("fragment-layout");
 
     public static final PortalDataKey IMPORT_32_DATA_KEY =
@@ -50,7 +56,7 @@ public class FragmentLayoutPortalDataType extends AbstractPortalDataType {
             Arrays.asList(IMPORT_26_DATA_KEY, IMPORT_30_DATA_KEY, IMPORT_32_DATA_KEY);
 
     public FragmentLayoutPortalDataType() {
-        super(LEGACY_LAYOUT_QNAME);
+        super(ORDER, LEGACY_LAYOUT_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/LayoutPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/LayoutPortalDataType.java
@@ -20,11 +20,17 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import org.apereo.portal.IUserIdentityStore;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /** Describes a user's layout */
-public class LayoutPortalDataType extends AbstractPortalDataType {
+@Component("layoutPortalDataType")
+public class LayoutPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 160;
+
     public static final QName LEGACY_LAYOUT_QNAME = new QName("layout");
 
     public static final PortalDataKey IMPORT_32_DATA_KEY =
@@ -59,7 +65,7 @@ public class LayoutPortalDataType extends AbstractPortalDataType {
     private IUserIdentityStore userIdentityStore;
 
     public LayoutPortalDataType() {
-        super(LEGACY_LAYOUT_QNAME);
+        super(ORDER, LEGACY_LAYOUT_QNAME);
     }
 
     @Autowired

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/LayoutPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/LayoutPortalDataType.java
@@ -27,7 +27,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a user's layout */
 @Component("layoutPortalDataType")
-public class LayoutPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class LayoutPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 160;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/ProfilePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/ProfilePortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a portal group */
-public class ProfilePortalDataType extends AbstractPortalDataType {
+@Component("profilePortalDataType")
+public class ProfilePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 130;
+
     public static final QName LEGACY_PROFILE_QNAME = new QName("profile");
 
     public static final PortalDataKey IMPORT_32_DATA_KEY =
@@ -33,7 +39,7 @@ public class ProfilePortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_32_DATA_KEY);
 
     public ProfilePortalDataType() {
-        super(LEGACY_PROFILE_QNAME);
+        super(ORDER, LEGACY_PROFILE_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/ProfilePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/layout/ProfilePortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a portal group */
 @Component("profilePortalDataType")
-public class ProfilePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class ProfilePortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 130;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/pags/PersonAttributesGroupStorePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/pags/PersonAttributesGroupStorePortalDataType.java
@@ -22,9 +22,15 @@ import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
-public class PersonAttributesGroupStorePortalDataType extends AbstractPortalDataType {
+@Component("personAttributesGroupStorePortalDataType")
+public class PersonAttributesGroupStorePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 10;
+
     public static final QName PERSON_ATTRIBUTE_GROUP_STORE_TYPE_QNAME = new QName("pags-group");
 
     public static final PortalDataKey IMPORT_PAGS_41_DATA_KEY =
@@ -55,7 +61,7 @@ public class PersonAttributesGroupStorePortalDataType extends AbstractPortalData
             ImmutableSet.of(IMPORT_PAGS_GROUP_41_DATA_KEY, IMPORT_PAGS_MEMBERS_41_DATA_KEY);
 
     public PersonAttributesGroupStorePortalDataType() {
-        super(PERSON_ATTRIBUTE_GROUP_STORE_TYPE_QNAME);
+        super(ORDER, PERSON_ATTRIBUTE_GROUP_STORE_TYPE_QNAME);
     }
 
     @Override
@@ -63,17 +69,11 @@ public class PersonAttributesGroupStorePortalDataType extends AbstractPortalData
         return PERSON_ATTRIBUTE_GROUP_STORE_DATA_KEYS;
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getTitle()
-     */
     @Override
     public String getTitleCode() {
         return "Person Attribute Group Store Type";
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getDescription()
-     */
     @Override
     public String getDescriptionCode() {
         return "Person Attribute Group Store";

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/pags/PersonAttributesGroupStorePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/pags/PersonAttributesGroupStorePortalDataType.java
@@ -27,7 +27,8 @@ import org.apereo.portal.io.xml.PortalDataKey;
 import org.springframework.stereotype.Component;
 
 @Component("personAttributesGroupStorePortalDataType")
-public class PersonAttributesGroupStorePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class PersonAttributesGroupStorePortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 10;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionOwnerPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionOwnerPortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a set of permissions in the portal */
-public class PermissionOwnerPortalDataType extends AbstractPortalDataType {
+@Component("permissionOwnerPortalDataType")
+public class PermissionOwnerPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 120;
+
     public static final QName PERMISSION_OWNER_QNAME =
             new QName(
                     "https://source.jasig.org/schemas/uportal/io/permission-owner",
@@ -32,7 +38,7 @@ public class PermissionOwnerPortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_40_DATA_KEY);
 
     public PermissionOwnerPortalDataType() {
-        super(PERMISSION_OWNER_QNAME);
+        super(ORDER, PERMISSION_OWNER_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionOwnerPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionOwnerPortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a set of permissions in the portal */
 @Component("permissionOwnerPortalDataType")
-public class PermissionOwnerPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class PermissionOwnerPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 120;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionPortalDataType.java
@@ -19,9 +19,14 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a permission owner in the portal */
+@Component("permissionPortalDataType")
 public class PermissionPortalDataType extends AbstractPortalDataType {
+
+    public static final int ORDER = 100;
+
     public static final QName LEGACY_PERMISSION_QNAME = new QName("permission");
 
     public static final PortalDataKey IMPORT_26_DATA_KEY =
@@ -33,7 +38,7 @@ public class PermissionPortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_26_DATA_KEY);
 
     public PermissionPortalDataType() {
-        super(LEGACY_PERMISSION_QNAME);
+        super(ORDER, LEGACY_PERMISSION_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionSetPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionSetPortalDataType.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes a permission in the portal */
 @Component("permissionSetPortalDataType")
-public class PermissionSetPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class PermissionSetPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 110;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionSetPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/permission/PermissionSetPortalDataType.java
@@ -18,10 +18,15 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a permission in the portal */
-public class PermissionSetPortalDataType extends AbstractPortalDataType {
+@Component("permissionSetPortalDataType")
+public class PermissionSetPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 110;
 
     public static final QName LEGACY_PERMISSION_SET_QNAME = new QName("permission-set");
 
@@ -42,7 +47,7 @@ public class PermissionSetPortalDataType extends AbstractPortalDataType {
             Arrays.asList(new PortalDataKey[] {IMPORT_31_DATA_KEY, IMPORT_50_DATA_KEY});
 
     public PermissionSetPortalDataType() {
-        super(LEGACY_PERMISSION_SET_QNAME);
+        super(ORDER, LEGACY_PERMISSION_SET_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlet/PortletPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlet/PortletPortalDataType.java
@@ -25,7 +25,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes the {@link IPortletDefinition} for import and export. */
 @Component("portletPortalDataType")
-public class PortletPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class PortletPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 90;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlet/PortletPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlet/PortletPortalDataType.java
@@ -18,11 +18,17 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
 import org.apereo.portal.portlet.om.IPortletDefinition;
+import org.springframework.stereotype.Component;
 
 /** Describes the {@link IPortletDefinition} for import and export. */
-public class PortletPortalDataType extends AbstractPortalDataType {
+@Component("portletPortalDataType")
+public class PortletPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 90;
+
     public static final QName PORTLET_DEFINITION_QNAME =
             new QName(
                     "https://source.jasig.org/schemas/uportal/io/portlet-definition",
@@ -88,7 +94,7 @@ public class PortletPortalDataType extends AbstractPortalDataType {
                     IMPORT_50_DATA_KEY);
 
     public PortletPortalDataType() {
-        super(PORTLET_DEFINITION_QNAME);
+        super(ORDER, PORTLET_DEFINITION_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlettype/PortletTypePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlettype/PortletTypePortalDataType.java
@@ -23,7 +23,8 @@ import org.apereo.portal.io.xml.PortalDataKey;
 import org.springframework.stereotype.Component;
 
 @Component("portletTypePortalDataType")
-public class PortletTypePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class PortletTypePortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 80;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlettype/PortletTypePortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/portlettype/PortletTypePortalDataType.java
@@ -18,9 +18,15 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
-public class PortletTypePortalDataType extends AbstractPortalDataType {
+@Component("portletTypePortalDataType")
+public class PortletTypePortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 80;
+
     public static final QName PORTLET_TYPE_QNAME =
             new QName("https://source.jasig.org/schemas/uportal/io/portlet-type", "portlet-type");
 
@@ -30,7 +36,7 @@ public class PortletTypePortalDataType extends AbstractPortalDataType {
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(IMPORT_40_DATA_KEY);
 
     public PortletTypePortalDataType() {
-        super(PORTLET_TYPE_QNAME);
+        super(ORDER, PORTLET_TYPE_QNAME);
     }
 
     @Override
@@ -38,17 +44,11 @@ public class PortletTypePortalDataType extends AbstractPortalDataType {
         return PORTAL_DATA_KEYS;
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getTitle()
-     */
     @Override
     public String getTitleCode() {
         return "Portlet Type";
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.io.xml.IPortalDataType#getDescription()
-     */
     @Override
     public String getDescriptionCode() {
         return "Types of portlets published in the portal";

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/ssd/StylesheetDescriptorPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/ssd/StylesheetDescriptorPortalDataType.java
@@ -18,11 +18,17 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
 import org.apereo.portal.layout.om.IStylesheetDescriptor;
+import org.springframework.stereotype.Component;
 
 /** Describes the {@link IStylesheetDescriptor} for import and export. */
-public class StylesheetDescriptorPortalDataType extends AbstractPortalDataType {
+@Component("stylesheetDescriptorPortalDataType")
+public class StylesheetDescriptorPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 30;
+
     public static final QName STYLESHEET_DESCRIPTOR_QNAME =
             new QName(
                     "https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor",
@@ -58,7 +64,7 @@ public class StylesheetDescriptorPortalDataType extends AbstractPortalDataType {
                     IMPORT_26_THEME_DATA_KEY, IMPORT_26_STRUCTURE_DATA_KEY, IMPORT_40_DATA_KEY);
 
     public StylesheetDescriptorPortalDataType() {
-        super(STYLESHEET_DESCRIPTOR_QNAME);
+        super(ORDER, STYLESHEET_DESCRIPTOR_QNAME);
     }
 
     @Override

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/ssd/StylesheetDescriptorPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/ssd/StylesheetDescriptorPortalDataType.java
@@ -25,7 +25,8 @@ import org.springframework.stereotype.Component;
 
 /** Describes the {@link IStylesheetDescriptor} for import and export. */
 @Component("stylesheetDescriptorPortalDataType")
-public class StylesheetDescriptorPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+public class StylesheetDescriptorPortalDataType extends AbstractPortalDataType
+        implements IExportAllPortalDataType {
 
     public static final int ORDER = 30;
 

--- a/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/user/UserPortalDataType.java
+++ b/uPortal-io/uPortal-io-types/src/main/java/org/apereo/portal/io/xml/user/UserPortalDataType.java
@@ -18,10 +18,16 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apereo.portal.io.xml.AbstractPortalDataType;
+import org.apereo.portal.io.xml.IExportAllPortalDataType;
 import org.apereo.portal.io.xml.PortalDataKey;
+import org.springframework.stereotype.Component;
 
 /** Describes a User data type in the portal */
-public class UserPortalDataType extends AbstractPortalDataType {
+@Component("userPortalDataType")
+public class UserPortalDataType extends AbstractPortalDataType implements IExportAllPortalDataType {
+
+    public static final int ORDER = 40;
+
     public static final QName USER_QNAME =
             new QName("https://source.jasig.org/schemas/uportal/io/user", "user");
 
@@ -60,7 +66,7 @@ public class UserPortalDataType extends AbstractPortalDataType {
                     IMPORT_26_DATA_KEY, IMPORT_30_DATA_KEY, IMPORT_32_DATA_KEY, IMPORT_40_DATA_KEY);
 
     public UserPortalDataType() {
-        super(USER_QNAME);
+        super(ORDER, USER_QNAME);
     }
 
     @Override

--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/registry/PortletWindowRegistryImpl.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/registry/PortletWindowRegistryImpl.java
@@ -69,12 +69,12 @@ import org.springframework.web.util.WebUtils;
 public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
     public static final QName PORTLET_WINDOW_ID_ATTR_NAME = new QName("portletWindowId");
 
-    static final String STATELESS_PORTLET_WINDOW_ID = "tw";
-    static final String PORTLET_WINDOW_DATA_ATTRIBUTE =
+    private static final String STATELESS_PORTLET_WINDOW_ID = "tw";
+    private static final String PORTLET_WINDOW_DATA_ATTRIBUTE =
             PortletWindowRegistryImpl.class.getName() + ".PORTLET_WINDOW_DATA";
-    static final String PORTLET_WINDOW_ATTRIBUTE =
+    private static final String PORTLET_WINDOW_ATTRIBUTE =
             PortletWindowRegistryImpl.class.getName() + ".PORTLET_WINDOW.thread-";
-    static final String DISABLE_PERSISTENT_WINDOWS =
+    private static final String DISABLE_PERSISTENT_WINDOWS =
             PortletWindowRegistryImpl.class.getName() + ".DISABLE_PERSISTENT_WINDOWS";
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -265,7 +265,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
         final PortletWindowData portletWindowData;
         if (STATELESS_PORTLET_WINDOW_ID.equals(localPortletWindowId.getWindowInstanceId())) {
             final PortletWindowCache<PortletWindowData> statelessPortletWindowDataMap =
-                    this.getStatelessPortletWindowDataMap(request, false);
+                    this.getStatelessPortletWindowDataMap(request);
             if (statelessPortletWindowDataMap != null) {
                 portletWindowData = statelessPortletWindowDataMap.getWindow(portletWindowId);
             } else {
@@ -379,7 +379,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
 
         final PortletWindowCache<IPortletWindow> portletWindowMap = getPortletWindowMap(request);
         final Set<IPortletWindow> portletWindows =
-                new LinkedHashSet<IPortletWindow>(portletWindowMap.getWindows(portletEntityId));
+                new LinkedHashSet<>(portletWindowMap.getWindows(portletEntityId));
 
         // Check for session cached windows that haven't been accessed in this request
         final PortletWindowCache<PortletWindowData> portletWindowDataMap =
@@ -389,7 +389,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
 
         // Check for stateless windows that exist on this request
         final PortletWindowCache<PortletWindowData> statelessPortletWindowDataMap =
-                this.getStatelessPortletWindowDataMap(request, false);
+                this.getStatelessPortletWindowDataMap(request);
         if (statelessPortletWindowDataMap != null) {
             this.addPortletWindowData(
                     request,
@@ -418,7 +418,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
             final String windowIdStr = windowIdAttribute.getValue();
             final IPortletWindowId portletWindowId = this.getPortletWindowId(request, windowIdStr);
             final IPortletWindow portletWindow = this.getPortletWindow(request, portletWindowId);
-            return new Tuple<IPortletWindow, StartElement>(portletWindow, element);
+            return new Tuple<>(portletWindow, element);
         }
 
         // No explicit window id, look it up based on the layout node id
@@ -456,7 +456,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
 
         element = this.addPortletWindowId(element, portletWindow.getPortletWindowId());
 
-        return new Tuple<IPortletWindow, StartElement>(portletWindow, element);
+        return new Tuple<>(portletWindow, element);
     }
 
     protected StartElement addPortletWindowId(
@@ -484,13 +484,6 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
                 prefix, namespaceURI, localPart, newAttributes, namespaces, namespaceContext);
     }
 
-    /**
-     * @param request
-     * @param portletEntityId
-     * @param portletWindows
-     * @param portletWindowMap
-     * @param portletWindowDataMap
-     */
     protected void addPortletWindowData(
             HttpServletRequest request,
             IPortletEntityId portletEntityId,
@@ -551,7 +544,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
                 this.getPortletWindow(request, basePortletWindowId);
 
         final PortletWindowCache<PortletWindowData> statelessPortletWindowDataMap =
-                this.getStatelessPortletWindowDataMap(request, true);
+                this.getStatelessPortletWindowDataMap(request);
 
         // If no base to clone from lookup the entity and pluto definition data
         if (basePortletWindow == null) {
@@ -670,7 +663,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
         final Set<String> allSubscribedChannels = userLayoutManager.getAllSubscribedChannels();
 
         final Set<IPortletWindow> allLayoutWindows =
-                new LinkedHashSet<IPortletWindow>(allSubscribedChannels.size());
+                new LinkedHashSet<>(allSubscribedChannels.size());
 
         for (final String channelSubscribeId : allSubscribedChannels) {
             final IPortletEntity portletEntity =
@@ -765,7 +758,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
         PortletWindowCache<IPortletWindow> windowCache =
                 (PortletWindowCache<IPortletWindow>) request.getAttribute(mapAttributeName);
         if (windowCache == null) {
-            windowCache = new PortletWindowCache<IPortletWindow>(false);
+            windowCache = new PortletWindowCache<>(false);
             request.setAttribute(mapAttributeName, windowCache);
         }
 
@@ -794,7 +787,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
                     (PortletWindowCache<PortletWindowData>)
                             session.getAttribute(PORTLET_WINDOW_DATA_ATTRIBUTE);
             if (windowCache == null) {
-                windowCache = new PortletWindowCache<PortletWindowData>();
+                windowCache = new PortletWindowCache<>();
                 session.setAttribute(PORTLET_WINDOW_DATA_ATTRIBUTE, windowCache);
             }
         }
@@ -804,7 +797,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
 
     @SuppressWarnings("unchecked")
     protected PortletWindowCache<PortletWindowData> getStatelessPortletWindowDataMap(
-            HttpServletRequest request, boolean create) {
+            HttpServletRequest request) {
         request = portalRequestUtils.getOriginalPortalRequest(request);
 
         PortletWindowCache<PortletWindowData> windowCache;
@@ -815,7 +808,7 @@ public class PortletWindowRegistryImpl implements IPortletWindowRegistry {
                     (PortletWindowCache<PortletWindowData>)
                             request.getAttribute(PORTLET_WINDOW_DATA_ATTRIBUTE);
             if (windowCache == null) {
-                windowCache = new PortletWindowCache<PortletWindowData>();
+                windowCache = new PortletWindowCache<>();
                 request.setAttribute(PORTLET_WINDOW_DATA_ATTRIBUTE, windowCache);
             }
         }

--- a/uPortal-tenants/src/main/java/org/apereo/portal/tenants/TemplateDataTenantOperationsListener.java
+++ b/uPortal-tenants/src/main/java/org/apereo/portal/tenants/TemplateDataTenantOperationsListener.java
@@ -105,7 +105,10 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
         this.reader.setMergeAdjacentText(true);
     }
 
-    /** The <code>@Autowired</code> list will reflect the order in which data types should be imported. */
+    /**
+     * The <code>@Autowired</code> list will reflect the order in which data types should be
+     * imported.
+     */
     @Autowired
     public void setDataTypeImportOrder(List<IPortalDataType> dataTypeImportOrder) {
         final ArrayList<PortalDataKey> dataKeyImportOrder =
@@ -205,8 +208,7 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
     @PostConstruct
     public void setup() throws Exception {
         entityResourcesToImportOnCreate =
-                new HashSet<>(
-                        Arrays.asList(applicationContext.getResources(templateLocation)));
+                new HashSet<>(Arrays.asList(applicationContext.getResources(templateLocation)));
         this.entityResourcesToImportOnUpdate =
                 buildResourcesFromPaths(applicationContext, entityResourcePathsToImportOnUpdate);
     }
@@ -369,8 +371,7 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
     /** Loads dom4j Documents and sorts the entity files into the proper order for Import. */
     private Map<PortalDataKey, Set<BucketTuple>> prepareImportQueue(
             final ITenant tenant, final Set<Resource> templates) throws Exception {
-        final Map<PortalDataKey, Set<BucketTuple>> rslt =
-                new HashMap<>();
+        final Map<PortalDataKey, Set<BucketTuple>> rslt = new HashMap<>();
         Resource rsc = null;
         try {
             for (Resource r : templates) {

--- a/uPortal-tenants/src/main/java/org/apereo/portal/tenants/TemplateDataTenantOperationsListener.java
+++ b/uPortal-tenants/src/main/java/org/apereo/portal/tenants/TemplateDataTenantOperationsListener.java
@@ -105,11 +105,11 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
         this.reader.setMergeAdjacentText(true);
     }
 
-    /** Order in which data types should be imported. */
-    @javax.annotation.Resource(name = "dataTypeImportOrder")
+    /** The <code>@Autowired</code> list will reflect the order in which data types should be imported. */
+    @Autowired
     public void setDataTypeImportOrder(List<IPortalDataType> dataTypeImportOrder) {
         final ArrayList<PortalDataKey> dataKeyImportOrder =
-                new ArrayList<PortalDataKey>(dataTypeImportOrder.size() * 2);
+                new ArrayList<>(dataTypeImportOrder.size() * 2);
 
         for (final IPortalDataType portalDataType : dataTypeImportOrder) {
             final List<PortalDataKey> supportedDataKeys = portalDataType.getDataKeyImportOrder();
@@ -205,7 +205,7 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
     @PostConstruct
     public void setup() throws Exception {
         entityResourcesToImportOnCreate =
-                new HashSet<Resource>(
+                new HashSet<>(
                         Arrays.asList(applicationContext.getResources(templateLocation)));
         this.entityResourcesToImportOnUpdate =
                 buildResourcesFromPaths(applicationContext, entityResourcePathsToImportOnUpdate);
@@ -370,7 +370,7 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
     private Map<PortalDataKey, Set<BucketTuple>> prepareImportQueue(
             final ITenant tenant, final Set<Resource> templates) throws Exception {
         final Map<PortalDataKey, Set<BucketTuple>> rslt =
-                new HashMap<PortalDataKey, Set<BucketTuple>>();
+                new HashMap<>();
         Resource rsc = null;
         try {
             for (Resource r : templates) {
@@ -394,7 +394,7 @@ public final class TemplateDataTenantOperationsListener extends AbstractTenantOp
                         Set<BucketTuple> bucket = rslt.get(atLeastOneMatchingDataKey);
                         if (bucket == null) {
                             // First of these we've seen;  create the bucket;
-                            bucket = new HashSet<BucketTuple>();
+                            bucket = new HashSet<>();
                             rslt.put(atLeastOneMatchingDataKey, bucket);
                         }
                         BucketTuple tuple = new BucketTuple(rsc, doc);

--- a/uPortal-webapp/src/main/resources/properties/contexts/importExportContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/importExportContext.xml
@@ -26,69 +26,6 @@
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd">
 
-
-
-    <!--
-     | The various portal data type descriptors
-     +-->
-    <bean id="entityTypePortalDataType" class="org.apereo.portal.io.xml.entitytype.EntityTypePortalDataType"/>
-    <bean id="stylesheetDescriptorPortalDataType" class="org.apereo.portal.io.xml.ssd.StylesheetDescriptorPortalDataType"/>
-    <bean id="userPortalDataType" class="org.apereo.portal.io.xml.user.UserPortalDataType"/>
-    <bean id="groupPortalDataType" class="org.apereo.portal.io.xml.group.GroupPortalDataType"/>
-    <bean id="groupMembershipPortalDataType" class="org.apereo.portal.io.xml.group.GroupMembershipPortalDataType"/>
-    <bean id="membershipPortalDataType" class="org.apereo.portal.io.xml.group.MembershipPortalDataType"/>
-    <bean id="portletTypePortalDataType" class="org.apereo.portal.io.xml.portlettype.PortletTypePortalDataType"/>
-    <bean id="portletPortalDataType" class="org.apereo.portal.io.xml.portlet.PortletPortalDataType"/>
-    <bean id="permissionPortalDataType" class="org.apereo.portal.io.xml.permission.PermissionPortalDataType"/>
-    <bean id="permissionSetPortalDataType" class="org.apereo.portal.io.xml.permission.PermissionSetPortalDataType"/>
-    <bean id="permissionOwnerPortalDataType" class="org.apereo.portal.io.xml.permission.PermissionOwnerPortalDataType"/>
-    <bean id="profilePortalDataType" class="org.apereo.portal.io.xml.layout.ProfilePortalDataType"/>
-    <bean id="fragmentLayoutPortalDataType" class="org.apereo.portal.io.xml.layout.FragmentLayoutPortalDataType"/>
-    <bean id="layoutPortalDataType" class="org.apereo.portal.io.xml.layout.LayoutPortalDataType"/>
-    <bean id="fragmentDefinitionPortalDataType" class="org.apereo.portal.io.xml.dlm.FragmentDefinitionPortalDataType"/>
-    <bean id="eventAggregationConfigurationPortalDataType" class="org.apereo.portal.io.xml.eventaggr.EventAggregationConfigurationPortalDataType" />
-    <bean id="personAttributesGroupStorePortalDataType" class="org.apereo.portal.io.xml.pags.PersonAttributesGroupStorePortalDataType" />
-
-    <!--
-     | Import order for portal data types
-     +-->
-    <util:list id="dataTypeImportOrder">
-        <ref bean="personAttributesGroupStorePortalDataType" />
-        <ref bean="entityTypePortalDataType" />
-        <ref bean="stylesheetDescriptorPortalDataType" />
-        <ref bean="userPortalDataType" />
-        <ref bean="groupPortalDataType" />
-        <ref bean="groupMembershipPortalDataType" />
-        <ref bean="membershipPortalDataType" />
-        <ref bean="portletTypePortalDataType" />
-        <ref bean="portletPortalDataType" />
-        <ref bean="permissionPortalDataType" />
-        <ref bean="permissionSetPortalDataType" />
-        <ref bean="permissionOwnerPortalDataType" />
-        <ref bean="profilePortalDataType" />
-        <ref bean="fragmentDefinitionPortalDataType" />
-        <ref bean="fragmentLayoutPortalDataType" />
-        <ref bean="layoutPortalDataType" />
-        <ref bean="eventAggregationConfigurationPortalDataType" />
-    </util:list>
-
-    <util:set id="exportAllPortalDataTypes">
-        <ref bean="personAttributesGroupStorePortalDataType" />
-        <ref bean="entityTypePortalDataType" />
-        <ref bean="fragmentDefinitionPortalDataType" />
-        <ref bean="fragmentLayoutPortalDataType" />
-        <ref bean="groupMembershipPortalDataType" />
-        <ref bean="layoutPortalDataType" />
-        <ref bean="permissionOwnerPortalDataType" />
-        <ref bean="permissionSetPortalDataType" />
-        <ref bean="portletTypePortalDataType" />
-        <ref bean="portletPortalDataType" />
-        <ref bean="profilePortalDataType" />
-        <ref bean="stylesheetDescriptorPortalDataType" />
-        <ref bean="userPortalDataType" />
-        <ref bean="eventAggregationConfigurationPortalDataType" />
-    </util:set>
-
     <!--
      | File-name patterns that a candidate file must match one of when doing a bulk import
      +-->


### PR DESCRIPTION
…all IPortalDataType beans from XML config in importExportContext.xml by using modern, idiomatic Spring

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This update reduces the noise in `importExportContext.xml`.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
