### PR TITLE
fix: prevent an uncommon but difficult to troubleshoot error when the…

### DIFF
--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/dlm/RDBMDistributedLayoutStore.java
@@ -1557,6 +1557,8 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                     this.portletDefinitionRegistry.getPortletDefinition(
                             String.valueOf(ls.getChanId()));
             if (channelDef != null
+                    && channelDef.getLifecycleState()
+                            != null // Unusual, but lifecycle state may apparently be null
                     && channelDef
                             .getLifecycleState()
                             .isEqualToOrAfter(PortletLifecycleState.APPROVED)) {


### PR DESCRIPTION
… lifecycle state of a portlet is null

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

It's not common (and certainly not recommended), but apparently the `lifecycleState` of a portlet can be `null` in some circumstances.  When such a portlet is included in a fragment layout, that fragment becomes unusable.

First you get...

```
ERROR [http-nio-8080-exec-3-10716429] o.a.p.layout.dlm.FragmentActivator 2019-04-02 15:42:05,057 - Anomaly occurred while loading layout for fragment 'All'. The fragment will not be available for inclusion into user layouts.
java.lang.NullPointerException: null
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore.getStructure(RDBMDistributedLayoutStore.java:1562)
	at org.apereo.portal.layout.simple.RDBMUserLayoutStore.createLayout(RDBMUserLayoutStore.java:320)
	at org.apereo.portal.layout.simple.RDBMUserLayoutStore.createLayout(RDBMUserLayoutStore.java:328)
	at org.apereo.portal.layout.simple.RDBMUserLayoutStore.createLayout(RDBMUserLayoutStore.java:328)
	at org.apereo.portal.layout.simple.RDBMUserLayoutStore.lambda$getPersonalUserLayout$4(RDBMUserLayoutStore.java:862)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:353)
	at org.apereo.portal.layout.simple.RDBMUserLayoutStore.getPersonalUserLayout(RDBMUserLayoutStore.java:412)
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore._safeGetUserLayout(RDBMDistributedLayoutStore.java:1212)
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore.getFragmentLayout(RDBMDistributedLayoutStore.java:1365)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[...]
```

and then you get...

```
ERROR [http-nio-8080-exec-3] o.a.p.web.ExceptionLoggingFilter 2019-04-02 15:42:05,106 - uPortal: unhandled exception 'Request processing failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'userLayoutManager' defined in file [/portal/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/layoutContext.xml]: Invocation of init method failed; nested exception is org.apereo.portal.PortalException: Exception encountered while reading a layout for userId=19, profileId=60' for URL=/uPortal/Login, user=null , from IP=127.0.0.1
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'userLayoutManager' defined in file [/portal/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/layoutContext.xml]: Invocation of init method failed; nested exception is org.apereo.portal.PortalException: Exception encountered while reading a layout for userId=19, profileId=60
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:982)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:861)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:635)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.portal.utils.web.RemoteCookieCheckFilter.doFilter(RemoteCookieCheckFilter.java:80)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:317)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.invoke(FilterSecurityInterceptor.java:127)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.doFilter(FilterSecurityInterceptor.java:91)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:114)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:137)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:111)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:170)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.www.BasicAuthenticationFilter.doFilterInternal(BasicAuthenticationFilter.java:158)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter.doFilter(DefaultLoginPageGeneratingFilter.java:177)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:200)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.apereo.portal.spring.security.preauth.PortalPreAuthenticatedProcessingFilter.doFilter(PortalPreAuthenticatedProcessingFilter.java:192)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:116)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.csrf.CsrfFilter.doFilterInternal(CsrfFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:66)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:56)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105)
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:214)
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:177)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.jasig.cas.client.util.AssertionThreadLocalFilter.doFilter(AssertionThreadLocalFilter.java:50)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.jasig.cas.client.validation.AbstractTicketValidationFilter.doFilter(AbstractTicketValidationFilter.java:236)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.portal.security.firewall.RequestParameterPolicyEnforcementFilter.doFilter(RequestParameterPolicyEnforcementFilter.java:234)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.services.persondir.support.web.RequestAttributeSourceFilter.doFilter(RequestAttributeSourceFilter.java:357)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.portal.security.ThreadNamingRequestFilter.doFilterInternal(ThreadNamingRequestFilter.java:66)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter.doFilterInternal(OpenEntityManagerInViewFilter.java:178)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.portal.web.ExceptionLoggingFilter.doFilter(ExceptionLoggingFilter.java:47)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.jasig.cas.client.authentication.AuthenticationFilter.doFilter(AuthenticationFilter.java:168)
	at org.apereo.portal.spring.web.OptionalFilterDecorator.doFilter(OptionalFilterDecorator.java:58)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apereo.portal.security.filter.CorsFilter.handleNonCORS(CorsFilter.java:440)
	at org.apereo.portal.security.filter.CorsFilter.doFilter(CorsFilter.java:163)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:197)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:496)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:650)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:803)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1468)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'userLayoutManager' defined in file [/portal/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/layoutContext.xml]: Invocation of init method failed; nested exception is org.apereo.portal.PortalException: Exception encountered while reading a layout for userId=19, profileId=60
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1631)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:553)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:331)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:207)
	at org.apereo.portal.layout.UserLayoutManagerFactory.getUserLayoutManager(UserLayoutManagerFactory.java:48)
	at org.apereo.portal.user.UserInstanceManagerImpl.getUserInstance(UserInstanceManagerImpl.java:152)
	at org.apereo.portal.url.UrlNodeSyntaxHelperRegistryImpl.getCurrentUrlNodeSyntaxHelper(UrlNodeSyntaxHelperRegistryImpl.java:70)
	at org.apereo.portal.url.PortalUrlProviderImpl.getDefaultUrl(PortalUrlProviderImpl.java:97)
	at org.apereo.portal.security.mvc.LoginController.service(LoginController.java:98)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.web.bind.annotation.support.HandlerMethodInvoker.invokeHandlerMethod(HandlerMethodInvoker.java:181)
	at org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter.invokeHandlerMethod(AnnotationMethodHandlerAdapter.java:440)
	at org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter.handle(AnnotationMethodHandlerAdapter.java:428)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:967)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:901)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970)
	... 118 common frames omitted
Caused by: org.apereo.portal.PortalException: Exception encountered while reading a layout for userId=19, profileId=60
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.loadUserLayout(DistributedLayoutManager.java:310)
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.loadUserLayout(DistributedLayoutManager.java:291)
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.afterPropertiesSet(DistributedLayoutManager.java:163)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1689)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1627)
	... 137 common frames omitted
Caused by: java.lang.NullPointerException: null
	at org.apereo.portal.layout.dlm.ILFBuilder.mergeFragment(ILFBuilder.java:96)
	at org.apereo.portal.layout.dlm.ILFBuilder.constructILF(ILFBuilder.java:81)
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore.createCompositeILF(RDBMDistributedLayoutStore.java:1322)
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore._getUserLayout(RDBMDistributedLayoutStore.java:1282)
	at org.apereo.portal.layout.dlm.RDBMDistributedLayoutStore.getUserLayout(RDBMDistributedLayoutStore.java:340)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:207)
	at com.sun.proxy.$Proxy320.getUserLayout(Unknown Source)
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.getDistributedUserLayout(DistributedLayoutManager.java:212)
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.getUserLayoutDOM(DistributedLayoutManager.java:201)
	at org.apereo.portal.layout.dlm.DistributedLayoutManager.loadUserLayout(DistributedLayoutManager.java:303)
	... 141 common frames omitted
```

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
