### PR TITLE
fix(search): in a recent minor version a 'type' parameter was added t…

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
@@ -113,6 +113,9 @@
 <%-- API URL for fetching search results --%>
 <c:url value="/api/v5-0/portal/search" var="searchApiUrl">
     <c:param name="q" value="${param.query}" />
+    <c:forEach items="${renderRequest.preferences.map['RESTSearch.type']}" var="value">
+        <c:param name="type" value="${value}" />
+    </c:forEach>
 </c:url>
 
 <%--

--- a/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -704,6 +704,11 @@
                 <name>RESTSearch</name>
                 <value>true</value>
             </preference>
+            <!-- Optional.  In the REST Search UI, this preference controls which type(s) (search strategies)
+                 will appear in the results.  If empty, all available types will be shown. -->
+            <preference>
+                <name>RESTSearch.type</name>
+            </preference>
             <!-- Max number of characters returned for title or description for auto-complete search results.
                  92 found to be a good fit for keeping most description text at 2 lines. -->
             <preference>


### PR DESCRIPTION
…o the SearchRESTController, but the parameter was omitted from the searchRest.jsp;  this change fixes that omission

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->

This fix properly allows the `searchRest.jsp` to use the `type` parameter that was recently added to the `SearchRESTController`.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
