### PR TITLE
feat: extract favicon path as property to be able to customize it wit…

### DIFF
--- a/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
+++ b/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
@@ -146,6 +146,9 @@ public class RenderingPipelineConfiguration {
     @Value("${org.apereo.portal.layout.useFlyoutMenus:false}")
     private String useFlyoutMenus;
 
+    @Value("${org.apereo.portal.layout.faviconPath:#{null}}")
+    private String faviconPath;
+
     @Resource(name = "org.apereo.portal.rendering.THEME_TRANSFORM")
     private Cache themeTransformCache;
 
@@ -411,6 +414,9 @@ public class RenderingPipelineConfiguration {
         parameters.put("useTabGroups", useTabGroups);
         parameters.put("UP_VERSION", uPortalVersion);
         parameters.put("USE_FLYOUT_MENUS", useFlyoutMenus);
+        if (faviconPath != null) {
+            parameters.put("PORTAL_SHORTCUT_ICON", faviconPath);
+        }
 
         final Map<String, String> parameterExpressions = new HashMap<>();
         parameterExpressions.put("CURRENT_REQUEST", "request.nativeRequest");

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -149,7 +149,8 @@
 <xsl:variable name="ABSOLUTE_MEDIA_PATH" select="concat($CONTEXT_PATH,'/',$MEDIA_PATH)"/>
 <xsl:variable name="SKIN_RESOURCES_PATH" select="concat('/',$MEDIA_PATH,'/',$SKIN,'/skin.xml')"/>
 <xsl:variable name="SKIN_PATH" select="concat($ABSOLUTE_MEDIA_PATH,'/',$SKIN)"/>
-<xsl:variable name="PORTAL_SHORTCUT_ICON" select="concat($CONTEXT_PATH,'/favicon.ico')" />
+<xsl:variable name="SHORTCUT_ICON" select="concat($CONTEXT_PATH,'/favicon.ico')" />
+<xsl:param name="PORTAL_SHORTCUT_ICON"><xsl:value-of select="$SHORTCUT_ICON"/></xsl:param>
 <xsl:variable name="FOCUSED_CLASS">
     <xsl:choose>
         <xsl:when test="//content/focused">focused <xsl:value-of select="//content/focused/channel/@fname"/></xsl:when>


### PR DESCRIPTION
…hout modifying it into the xsl

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This permit to extract as a property the favicon path and avoid to modify it into the xsl (and so avoid having into uPortal-start a copy of the xsl only for this change)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
