### PR TITLE
feat: add a new REST API ('/v5-5/assignments/users/{username}') to Pe…

### DIFF
--- a/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/layout/dlm/remoting/GroupListHelperImpl.java
+++ b/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/layout/dlm/remoting/GroupListHelperImpl.java
@@ -55,7 +55,7 @@ public class GroupListHelperImpl implements IGroupListHelper {
     @Override
     public Set<JsonEntityBean> search(String entityType, String searchTerm) {
 
-        Set<JsonEntityBean> results = new HashSet<JsonEntityBean>();
+        Set<JsonEntityBean> results = new HashSet<>();
 
         EntityEnum entityEnum = EntityEnum.getEntityEnum(entityType);
         if (entityEnum == null) {

--- a/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/groupselector/EntityEnum.java
+++ b/uPortal-api/uPortal-api-internal/src/main/java/org/apereo/portal/portlets/groupselector/EntityEnum.java
@@ -32,7 +32,7 @@ public enum EntityEnum {
     private String stringValue;
     private boolean isGroup;
 
-    private EntityEnum(Class<?> clazz, String stringValue, boolean isGroup) {
+    EntityEnum(Class<?> clazz, String stringValue, boolean isGroup) {
         this.clazz = clazz;
         this.stringValue = stringValue;
         this.isGroup = isGroup;

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/permissions/PermissionsRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/permissions/PermissionsRESTController.java
@@ -234,7 +234,7 @@ public class PermissionsRESTController {
      */
     @PreAuthorize(
             "hasPermission('ALL', 'java.lang.String', new org.apereo.portal.spring.security.evaluator.AuthorizableActivity('UP_PERMISSIONS', 'VIEW_PERMISSIONS'))")
-    @RequestMapping("/v5-5/assignments/users/{username}")
+    @RequestMapping("/v5-5/permissions/assignments/users/{username}")
     public ModelAndView getAssignmentsForUser(
             @PathVariable("username") String username,
             @RequestParam(value = "includeInherited", required = false, defaultValue = "false")

--- a/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/org/apereo/portal/rest/permissions/PermissionsRESTControllerTest.java
+++ b/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/org/apereo/portal/rest/permissions/PermissionsRESTControllerTest.java
@@ -58,7 +58,7 @@ public class PermissionsRESTControllerTest {
     private MockHttpServletResponse res;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         permissionsRESTController = new PermissionsRESTController();
         permissionOwnerDao = Mockito.mock(JpaPermissionOwnerDao.class);
         req = new MockHttpServletRequest();
@@ -67,18 +67,18 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetOwnersNull() throws Exception {
+    public void testGetOwnersNull() {
         Mockito.when(permissionOwnerDao.getAllPermissionOwners()).thenReturn(null);
-        ModelAndView modelAndView = permissionsRESTController.getOwners(req, res);
+        ModelAndView modelAndView = permissionsRESTController.getOwners();
 
         Assert.assertNull(modelAndView.getModel().get("owners"));
     }
 
     @Test
-    public void testGetOwnersEmpty() throws Exception {
+    public void testGetOwnersEmpty() {
         Mockito.when(permissionOwnerDao.getAllPermissionOwners())
                 .thenReturn(Collections.emptyList());
-        ModelAndView modelAndView = permissionsRESTController.getOwners(req, res);
+        ModelAndView modelAndView = permissionsRESTController.getOwners();
         List<IPermissionOwner> owners =
                 (List<IPermissionOwner>) modelAndView.getModel().get("owners");
 
@@ -86,7 +86,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetOwnersByOwnerParamString() throws Exception {
+    public void testGetOwnersByOwnerParamString() {
         String ownerParam = "test";
         IPermissionOwner owner = Mockito.mock(IPermissionOwner.class);
         owner.setFname("john");
@@ -94,7 +94,7 @@ public class PermissionsRESTControllerTest {
         owner.setName("john doe");
 
         Mockito.when(permissionOwnerDao.getPermissionOwner(ownerParam)).thenReturn(owner);
-        ModelAndView modelAndView = permissionsRESTController.getOwners(ownerParam, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getOwners(ownerParam, res);
         IPermissionOwner returnOwner = (IPermissionOwner) modelAndView.getModel().get("owner");
 
         Assert.assertEquals(owner.getId(), returnOwner.getId());
@@ -102,7 +102,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetOwnersByOwnerParamNumeric() throws Exception {
+    public void testGetOwnersByOwnerParamNumeric() {
         String ownerParam = "123";
 
         IPermissionOwner owner = Mockito.mock(IPermissionOwner.class);
@@ -113,7 +113,7 @@ public class PermissionsRESTControllerTest {
         Mockito.when(permissionOwnerDao.getPermissionOwner(Long.valueOf(ownerParam)))
                 .thenReturn(owner);
 
-        ModelAndView modelAndView = permissionsRESTController.getOwners(ownerParam, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getOwners(ownerParam, res);
 
         IPermissionOwner returnOwner = (IPermissionOwner) modelAndView.getModel().get("owner");
 
@@ -122,12 +122,12 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetActivitiesEmpty() throws Exception {
+    public void testGetActivitiesEmpty() {
         String query = "activity1";
 
         Mockito.when(permissionOwnerDao.getAllPermissionOwners())
                 .thenReturn(Collections.EMPTY_LIST);
-        ModelAndView modelAndView = permissionsRESTController.getActivities(query, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getActivities(query);
         List<IPermissionActivity> activities =
                 (List<IPermissionActivity>) modelAndView.getModel().get("activities");
 
@@ -136,7 +136,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetActivities() throws Exception {
+    public void testGetActivities() {
         String query = "activity1";
         IPermissionOwner owner = Mockito.mock(IPermissionOwner.class);
         owner.setFname("john");
@@ -151,7 +151,7 @@ public class PermissionsRESTControllerTest {
         owners.add(owner);
 
         Mockito.when(permissionOwnerDao.getAllPermissionOwners()).thenReturn(owners);
-        ModelAndView modelAndView = permissionsRESTController.getActivities(query, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getActivities(query);
         List<IPermissionActivity> activities =
                 (List<IPermissionActivity>) modelAndView.getModel().get("activities");
 
@@ -159,7 +159,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetTargetsEmpty() throws Exception {
+    public void testGetTargetsEmpty() {
         Long activityId = 2L;
         String query = "activity1";
 
@@ -175,8 +175,7 @@ public class PermissionsRESTControllerTest {
         Mockito.when(targetProviderRegistry.getTargetProvider(activity.getTargetProviderKey()))
                 .thenReturn(provider);
 
-        ModelAndView modelAndView =
-                permissionsRESTController.getTargets(activityId, query, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getTargets(activityId, query);
         Collection<IPermissionTarget> targets =
                 (Collection<IPermissionTarget>) modelAndView.getModel().get("targets");
 
@@ -186,7 +185,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetTargetsNullActivity() throws Exception {
+    public void testGetTargetsNullActivity() {
         Long activityId = 2L;
         String query = "activity1";
 
@@ -202,15 +201,14 @@ public class PermissionsRESTControllerTest {
         Mockito.when(targetProviderRegistry.getTargetProvider(activity.getTargetProviderKey()))
                 .thenReturn(null);
 
-        ModelAndView modelAndView =
-                permissionsRESTController.getTargets(activityId, query, req, res);
+        ModelAndView modelAndView = permissionsRESTController.getTargets(activityId, query);
         Collection<IPermissionTarget> targets =
                 (Collection<IPermissionTarget>) modelAndView.getModel().get("targets");
         Assert.assertTrue(targets.isEmpty());
     }
 
     @Test(expected = NullPointerException.class)
-    public void testGetgetAssignmentsForPrincipalNullPrincipal() throws Exception {
+    public void testGetgetAssignmentsForPrincipalNullPrincipal() {
         String principal = "principal";
         boolean includeInherited = true;
         JsonEntityBean entity = buildJsonPersonEntityBean();
@@ -220,8 +218,7 @@ public class PermissionsRESTControllerTest {
                                 entity.getId(), entity.getEntityType().getClazz()))
                 .thenReturn(null);
         ModelAndView modelAndView =
-                permissionsRESTController.getAssignmentsForPrincipal(
-                        principal, includeInherited, req, res);
+                permissionsRESTController.getAssignmentsForPrincipal(principal, includeInherited);
         Collection<IPermissionTarget> targets =
                 (Collection<IPermissionTarget>) modelAndView.getModel().get("assignments");
     }
@@ -237,7 +234,7 @@ public class PermissionsRESTControllerTest {
     }
 
     @Test
-    public void testGetgetAssignmentsForTargetNull() throws Exception {
+    public void testGetgetAssignmentsForTargetNull() {
         String target = "target";
         boolean includeInherited = false;
         JsonEntityBean entity = buildJsonPersonEntityBean();
@@ -251,8 +248,7 @@ public class PermissionsRESTControllerTest {
                 .thenReturn(null);
 
         ModelAndView modelAndView =
-                permissionsRESTController.getAssignmentsOnTarget(
-                        target, includeInherited, req, res);
+                permissionsRESTController.getAssignmentsOnTarget(target, includeInherited);
 
         Collection<IPermissionTarget> assignments =
                 (Collection<IPermissionTarget>) modelAndView.getModel().get("assignments");

--- a/uPortal-content/uPortal-content-portlet/src/main/java/org/apereo/portal/portlet/dao/jpa/PortletPreferenceImpl.java
+++ b/uPortal-content/uPortal-content-portlet/src/main/java/org/apereo/portal/portlet/dao/jpa/PortletPreferenceImpl.java
@@ -90,7 +90,7 @@ public class PortletPreferenceImpl implements IPortletPreference, Cloneable {
     @Type(type = "org.hibernate.type.StringType")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Fetch(FetchMode.JOIN)
-    private List<String> values = new ArrayList<String>(0);
+    private List<String> values = new ArrayList<>(0);
 
     @Column(name = "NULL_VALUES", nullable = false)
     private boolean nullValues = true;
@@ -214,7 +214,7 @@ public class PortletPreferenceImpl implements IPortletPreference, Cloneable {
             this.values = null;
             this.nullValues = true;
         } else if (this.values == null) {
-            this.values = new ArrayList<String>(Arrays.asList(values));
+            this.values = new ArrayList<>(Arrays.asList(values));
             this.nullValues = false;
             this.valuesArray = values.clone();
         } else {

--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/services/PortletDefinitionPreferencesImpl.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/services/PortletDefinitionPreferencesImpl.java
@@ -14,12 +14,10 @@
  */
 package org.apereo.portal.portlet.container.services;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import javax.portlet.ValidatorException;
 import org.apache.pluto.container.om.portlet.PortletDefinition;
 import org.apache.pluto.container.om.portlet.Preference;
 import org.apache.pluto.container.om.portlet.Preferences;
@@ -96,7 +94,7 @@ public class PortletDefinitionPreferencesImpl
     }
 
     @Override
-    protected boolean storeInternal() throws IOException, ValidatorException {
+    protected boolean storeInternal() {
 
         return this.transactionOperations.execute(
                 new TransactionCallback<Boolean>() {
@@ -111,8 +109,7 @@ public class PortletDefinitionPreferencesImpl
                         final Collection<IPortletPreference> values =
                                 targetPortletPreferences.values();
                         final boolean modified =
-                                portletDefinition.setPortletPreferences(
-                                        new ArrayList<IPortletPreference>(values));
+                                portletDefinition.setPortletPreferences(new ArrayList<>(values));
                         if (!modified) {
                             // Nothing actually changed, skip the store
                             return Boolean.FALSE;

--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/services/PortletEntityPreferencesImpl.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/services/PortletEntityPreferencesImpl.java
@@ -14,13 +14,11 @@
  */
 package org.apereo.portal.portlet.container.services;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
-import javax.portlet.ValidatorException;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.pluto.container.PortletRequestContext;
 import org.apache.pluto.container.om.portlet.PortletDefinition;
@@ -109,7 +107,7 @@ public class PortletEntityPreferencesImpl extends AbstractPortletPreferencesImpl
     }
 
     @Override
-    protected boolean storeInternal() throws IOException, ValidatorException {
+    protected boolean storeInternal() {
         final HttpServletRequest containerRequest = portletRequestContext.getContainerRequest();
 
         final IPortletEntity portletEntity =
@@ -149,8 +147,7 @@ public class PortletEntityPreferencesImpl extends AbstractPortletPreferencesImpl
                             final Collection<IPortletPreference> values =
                                     targetPortletPreferences.values();
                             final boolean modified =
-                                    portletEntity.setPortletPreferences(
-                                            new ArrayList<IPortletPreference>(values));
+                                    portletEntity.setPortletPreferences(new ArrayList<>(values));
                             if (!modified) {
                                 // Nothing actually changed, skip the store
                                 return Boolean.FALSE;


### PR DESCRIPTION
…rmissionsRESTController that returns permissions assignments based on a username

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This API is a more sensible way for non-uPortal clients to obtain information about uPortal permissions assignments.

The existing API is `/assignments/principal/{principal}.json`, which expects you to know the _principal string_ of the user or group you're interested in.  (A  _principal string_ is a dot-separated concatenation that contains an internal datanase id.)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
