### PR TITLE
fix(portletConfig.jsp): Turn off escaping XML on action url to fix &am…

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/edit-portlet/portletConfig.jsp
@@ -26,7 +26,7 @@
 <c:set var="n"><portlet:namespace/></c:set>
 
 <!-- START: VALUES BEING PASSED FROM BACKEND -->
-<portlet:actionURL var="queryUrl">
+<portlet:actionURL var="queryUrl" escapeXml="false">
     <portlet:param name="execution" value="${flowExecutionKey}"/>
 </portlet:actionURL>
 <!-- END: VALUES BEING PASSED FROM BACKEND -->


### PR DESCRIPTION
…p; breaking url.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Client reporting that changing lifecycle of portlet in Portlet Administration portlet fails. Issue was that the `&` character that separates parameters was escaped. This caused the flow key to be lost.

Fix is to not escape the generated action URL which does not depend on user/external data. All parameters are system generated. 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
