### PR TITLE
Add an option for a 'Direct URL' to the portlet options menu

### DIFF
--- a/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
+++ b/uPortal-webapp/src/main/java/org/apereo/portal/context/rendering/RenderingPipelineConfiguration.java
@@ -117,6 +117,9 @@ public class RenderingPipelineConfiguration {
 
     @Autowired private XsltPortalUrlProvider xslPortalUrlProvider;
 
+    @Value("${portal.protocol}://${portal.server}")
+    private String portalProtocolAndServer;
+
     @Value("${org.apereo.portal.channels.CLogin.CasLoginUrl}")
     private String casLoginUrl;
 
@@ -423,6 +426,7 @@ public class RenderingPipelineConfiguration {
         final Map<String, Object> parameters = new HashMap<>();
         parameters.put(XsltPortalUrlProvider.XSLT_PORTAL_URL_PROVIDER, xslPortalUrlProvider);
         parameters.put("EXTERNAL_LOGIN_URL", casLoginUrl);
+        parameters.put("PORTAL_PROTOCOL_AND_SERVER", portalProtocolAndServer);
         parameters.put("useTabGroups", useTabGroups);
         parameters.put("UP_VERSION", uPortalVersion);
         parameters.put("USE_FLYOUT_MENUS", useFlyoutMenus);

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
@@ -674,6 +674,14 @@
         </xsl:if>
       </xsl:if>
 
+      <!-- Direct URL Icon -->
+      <xsl:variable name="portletDirectUrl">
+          <xsl:value-of select="$HOST_NAME"/><xsl:value-of select="$CONTEXT_PATH"/>/p/<xsl:value-of select="@fname"/>
+      </xsl:variable>
+      <li class="up-portlet-options-item directUrl">
+          <a title="{upMsg:getMessage('direct.url', $USER_LANG)}" class="up-portlet-control directUrl"  data-toggle="modal" data-target="#direct-url-modal" data-direct-url="{$portletDirectUrl}"><xsl:value-of select="upMsg:getMessage('direct.url', $USER_LANG)"/></a>
+      </li>
+
           <!-- About Icon -->
           <xsl:if test="$hasAbout='true'">
               <xsl:variable name="portletAboutUrl">

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
@@ -676,7 +676,7 @@
 
       <!-- Direct URL Icon -->
       <xsl:variable name="portletDirectUrl">
-          <xsl:value-of select="$HOST_NAME"/><xsl:value-of select="$CONTEXT_PATH"/>/p/<xsl:value-of select="@fname"/>
+          <xsl:value-of select="$PORTAL_PROTOCOL_AND_SERVER"/><xsl:value-of select="$CONTEXT_PATH"/>/p/<xsl:value-of select="@fname"/>
       </xsl:variable>
       <li class="up-portlet-options-item directUrl">
           <a title="{upMsg:getMessage('direct.url', $USER_LANG)}" class="up-portlet-control directUrl"  data-toggle="modal" data-target="#direct-url-modal" data-direct-url="{$portletDirectUrl}"><xsl:value-of select="upMsg:getMessage('direct.url', $USER_LANG)"/></a>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -393,6 +393,36 @@
                 </div>
             </div>
         </div>
+        <div id='direct-url-modal' class="modal fade">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only"><xsl:value-of select="upMsg:getMessage('close', $USER_LANG)"/></span></button>
+                        <h4 class="modal-title"><xsl:value-of select="upMsg:getMessage('direct.url', $USER_LANG)"/></h4>
+                    </div>
+                    <div class="modal-body">
+                        <form>
+                            <div class="form-group">
+                                <input type="text" class="form-control" id="direct-url-display"/>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal"><xsl:value-of select="upMsg:getMessage('close', $USER_LANG)"/></button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            up.jQuery(document).ready(function() {
+            var $ = up.jQuery;
+            $('#direct-url-modal').on('show.bs.modal', function (event) {
+            var widget = $(event.relatedTarget) // Widget that triggered the modal
+            var dUrl = widget.data('direct-url') // Extract info from data-* attributes
+            $('#direct-url-display').val(dUrl);
+            })
+            });
+        </script>
     </xsl:template>
 
 

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -414,13 +414,13 @@
             </div>
         </div>
         <script type="text/javascript">
-            up.jQuery(document).ready(function() {
-            var $ = up.jQuery;
-            $('#direct-url-modal').on('show.bs.modal', function (event) {
-            var widget = $(event.relatedTarget) // Widget that triggered the modal
-            var dUrl = widget.data('direct-url') // Extract info from data-* attributes
-            $('#direct-url-display').val(dUrl);
-            })
+            up.jQuery(function() {
+                var $ = up.jQuery;
+                $('#direct-url-modal').on('show.bs.modal', function (event) {
+                    var widget = $(event.relatedTarget); // Widget that triggered the modal
+                    var dUrl = widget.data('direct-url'); // Extract info from data-* attributes
+                    $('#direct-url-display').val(dUrl);
+                });
             });
         </script>
     </xsl:template>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -175,6 +175,7 @@
  | Portal Settings should generally not be (and not need to be) modified.
  -->
 <xsl:param name="AUTHENTICATED" select="'false'"/>
+<xsl:param name="PORTAL_PROTOCOL_AND_SERVER"></xsl:param>
 <xsl:param name="HOST_NAME"></xsl:param>
 <xsl:param name="USER_ID">guest</xsl:param>
 <xsl:param name="userName">Guest User</xsl:param>

--- a/uPortal-webapp/src/main/resources/properties/i18n/Messages.properties
+++ b/uPortal-webapp/src/main/resources/properties/i18n/Messages.properties
@@ -172,6 +172,7 @@ deny=Deny
 description=Description
 deselect=De-select
 directory=Directory
+direct.url=Direct URL
 disable.dynamic.title=Disable Dynamic Title
 disable.portlet.events=Disable Portlet Events
 disk.store.object.count=Disk store object count


### PR DESCRIPTION
Resolves #1592 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
'Direct URL' option added to the 'Options' menu for a given portlet.

The option will launch a simple modal dialog with the link to the portal.

In the options menu:
![image](https://user-images.githubusercontent.com/28629296/54060748-7cd0d600-41c3-11e9-95f7-89e41c0fb21e.png)

Modal dialog:
![image](https://user-images.githubusercontent.com/28629296/54060989-7f7ffb00-41c4-11e9-8d14-89f97d714fd7.png)

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
