### PR TITLE
fix: moved portlet options outside the portlet title

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
@@ -360,10 +360,10 @@
           </xsl:choose>
           <xsl:value-of select="@title"/>
         </xsl:element>
-        <xsl:call-template name="controls">
-          <xsl:with-param name="STYLE">standard</xsl:with-param>
-        </xsl:call-template>
       </h2>
+      <xsl:call-template name="controls">
+        <xsl:with-param name="STYLE">standard</xsl:with-param>
+      </xsl:call-template>
     </div>
   </xsl:template>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

In a recent accessibility test, it was noted that "Options" and "Rate this portlet" can't both be level 2. So this patch moves the options out of the portlet title (`<h2>`) which was accepted by our Accessible Technology group.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
