### PR TITLE
#1526 Added the type param to the Search REST API

### DIFF
--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,11 +139,9 @@ public class SearchRESTController {
             HttpServletResponse response)
             throws IOException {
 
+        logger.debug("Searching with q={}, type={}", query, types);
+
         final Map<String, List<?>> searchResults = new TreeMap<>();
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "Searching with q={}, type={}", query, ArrayUtils.toString(types.toArray()));
-        }
 
         for (ISearchStrategy strategy : searchStrategies) {
             if (types == null

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
@@ -143,11 +142,15 @@ public class SearchRESTController {
 
         final Map<String, List<?>> searchResults = new TreeMap<>();
         if (logger.isDebugEnabled()) {
-            logger.debug("Searching with q={}, type={}", query, ArrayUtils.toString(types.toArray()));
+            logger.debug(
+                    "Searching with q={}, type={}", query, ArrayUtils.toString(types.toArray()));
         }
 
         for (ISearchStrategy strategy : searchStrategies) {
-            if(types == null || types.isEmpty() || types.contains("") || types.contains(strategy.getResultTypeName())) {
+            if (types == null
+                    || types.isEmpty()
+                    || types.contains("")
+                    || types.contains(strategy.getResultTypeName())) {
                 searchResults.put(strategy.getResultTypeName(), strategy.search(query, request));
             }
         }

--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/SearchRESTController.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,14 +136,20 @@ public class SearchRESTController {
     @RequestMapping(method = RequestMethod.GET)
     public void search(
             @RequestParam("q") String query,
+            @RequestParam(value = "type", required = false) Set<String> types,
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
         final Map<String, List<?>> searchResults = new TreeMap<>();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Searching with q={}, type={}", query, ArrayUtils.toString(types.toArray()));
+        }
 
         for (ISearchStrategy strategy : searchStrategies) {
-            searchResults.put(strategy.getResultTypeName(), strategy.search(query, request));
+            if(types == null || types.isEmpty() || types.contains("") || types.contains(strategy.getResultTypeName())) {
+                searchResults.put(strategy.getResultTypeName(), strategy.search(query, request));
+            }
         }
 
         if (searchResults.isEmpty()) {

--- a/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/rest/search/SearchRESTControllerTest.java
+++ b/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/rest/search/SearchRESTControllerTest.java
@@ -1,0 +1,188 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.rest.search;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SearchRESTControllerTest {
+    @InjectMocks private SearchRESTController searchRESTController;
+
+    // For the SearchRESTController
+    @Spy private Set<ISearchStrategy> searchStrategies = new HashSet<>();
+
+    @Mock private ISearchStrategy strategy;
+
+    @Mock private HttpServletRequest req;
+
+    private MockHttpServletResponse res;
+
+    private MockMvc mockMvc;
+
+    public SearchRESTControllerTest() {
+    }
+
+    @Before
+    public void setup() throws Exception {
+        res = new MockHttpServletResponse();
+        res.setOutputStreamAccessAllowed(true);
+        MockitoAnnotations.initMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(searchRESTController).build();
+        searchStrategies.add(new ISearchStrategy() {
+            @Override
+            public String getResultTypeName() {
+                return "person";
+            }
+
+            @Override
+            public List<?> search(String query, HttpServletRequest request) {
+                final List<String> someDefinedResults = new ArrayList<>();
+                someDefinedResults.add("test person data");
+                return someDefinedResults;
+            }
+        });
+        searchStrategies.add(new ISearchStrategy() {
+            @Override
+            public String getResultTypeName() {
+                return "portlets";
+            }
+
+            @Override
+            public List<?> search(String query, HttpServletRequest request) {
+                final List<String> someDefinedResults = new ArrayList<>();
+                someDefinedResults.add("test portlets data");
+                return someDefinedResults;
+            }
+        });
+    }
+
+    @Test
+    public void testSearchTypeMultiple() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "portlets,person"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSearchTypeMultipleReversedAndExtra() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "person,portlets,frameworks"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSearchTypeSingle() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "portlets,person"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+
+    @Test
+    public void testSearchTypeRandom() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "a,b,c"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(404, mvcResult.getResponse().getStatus());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+
+    @Test
+    public void testSearchTypeRandomAndEmpty() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "a,b,c,"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSearchTypeNone() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSearchTypeEmpty() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", ""));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSearchQueryNone() {
+        try{
+            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search"));
+            MvcResult mvcResult = resultActions.andReturn();
+            Assert.assertEquals(400, mvcResult.getResponse().getStatus());
+        } catch (Exception e) {
+            Assert.fail("Exception occurred:  " + e.getMessage());
+        }
+    }
+
+}

--- a/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/rest/search/SearchRESTControllerTest.java
+++ b/uPortal-api/uPortal-api-rest/src/test/java/org/apereo/portal/rest/search/SearchRESTControllerTest.java
@@ -18,6 +18,11 @@
  */
 package org.apereo.portal.rest.search;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,12 +36,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public class SearchRESTControllerTest {
     @InjectMocks private SearchRESTController searchRESTController;
@@ -52,8 +51,7 @@ public class SearchRESTControllerTest {
 
     private MockMvc mockMvc;
 
-    public SearchRESTControllerTest() {
-    }
+    public SearchRESTControllerTest() {}
 
     @Before
     public void setup() throws Exception {
@@ -61,41 +59,49 @@ public class SearchRESTControllerTest {
         res.setOutputStreamAccessAllowed(true);
         MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(searchRESTController).build();
-        searchStrategies.add(new ISearchStrategy() {
-            @Override
-            public String getResultTypeName() {
-                return "person";
-            }
+        searchStrategies.add(
+                new ISearchStrategy() {
+                    @Override
+                    public String getResultTypeName() {
+                        return "person";
+                    }
 
-            @Override
-            public List<?> search(String query, HttpServletRequest request) {
-                final List<String> someDefinedResults = new ArrayList<>();
-                someDefinedResults.add("test person data");
-                return someDefinedResults;
-            }
-        });
-        searchStrategies.add(new ISearchStrategy() {
-            @Override
-            public String getResultTypeName() {
-                return "portlets";
-            }
+                    @Override
+                    public List<?> search(String query, HttpServletRequest request) {
+                        final List<String> someDefinedResults = new ArrayList<>();
+                        someDefinedResults.add("test person data");
+                        return someDefinedResults;
+                    }
+                });
+        searchStrategies.add(
+                new ISearchStrategy() {
+                    @Override
+                    public String getResultTypeName() {
+                        return "portlets";
+                    }
 
-            @Override
-            public List<?> search(String query, HttpServletRequest request) {
-                final List<String> someDefinedResults = new ArrayList<>();
-                someDefinedResults.add("test portlets data");
-                return someDefinedResults;
-            }
-        });
+                    @Override
+                    public List<?> search(String query, HttpServletRequest request) {
+                        final List<String> someDefinedResults = new ArrayList<>();
+                        someDefinedResults.add("test portlets data");
+                        return someDefinedResults;
+                    }
+                });
     }
 
     @Test
     public void testSearchTypeMultiple() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "portlets,person"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", "portlets,person"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
@@ -103,11 +109,17 @@ public class SearchRESTControllerTest {
 
     @Test
     public void testSearchTypeMultipleReversedAndExtra() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "person,portlets,frameworks"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", "person,portlets,frameworks"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
@@ -115,21 +127,30 @@ public class SearchRESTControllerTest {
 
     @Test
     public void testSearchTypeSingle() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "portlets,person"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", "portlets,person"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
     }
 
-
     @Test
     public void testSearchTypeRandom() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "a,b,c"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", "a,b,c"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(404, mvcResult.getResponse().getStatus());
         } catch (Exception e) {
@@ -137,14 +158,19 @@ public class SearchRESTControllerTest {
         }
     }
 
-
     @Test
     public void testSearchTypeRandomAndEmpty() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", "a,b,c,"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", "a,b,c,"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
@@ -152,11 +178,15 @@ public class SearchRESTControllerTest {
 
     @Test
     public void testSearchTypeNone() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
@@ -164,11 +194,17 @@ public class SearchRESTControllerTest {
 
     @Test
     public void testSearchTypeEmpty() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search").param("q", "bar").param("type", ""));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(
+                            MockMvcRequestBuilders.get("/v5-0/portal/search")
+                                    .param("q", "bar")
+                                    .param("type", ""));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(200, mvcResult.getResponse().getStatus());
-            Assert.assertEquals("{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}", mvcResult.getResponse().getContentAsString());
+            Assert.assertEquals(
+                    "{\"person\":[\"test person data\"],\"portlets\":[\"test portlets data\"]}",
+                    mvcResult.getResponse().getContentAsString());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
@@ -176,13 +212,13 @@ public class SearchRESTControllerTest {
 
     @Test
     public void testSearchQueryNone() {
-        try{
-            ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search"));
+        try {
+            ResultActions resultActions =
+                    mockMvc.perform(MockMvcRequestBuilders.get("/v5-0/portal/search"));
             MvcResult mvcResult = resultActions.andReturn();
             Assert.assertEquals(400, mvcResult.getResponse().getStatus());
         } catch (Exception e) {
             Assert.fail("Exception occurred:  " + e.getMessage());
         }
     }
-
 }


### PR DESCRIPTION
Resolves #1526.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->
`/api/v5-0/portal/search` can now take an optional `type` parameter that can be a multi-value parameter.  

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
