### PR TITLE
Added support for overriding groups and/or custom claims for OIDC tokens

### DIFF
--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
@@ -14,6 +14,10 @@
  */
 package org.apereo.portal.rest;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.oauth.IdTokenFactory;
@@ -22,10 +26,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * This controller provides an endpoint through which clients can obtain an ID Token in a format
@@ -58,24 +58,24 @@ public class OidcUserInfoController {
             method = {RequestMethod.GET, RequestMethod.POST})
     public String userInfo(
             HttpServletRequest request,
-            @RequestParam(value = "groups", required = false) String overrideGroups,
-            @RequestParam(value = "customClaims", required = false) String overrideCustomClaims) {
+            @RequestParam(value = "claims", required = false) String claims,
+            @RequestParam(value = "groups", required = false) String groups) {
 
         final IPerson person = personManager.getPerson(request);
 
-        List<String> parsedGroups = null;
-        if (overrideGroups != null) {
-            String[] tokens = overrideGroups.split("[,]");
-            parsedGroups = Arrays.asList(tokens);
+        Set<String> claimsToInclude = null;
+        if (claims != null) {
+            String[] tokens = claims.split("[,]");
+            claimsToInclude = new HashSet<>(Arrays.asList(tokens));
         }
 
-        List<String> parsedCustomClaims = null;
-        if (overrideCustomClaims != null) {
-            String[] tokens = overrideCustomClaims.split("[,]");
-            parsedCustomClaims = Arrays.asList(tokens);
+        Set<String> groupsToInclude = null;
+        if (groups != null) {
+            String[] tokens = groups.split("[,]");
+            groupsToInclude = new HashSet<>(Arrays.asList(tokens));
         }
 
         return idTokenFactory.createUserInfo(
-                person.getUserName(), parsedGroups, parsedCustomClaims);
+                person.getUserName(), claimsToInclude, groupsToInclude);
     }
 }

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
@@ -14,7 +14,6 @@
  */
 package org.apereo.portal.rest;
 
-import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.oauth.IdTokenFactory;
@@ -22,6 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This controller provides an endpoint through which clients can obtain an ID Token in a format
@@ -54,6 +57,28 @@ public class OidcUserInfoController {
             method = {RequestMethod.GET, RequestMethod.POST})
     public String userInfo(HttpServletRequest request) {
         final IPerson person = personManager.getPerson(request);
-        return idTokenFactory.createUserInfo(person.getUserName());
+
+        List<String> overrideGroups = null;
+        if(request.getParameter("groups") != null) {
+            String[] tokens = request
+                .getParameter("groups")
+                .split("[,]");
+
+            overrideGroups = Arrays.asList(tokens);
+        }
+
+        List<String> overrideCustomClaims = null;
+        if(request.getParameter("customClaims") != null) {
+            String[] tokens = request
+                .getParameter("customClaims")
+                .split("[,]");
+
+            overrideCustomClaims = Arrays.asList(tokens);
+        }
+
+        return idTokenFactory.createUserInfo(
+            person.getUserName(),
+            overrideGroups,
+            overrideCustomClaims);
     }
 }

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
@@ -59,26 +59,20 @@ public class OidcUserInfoController {
         final IPerson person = personManager.getPerson(request);
 
         List<String> overrideGroups = null;
-        if(request.getParameter("groups") != null) {
-            String[] tokens = request
-                .getParameter("groups")
-                .split("[,]");
+        if (request.getParameter("groups") != null) {
+            String[] tokens = request.getParameter("groups").split("[,]");
 
             overrideGroups = Arrays.asList(tokens);
         }
 
         List<String> overrideCustomClaims = null;
-        if(request.getParameter("customClaims") != null) {
-            String[] tokens = request
-                .getParameter("customClaims")
-                .split("[,]");
+        if (request.getParameter("customClaims") != null) {
+            String[] tokens = request.getParameter("customClaims").split("[,]");
 
             overrideCustomClaims = Arrays.asList(tokens);
         }
 
         return idTokenFactory.createUserInfo(
-            person.getUserName(),
-            overrideGroups,
-            overrideCustomClaims);
+                person.getUserName(), overrideGroups, overrideCustomClaims);
     }
 }

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
@@ -14,6 +14,9 @@
  */
 package org.apereo.portal.rest;
 
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.oauth.IdTokenFactory;
@@ -21,10 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * This controller provides an endpoint through which clients can obtain an ID Token in a format

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/OidcUserInfoController.java
@@ -14,16 +14,18 @@
  */
 package org.apereo.portal.rest;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import org.apereo.portal.security.IPerson;
 import org.apereo.portal.security.IPersonManager;
 import org.apereo.portal.security.oauth.IdTokenFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This controller provides an endpoint through which clients can obtain an ID Token in a format
@@ -54,24 +56,26 @@ public class OidcUserInfoController {
             value = ENDPOINT_URI,
             produces = CONTENT_TYPE,
             method = {RequestMethod.GET, RequestMethod.POST})
-    public String userInfo(HttpServletRequest request) {
+    public String userInfo(
+            HttpServletRequest request,
+            @RequestParam(value = "groups", required = false) String overrideGroups,
+            @RequestParam(value = "customClaims", required = false) String overrideCustomClaims) {
+
         final IPerson person = personManager.getPerson(request);
 
-        List<String> overrideGroups = null;
-        if (request.getParameter("groups") != null) {
-            String[] tokens = request.getParameter("groups").split("[,]");
-
-            overrideGroups = Arrays.asList(tokens);
+        List<String> parsedGroups = null;
+        if (overrideGroups != null) {
+            String[] tokens = overrideGroups.split("[,]");
+            parsedGroups = Arrays.asList(tokens);
         }
 
-        List<String> overrideCustomClaims = null;
-        if (request.getParameter("customClaims") != null) {
-            String[] tokens = request.getParameter("customClaims").split("[,]");
-
-            overrideCustomClaims = Arrays.asList(tokens);
+        List<String> parsedCustomClaims = null;
+        if (overrideCustomClaims != null) {
+            String[] tokens = overrideCustomClaims.split("[,]");
+            parsedCustomClaims = Arrays.asList(tokens);
         }
 
         return idTokenFactory.createUserInfo(
-                person.getUserName(), overrideGroups, overrideCustomClaims);
+                person.getUserName(), parsedGroups, parsedCustomClaims);
     }
 }

--- a/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/oauth/IdTokenFactory.java
+++ b/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/oauth/IdTokenFactory.java
@@ -261,7 +261,8 @@ public class IdTokenFactory {
         return this.createUserInfo(username, null, null);
     }
 
-    public String createUserInfo(String username, List<String> overrideGroups, List<String> overrideCustomClaims) {
+    public String createUserInfo(
+            String username, List<String> overrideGroups, List<String> overrideCustomClaims) {
 
         final Date now = new Date();
         final Date expires = new Date(now.getTime() + (timeoutSeconds * 1000L));
@@ -297,11 +298,10 @@ public class IdTokenFactory {
                 // Is an override set of groups provided?
                 if (overrideGroups != null) {
                     // Does the override list contain the group currently being evaluated?
-                    if(overrideGroups.contains(g.getName())) {
+                    if (overrideGroups.contains(g.getName())) {
                         groups.add(g.getName());
                     }
-                }
-                else {
+                } else {
                     if (groupsWhitelist.contains(g.getName())) {
                         groups.add(g.getName());
                     }
@@ -317,26 +317,27 @@ public class IdTokenFactory {
         }
 
         // Is an override set of custom claim attributes provided?
-        if(overrideCustomClaims != null) {
+        if (overrideCustomClaims != null) {
             overrideCustomClaims
-                .stream()
-                .map(
-                    attributeName ->
-                        new CustomClaim(
-                            attributeName, person.getAttributeValues(attributeName)))
-                .filter(claim -> claim.getClaimValue() != null)
-                .forEach(claim -> builder.claim(claim.getClaimName(), claim.getClaimValue()));
-        }
-        else {
+                    .stream()
+                    .map(
+                            attributeName ->
+                                    new CustomClaim(
+                                            attributeName,
+                                            person.getAttributeValues(attributeName)))
+                    .filter(claim -> claim.getClaimValue() != null)
+                    .forEach(claim -> builder.claim(claim.getClaimName(), claim.getClaimValue()));
+        } else {
             // Default custom claims defined by uPortal.properties
             customClaims
-                .stream()
-                .map(
-                    attributeName ->
-                        new CustomClaim(
-                            attributeName, person.getAttributeValues(attributeName)))
-                .filter(claim -> claim.getClaimValue() != null)
-                .forEach(claim -> builder.claim(claim.getClaimName(), claim.getClaimValue()));
+                    .stream()
+                    .map(
+                            attributeName ->
+                                    new CustomClaim(
+                                            attributeName,
+                                            person.getAttributeValues(attributeName)))
+                    .filter(claim -> claim.getClaimValue() != null)
+                    .forEach(claim -> builder.claim(claim.getClaimName(), claim.getClaimValue()));
         }
 
         final String rslt = builder.signWith(SignatureAlgorithm.HS512, signatureKey).compact();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR is a reboot of #1408.

It includes a couple changes:

  - It prevents unauthorized (by deployment config) user attributes from appearing in the JWT by use of clever parameters
  - It applies the `claims` query string param (the filtering feature) to standard OIDC claims as well as custom claims

In addition to these substantive changes, some items & names were refactored for simplicity.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
