### PR TITLE
fix(CORS): add 'Authorization' to the default value(s) for cors.allowed.headers because of our recent changes to support two-legged OAuth

### DIFF
--- a/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/security/filter/CorsFilter.java
+++ b/uPortal-security/uPortal-security-mvc/src/main/java/org/apereo/portal/security/filter/CorsFilter.java
@@ -74,7 +74,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CorsFilter implements Filter {
 
-    private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(CorsFilter.class);
 
     /** {@link FilterConfig} reference to {@code init()} parameter. */

--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -105,7 +105,7 @@
         <!-- allowedOrigins should include protocol. For example, "https://idp.myschool.edu, https://cas.myschool.edu" -->
         <property name="allowedOrigins" value="${cors.allowed.origins:}" />
         <property name="allowedHttpMethods" value="${cors.allowed.methods:GET,HEAD}" />
-        <property name="allowedHttpHeaders" value="${cors.allowed.headers:Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers}" />
+        <property name="allowedHttpHeaders" value="${cors.allowed.headers:Origin,Accept,Authorization,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers}" />
         <property name="exposedHeaders" value="${cors.exposed.headers:}" />
         <property name="supportsCredentials" value="${cors.support.credentials:true}" />
         <property name="preflightMaxAge" value="${cors.preflight.maxage:1800}" />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Recent changes we have made to support to-legged OAuth are breaking CORS support (default config) because `Authorization` is missing from `cors.allowed.headers`.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
