### PR TITLE
fix(startup): fix a race condition with XmlUtilitiesImpl that has become a problem lately

### DIFF
--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/xml/XmlUtilitiesImpl.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/xml/XmlUtilitiesImpl.java
@@ -82,7 +82,7 @@ public class XmlUtilitiesImpl implements XmlUtilities {
     @Override
     public Templates getTemplates(Resource stylesheet)
             throws TransformerConfigurationException, IOException {
-        final CachedResource<Templates> templates = this.getStylesheetCachedResource(stylesheet);
+        final CachedResource<Templates> templates = getStylesheetCachedResource(stylesheet);
         return templates.getCachedResource();
     }
 
@@ -216,7 +216,7 @@ public class XmlUtilitiesImpl implements XmlUtilities {
 
     private CachedResource<Templates> getStylesheetCachedResource(Resource stylesheet)
             throws IOException {
-        return this.cachingResourceLoader.getResource(stylesheet, this.templatesBuilder);
+        return cachingResourceLoader.getResource(stylesheet, templatesBuilder);
     }
 
     public static String getElementText(Element e) {

--- a/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/BaseXsltDataUpgraderTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/BaseXsltDataUpgraderTest.java
@@ -82,7 +82,6 @@ public abstract class BaseXsltDataUpgraderTest {
         xsltDataUpgrader.setPortalDataKey(dataKey);
         xsltDataUpgrader.setXslResource(xslResource);
         xsltDataUpgrader.setXmlUtilities(xmlUtilities);
-        xsltDataUpgrader.afterPropertiesSet();
 
         // Create XmlEventReader (what the JaxbPortalDataHandlerService has)
         final XMLInputFactory xmlInputFactory = xmlUtilities.getXmlInputFactory();

--- a/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerServiceTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/JaxbPortalDataHandlerServiceTest.java
@@ -348,7 +348,6 @@ public class JaxbPortalDataHandlerServiceTest {
         xsltDataUpgrader.setPortalDataKey(dataKey);
         xsltDataUpgrader.setXslResource(xslResource);
         xsltDataUpgrader.setXmlUtilities(xmlUtilities);
-        xsltDataUpgrader.afterPropertiesSet();
 
         return xsltDataUpgrader;
     }


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Recently an intermittent issue with the order in which Spring application context components are bootstrapped has become a very common problem.  When the issue occurs, the application context fails to start.

### Stack Trace

```
[ant:java] Exception in thread "main" org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.scheduling.support.ScheduledMethodRunnable#3': Cannot resolve reference to bean 'portalSearchIndexer' while setting constructor argument; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalSearchIndexer': Unsatisfied dependency expressed through field 'portletRegistry'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletDefinitionRegistry': Unsatisfied dependency expressed through method 'setPortalDriverContainerServices' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDriverServices': Unsatisfied dependency expressed through method 'setEventCoordinationService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'eventCoordinationService': Unsatisfied dependency expressed through method 'setXmlUtilities' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:359)
[ant:java] 	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:108)
[ant:java] 	at org.springframework.beans.factory.support.ConstructorResolver.resolveConstructorArguments(ConstructorResolver.java:634)
[ant:java] 	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:145)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1197)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1099)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:511)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:756)
[ant:java] 	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:867)
[ant:java] 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:542)
[ant:java] 	at org.apereo.portal.utils.PortalApplicationContextLocator$PortalApplicationContextCreator.createSingleton(PortalApplicationContextLocator.java:231)
[ant:java] 	at org.apereo.portal.utils.PortalApplicationContextLocator$PortalApplicationContextCreator.createSingleton(PortalApplicationContextLocator.java:205)
[ant:java] 	at org.apereo.portal.utils.threading.SingletonDoubleCheckedCreator.create(SingletonDoubleCheckedCreator.java:46)
[ant:java] 	at org.apereo.portal.utils.threading.DoubleCheckedCreator.get(DoubleCheckedCreator.java:124)
[ant:java] 	at org.apereo.portal.utils.PortalApplicationContextLocator.getApplicationContext(PortalApplicationContextLocator.java:176)
[ant:java] 	at org.apereo.portal.shell.PortalShell.main(PortalShell.java:67)
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalSearchIndexer': Unsatisfied dependency expressed through field 'portletRegistry'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletDefinitionRegistry': Unsatisfied dependency expressed through method 'setPortalDriverContainerServices' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDriverServices': Unsatisfied dependency expressed through method 'setEventCoordinationService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'eventCoordinationService': Unsatisfied dependency expressed through method 'setXmlUtilities' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:586)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
[ant:java] 	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:351)
[ant:java] 	... 20 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletDefinitionRegistry': Unsatisfied dependency expressed through method 'setPortalDriverContainerServices' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDriverServices': Unsatisfied dependency expressed through method 'setEventCoordinationService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'eventCoordinationService': Unsatisfied dependency expressed through method 'setXmlUtilities' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:583)
[ant:java] 	... 30 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDriverServices': Unsatisfied dependency expressed through method 'setEventCoordinationService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'eventCoordinationService': Unsatisfied dependency expressed through method 'setXmlUtilities' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 43 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'eventCoordinationService': Unsatisfied dependency expressed through method 'setXmlUtilities' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 56 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xmlUtilitiesImpl': Unsatisfied dependency expressed through method 'setCachingResourceLoader' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 69 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cachingResourceLoaderImpl': Unsatisfied dependency expressed through method 'setResourcesElementsProvider' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 82 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'renderingPipelineConfiguration': Unsatisfied dependency expressed through field 'xslPortalUrlProvider'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:586)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
[ant:java] 	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:372)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1177)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1072)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:511)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 95 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xslPortalUrlProvider': Unsatisfied dependency expressed through method 'setPortletWindowRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:583)
[ant:java] 	... 117 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletWindowRegistryImpl': Unsatisfied dependency expressed through method 'setPortletEntityRegistry' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 130 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portletEntityRegistryImpl': Unsatisfied dependency expressed through method 'setUserInstanceManager' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 143 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userInstanceManager': Unsatisfied dependency expressed through method 'setUserLayoutStore' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 156 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'userLayoutStore': Unsatisfied dependency expressed through method 'setPortalDataHandlerService' parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 169 more
[ant:java] Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'portalDataHandlerService': Unsatisfied dependency expressed through method 'setDataUpgraders' parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:664)
[ant:java] 	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:87)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:364)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1268)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 182 more
[ant:java] Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'user26_32DataUpgrader' defined in file [/home/drew/Projects/Apereo/portal/uPortal-start/.gradle/tomcat/webapps/uPortal/WEB-INF/classes/properties/contexts/importExportContext.xml]: Invocation of init method failed; nested exception is java.lang.NullPointerException
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1630)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:553)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
[ant:java] 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
[ant:java] 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
[ant:java] 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:208)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.addCandidateEntry(DefaultListableBeanFactory.java:1309)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.findAutowireCandidates(DefaultListableBeanFactory.java:1275)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveMultipleBeans(DefaultListableBeanFactory.java:1173)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1089)
[ant:java] 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059)
[ant:java] 	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:656)
[ant:java] 	... 195 more
[ant:java] Caused by: java.lang.NullPointerException
[ant:java] 	at org.apereo.portal.xml.XmlUtilitiesImpl.getStylesheetCachedResource(XmlUtilitiesImpl.java:219)
[ant:java] 	at org.apereo.portal.xml.XmlUtilitiesImpl.getTemplates(XmlUtilitiesImpl.java:85)
[ant:java] 	at org.apereo.portal.io.xml.XsltDataUpgrader.afterPropertiesSet(XsltDataUpgrader.java:58)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1688)
[ant:java] 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1626)
[ant:java] 	... 208 more
```

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
