### PR TITLE
fix:  update the PortletsRESTController.getRenderedPortlet method (AP…

### DIFF
--- a/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletFactoryService.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/PortalHttpServletFactoryService.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apereo.portal.user.IUserInstanceManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * This <code>Service</code> bean is responsible for creating and properly initializing instances of
+ * {@link PortalHttpServletRequestWrapper} and {@link PortalHttpServletResponseWrapper}.
+ *
+ * @since 5.4
+ */
+@Service
+public class PortalHttpServletFactoryService {
+
+    @Autowired private IUrlSyntaxProvider urlSyntaxProvider;
+
+    @Autowired private IUserInstanceManager userInstanceManager;
+
+    public RequestAndResponseWrapper createRequestAndResponseWrapper(
+            HttpServletRequest request, HttpServletResponse response) {
+
+        final IPortalRequestInfo portalRequestInfo =
+                urlSyntaxProvider.getPortalRequestInfo(request);
+
+        final UrlType urlType = portalRequestInfo.getUrlType();
+        final UrlState urlState = portalRequestInfo.getUrlState();
+
+        final PortalHttpServletResponseWrapper responseWrapper =
+                new PortalHttpServletResponseWrapper(response);
+        final PortalHttpServletRequestWrapper requestWrapper =
+                new PortalHttpServletRequestWrapper(request, responseWrapper, userInstanceManager);
+
+        requestWrapper.setHeader(IPortalRequestInfo.URL_TYPE_HEADER, urlType.toString());
+        requestWrapper.setHeader(IPortalRequestInfo.URL_STATE_HEADER, urlState.toString());
+
+        // Hack to make PortalController work in light of
+        // https://jira.springsource.org/secure/attachment/18283/SPR7346.patch
+        requestWrapper.setHeader(
+                IPortalRequestInfo.URL_TYPE_HEADER + "." + urlType, Boolean.TRUE.toString());
+        requestWrapper.setHeader(
+                IPortalRequestInfo.URL_STATE_HEADER + "." + urlState, Boolean.TRUE.toString());
+
+        return new RequestAndResponseWrapper(requestWrapper, responseWrapper);
+    }
+
+    /*
+     * Nested Types
+     */
+
+    public static final class RequestAndResponseWrapper {
+
+        final PortalHttpServletRequestWrapper requestWrapper;
+        final PortalHttpServletResponseWrapper responseWrapper;
+
+        /* package-private */ RequestAndResponseWrapper(
+                PortalHttpServletRequestWrapper requestWrapper,
+                PortalHttpServletResponseWrapper responseWrapper) {
+            this.requestWrapper = requestWrapper;
+            this.responseWrapper = responseWrapper;
+        }
+
+        public PortalHttpServletRequestWrapper getRequest() {
+            return requestWrapper;
+        }
+
+        public PortalHttpServletResponseWrapper getResponse() {
+            return responseWrapper;
+        }
+    }
+}

--- a/uPortal-url/src/main/java/org/apereo/portal/url/PortalRequestUtilsImpl.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/PortalRequestUtilsImpl.java
@@ -34,9 +34,6 @@ import org.springframework.web.portlet.context.PortletRequestAttributes;
 @Service("portalRequestUtils")
 public class PortalRequestUtilsImpl implements IPortalRequestUtils {
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.url.IPortalRequestUtils#getOriginalPortalRequest(javax.portlet.PortletRequest)
-     */
     @Override
     public HttpServletRequest getPortletHttpRequest(PortletRequest portletRequest) {
         final HttpServletRequest portalRequest =
@@ -53,9 +50,6 @@ public class PortalRequestUtilsImpl implements IPortalRequestUtils {
                         + "'");
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.url.IPortalRequestUtils#getOriginalPortalRequest(javax.servlet.http.HttpServletRequest)
-     */
     @Override
     public HttpServletRequest getOriginalPortalRequest(HttpServletRequest portletRequest) {
         final HttpServletRequest portalRequest =
@@ -103,7 +97,7 @@ public class PortalRequestUtilsImpl implements IPortalRequestUtils {
         }
 
         throw new IllegalArgumentException(
-                "The orginal portal HttpServletRequest is not available from the WebRequest using attribute '"
+                "The original portal HttpServletRequest is not available from the WebRequest using attribute '"
                         + PortalHttpServletRequestWrapper.ATTRIBUTE__HTTP_SERVLET_REQUEST
                         + "'");
     }
@@ -140,9 +134,6 @@ public class PortalRequestUtilsImpl implements IPortalRequestUtils {
                         + "'");
     }
 
-    /* (non-Javadoc)
-     * @see org.apereo.portal.url.IPortalRequestUtils#getCurrentPortalRequest()
-     */
     @Override
     public HttpServletRequest getCurrentPortalRequest() {
         final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();


### PR DESCRIPTION
…I @RequestMapping '/v4-3/portlet/{fname}.html') so that it prepares the PortalHttpServletRequestWrapper and PortalHttpServletResponseWrapper in the same way that UrlCanonicalizingFilter does (for typical portal requests)

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This change fixes an issue with the `/v4-3/portlet/{fname}.html` API endpoint where some portlets would fail to render because `PortalHttpServletRequestWrapper` and `PortalHttpServletResponseWrapper` objects were not set up (and passed _downstream_ to the rest of the portal) in the manner that `UrlCanonicalizingFilter` does it.

This change also refactors creating and properly initializing instances of these wrapper classes to a new `@Service` bean -- `PortalHttpServletFactoryService` -- so that `UrlCanonicalizingFilter` and `PortletsRESTController` can leverage the same code (DRY principal).

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
