### PR TITLE
#1745 - rolling back the change to make the parameter maps read-only

### DIFF
--- a/uPortal-url/src/main/java/org/apereo/portal/url/AbstractUrlBuilder.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/AbstractUrlBuilder.java
@@ -16,7 +16,6 @@ package org.apereo.portal.url;
 
 import com.google.common.collect.ObjectArrays;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,7 @@ public abstract class AbstractUrlBuilder implements IUrlBuilder {
 
     @Override
     public final Map<String, String[]> getParameters() {
-        return Collections.unmodifiableMap(this.parameters);
+        return this.parameters;
     }
 
     @Override

--- a/uPortal-url/src/main/java/org/apereo/portal/url/PortletUrlBuilder.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/PortletUrlBuilder.java
@@ -15,7 +15,6 @@
 package org.apereo.portal.url;
 
 import com.google.common.base.Preconditions;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.portlet.PortletMode;
@@ -164,7 +163,7 @@ class PortletUrlBuilder extends AbstractUrlBuilder implements IPortletUrlBuilder
 
     @Override
     public Map<String, String[]> getPublicRenderParameters() {
-        return Collections.unmodifiableMap(this.publicRenderParameters);
+        return this.publicRenderParameters;
     }
 
     @Override


### PR DESCRIPTION
##### Checklist
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
The portal was failing to render portlet contents due to #1745.  Allowing the parameter maps to be read-write resolved the issue (rolled back https://github.com/Jasig/uPortal/commit/59fe015a9ea32661000543977a8cd424ddba5065 )


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
