### PR TITLE
feat:  allow regions to contain child <folder> elements (nested struc…

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/structure/columns/columns-imports.xsl
+++ b/uPortal-webapp/src/main/resources/layout/structure/columns/columns-imports.xsl
@@ -69,8 +69,8 @@
      | queue. 
      +-->
     <xsl:template name="region">
-        <region name="{@type}">
-            <xsl:copy-of select="channel"/>
+        <region name="{@type}" title="{@name}">
+            <xsl:copy-of select="child::*"/>
         </region>
     </xsl:template>
 

--- a/uPortal-webapp/src/main/resources/layout/structure/columns/columns-js.xsl
+++ b/uPortal-webapp/src/main/resources/layout/structure/columns/columns-js.xsl
@@ -66,7 +66,7 @@
     <xsl:template name="regions">
             <regions>
                 <!-- Include all regions -->
-                <xsl:for-each select="child::folder[@type!='regular' and @type!='sidebar' and @type!='favorites' and @type!='favorite_collection' and channel]"><!-- Ignores empty folders -->
+                <xsl:for-each select="child::folder[@type!='regular' and @type!='sidebar' and @type!='favorites' and @type!='favorite_collection' and descendant::channel]"><!-- Ignores empty folders -->
                     <xsl:call-template name="region"/>
                 </xsl:for-each>
             </regions>

--- a/uPortal-webapp/src/main/resources/layout/theme/json/json-v4-3.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/json/json-v4-3.xsl
@@ -271,9 +271,22 @@
         {
             <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="."/>",
             </xsl:for-each>
+            "folders": [
+            <xsl:for-each select="folder">
+            {
+                <xsl:for-each select="@*">"<xsl:value-of select ="local-name()"/>": "<xsl:value-of select="upJsonTool:escapeForJson(.)"/>",
+                </xsl:for-each>
+                "content": [
+                <xsl:for-each select="channel">
+                    <xsl:call-template name="folderContent"/>
+                </xsl:for-each>
+                ]
+            }<xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+            ],
             "content": [
             <xsl:for-each select="key('regions-by-name', @name)">
-                <xsl:for-each select="*">
+                <xsl:for-each select="channel">
                     <xsl:call-template name="folderContent"/>
                 </xsl:for-each>
                 <xsl:if test="position() != last()">,</xsl:if>


### PR DESCRIPTION
…tures), instead of merely a flat collection of <channel> elements

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This enhancement is required for https://github.com/uPortal-contrib/uPortal-web-components/pull/184.

This change provides support for nested structures within regions (Respondr) in the `/uPortal/api/v4-3/dlm/layout.json` API.  Previously everything except direct `<channel>` element children was discarded by the structure transform.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
