### PR TITLE
feat:  add support for ranked search results to the uPortal portlet e…

### DIFF
--- a/uPortal-api/uPortal-api-search/src/main/resources/xsd/portal-search-4.0.xsd
+++ b/uPortal-api/uPortal-api-search/src/main/resources/xsd/portal-search-4.0.xsd
@@ -54,6 +54,7 @@
             <xs:element name="title" type="xs:string" />
             <xs:element name="summary" type="xs:string" />
             <xs:element name="type" type="xs:string" maxOccurs="unbounded" minOccurs="0" />
+            <xs:element name="rank" type="xs:int" /><!-- Added in uPortal 5.4.0 to support ranked search results -->
             <xs:choice minOccurs="0">
                 <xs:element name="portletUrl" type="portletUrl"/>
                 <xs:element name="externalUrl" type="xs:anyURI"/>

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
@@ -627,6 +627,8 @@ public class SearchPortletController {
                     value.sort(Comparator.comparingInt(tuple -> tuple.first.getRank()));
                 });
 
+        logger.debug("Search results for query '{}' are:  {}", query, results);
+
         model.put("results", results);
         model.put("defaultTabKey", this.defaultTabKey);
         model.put("tabKeys", this.tabKeys);

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/search/SearchPortletController.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -298,6 +299,7 @@ public class SearchPortletController {
              */
 
             // send a search query event
+            logger.debug("Sending search event:  {}", queryObj);
             response.setEvent(SearchConstants.SEARCH_REQUEST_QNAME, queryObj);
         }
 
@@ -619,6 +621,12 @@ public class SearchPortletController {
         if (portalSearchResults != null) {
             results = portalSearchResults.getResults();
         }
+
+        results.forEach(
+                (key, value) -> {
+                    value.sort(Comparator.comparingInt(tuple -> tuple.first.getRank()));
+                });
+
         model.put("results", results);
         model.put("defaultTabKey", this.defaultTabKey);
         model.put("tabKeys", this.tabKeys);


### PR DESCRIPTION
…vent-based search integration API

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR is a modest enhancement to the portlet event-based search integration API.  It adds the (optional) ability to specify a `rank` with each search result -- higher-ranked results appear before lower-ranked results.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
