### PR TITLE
test: replace findbugs with spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,9 +72,18 @@ allprojects {
     /*======== Static Analysis ========*/
     spotbugs {
         toolVersion = '4.1.1'
+        // allow build to continue to other sub projects
+        ignoreFailures = true
     }
     tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
         enabled = gradle.startParameter.taskNames.contains(it.name)
+        reports {
+            html {
+                enabled = true
+                destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
+                stylesheet = 'fancy-hist.xsl'
+            }
+        }
     }
     googleJavaFormat {
         toolVersion '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'nebula.lint' version '16.17.0' apply false
     id 'net.ltgt.errorprone' version '1.3.0' apply false
+    id 'com.github.spotbugs' version '4.6.0' apply false
 }
 
 description = "Apereo uPortal $version"
@@ -31,6 +32,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'eclipse'
+    apply plugin: 'com.github.spotbugs'
     apply plugin: 'idea'
     apply plugin: 'nebula.lint'
     apply plugin: 'groovy'
@@ -68,6 +70,12 @@ allprojects {
     ]
 
     /*======== Static Analysis ========*/
+    spotbugs {
+        toolVersion = '4.1.1'
+    }
+    tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
+        enabled = gradle.startParameter.taskNames.contains(it.name)
+    }
     googleJavaFormat {
         toolVersion '1.7'
         options style: 'AOSP'
@@ -104,6 +112,7 @@ subprojects {
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
         testCompile "org.springframework:spring-test:${springVersion}"
         testCompile "org.xmlunit:xmlunit-legacy:${xmlunitVersion}"
+        spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0'
     }
 
     /* Release Management


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->

Findbugs is not longer being actively maintained.
Spotbugs is Findbug's successor.
With 400 possible error types it can identify https://spotbugs.github.io
Plus with Spot Security Bugs an additional 130 possible security issues types can be automatically scanned https://find-sec-bugs.github.io/

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
