### PR TITLE
chore: renove unused renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,7 @@
   "extends": [
     "config:base",
     ":rebaseStalePrs",
-    ":preserveSemverRanges",
-    ":semanticPrefixChore",
-    ":disableRateLimiting"
+    ":preserveSemverRanges"
   ],
   "gradle": {
     "enabled": true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Rate limiting is no longer needed now that renovate runs on a regular schedule.
`semanticPrefixChore` is a default setting that didn't need to be set.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
