### PR TITLE
feat(props): Add support to overwrite properties based on a UP_CLUSTE…

### DIFF
--- a/uPortal-spring/build.gradle
+++ b/uPortal-spring/build.gradle
@@ -20,4 +20,6 @@ dependencies {
 
     testCompile "${portletApiDependency}"
     testCompile "${servletApiDependency}"
-}
+
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"}

--- a/uPortal-spring/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
+++ b/uPortal-spring/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
@@ -17,11 +17,12 @@ package org.springframework.context.support;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.properties.EncryptableProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -44,14 +45,15 @@ import org.springframework.util.CollectionUtils;
  *   <li>Provide support for encrypted property values based on Jasypt
  * </ul>
  */
+@Slf4j
 public class PortalPropertySourcesPlaceholderConfigurer
         extends PropertySourcesPlaceholderConfigurer {
 
     public static final String EXTENDED_PROPERTIES_SOURCE = "extendedPropertiesSource";
     public static final String JAYSYPT_ENCRYPTION_KEY_VARIABLE = "UP_JASYPT_KEY";
+    public static final String CLUSTER_PREFIX_VARIABLE = "UP_CLUSTER";
 
     private PropertyResolver propertyResolver;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public PortalPropertySourcesPlaceholderConfigurer() {
         /*
@@ -86,7 +88,7 @@ public class PortalPropertySourcesPlaceholderConfigurer
                 list.add(r);
             } else {
                 // In our case this event is worth a DEBUG note.
-                logger.debug(
+                log.debug(
                         "The following Resource was not present (it may be "
                                 + "optional, or it's absence may lead to issues):  ",
                         r);
@@ -157,7 +159,7 @@ public class PortalPropertySourcesPlaceholderConfigurer
         final String encryptionKey = System.getenv(JAYSYPT_ENCRYPTION_KEY_VARIABLE);
         if (encryptionKey != null) {
 
-            logger.info("Jasypt support for encrypted property values ENABLED");
+            log.info("Jasypt support for encrypted property values ENABLED");
 
             StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
             encryptor.setPassword(encryptionKey);
@@ -189,7 +191,7 @@ public class PortalPropertySourcesPlaceholderConfigurer
 
         } else {
 
-            logger.info(
+            log.info(
                     "Jasypt support for encrypted property values DISABLED;  "
                             + "specify environment variable {} to use this feature",
                     JAYSYPT_ENCRYPTION_KEY_VARIABLE);
@@ -198,9 +200,38 @@ public class PortalPropertySourcesPlaceholderConfigurer
              * The feature is not in use;  defer to the Spring-provided
              * implementation of this method.
              */
-            return super.mergeProperties();
+            rslt = super.mergeProperties();
         }
 
+        honorClusterOverrides(rslt);
         return rslt;
+    }
+
+    public static void honorClusterOverrides(Properties properties) {
+        final String cluster = System.getenv(CLUSTER_PREFIX_VARIABLE);
+        honorClusterOverrides(cluster, properties);
+    }
+
+    // This class is mainly here because JUnit/Mockito/PowerMock cannot mock System.class
+    public static void honorClusterOverrides(String cluster, Properties properties) {
+        assert (properties != null);
+
+        if (cluster != null && cluster.length() > 0) {
+            log.info("Cluster prefix filtering for {}", cluster);
+            final String clusterPrefix = cluster + ".";
+            final Map<String, Object> clusterEntries =
+                    properties.entrySet().stream()
+                            .filter(e -> e.getKey().toString().startsWith(clusterPrefix))
+                            .collect(
+                                    Collectors.toMap(
+                                            e ->
+                                                    e.getKey()
+                                                            .toString()
+                                                            .substring(clusterPrefix.length()),
+                                            e -> e.getValue()));
+            final Properties clusterProps = new Properties();
+            clusterProps.putAll(clusterEntries);
+            CollectionUtils.mergePropertiesIntoMap(clusterProps, properties);
+        }
     }
 }

--- a/uPortal-spring/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
+++ b/uPortal-spring/src/main/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurer.java
@@ -51,7 +51,8 @@ public class PortalPropertySourcesPlaceholderConfigurer
 
     public static final String EXTENDED_PROPERTIES_SOURCE = "extendedPropertiesSource";
     public static final String JAYSYPT_ENCRYPTION_KEY_VARIABLE = "UP_JASYPT_KEY";
-    public static final String CLUSTER_PREFIX_VARIABLE = "UP_CLUSTER";
+    public static final String CLUSTER_ENV_VARIABLE = "UP_CLUSTER";
+    public static final String CLUSTER_JVM_VARIABLE = "cluster";
 
     private PropertyResolver propertyResolver;
 
@@ -208,7 +209,10 @@ public class PortalPropertySourcesPlaceholderConfigurer
     }
 
     public static void honorClusterOverrides(Properties properties) {
-        final String cluster = System.getenv(CLUSTER_PREFIX_VARIABLE);
+        String cluster = System.getenv(CLUSTER_ENV_VARIABLE);
+        if (cluster == null || cluster.length() == 0) {
+            cluster = System.getProperty(CLUSTER_JVM_VARIABLE, "");
+        }
         honorClusterOverrides(cluster, properties);
     }
 

--- a/uPortal-spring/src/test/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurerTest.java
+++ b/uPortal-spring/src/test/java/org/springframework/context/support/PortalPropertySourcesPlaceholderConfigurerTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.context.support;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PortalPropertySourcesPlaceholderConfigurerTest {
+
+    PortalPropertySourcesPlaceholderConfigurer propConfig =
+            new PortalPropertySourcesPlaceholderConfigurer();
+    Properties props = new Properties();
+
+    @Before
+    public void init() {
+        props.clear();
+        props.setProperty("dev.url", "https://github.com/");
+        props.setProperty("dev.user", "bjagg");
+        props.setProperty("doc.url", "https://github.io/");
+        props.setProperty("doc.user", "jhelwig");
+        props.setProperty("user", "jwick");
+    }
+
+    @Test
+    public void testNoEnvVar() {
+        propConfig.honorClusterOverrides("", props);
+        assertEquals("props has same size", 5, props.size());
+        assertEquals(
+                "dev.url is still https://github.com/",
+                "https://github.com/",
+                props.getProperty("dev.url"));
+        assertEquals(
+                "dev.user is still https://github.com/", "bjagg", props.getProperty("dev.user"));
+        assertEquals(
+                "doc.url is still https://github.com/",
+                "https://github.io/",
+                props.getProperty("doc.url"));
+        assertEquals(
+                "doc.user is still https://github.com/", "jhelwig", props.getProperty("doc.user"));
+        assertEquals("user is still https://github.com/", "jwick", props.getProperty("user"));
+    }
+
+    @Test
+    public void testDev() {
+        propConfig.honorClusterOverrides("dev", props);
+        assertEquals("props has same size", 6, props.size());
+        assertEquals(
+                "dev.url is still https://github.com/",
+                "https://github.com/",
+                props.getProperty("dev.url"));
+        assertEquals(
+                "dev.user is still https://github.com/", "bjagg", props.getProperty("dev.user"));
+        assertEquals(
+                "doc.url is still https://github.com/",
+                "https://github.io/",
+                props.getProperty("doc.url"));
+        assertEquals(
+                "doc.user is still https://github.com/", "jhelwig", props.getProperty("doc.user"));
+        assertEquals(
+                "url is now https://github.com/", "https://github.com/", props.getProperty("url"));
+        assertEquals("user is now https://github.com/", "bjagg", props.getProperty("user"));
+    }
+
+    @Test
+    public void testDoc() {
+        propConfig.honorClusterOverrides("doc", props);
+        assertEquals("props has same size", 6, props.size());
+        assertEquals(
+                "dev.url is still https://github.com/",
+                "https://github.com/",
+                props.getProperty("dev.url"));
+        assertEquals(
+                "dev.user is still https://github.com/", "bjagg", props.getProperty("dev.user"));
+        assertEquals(
+                "doc.url is still https://github.com/",
+                "https://github.io/",
+                props.getProperty("doc.url"));
+        assertEquals(
+                "doc.user is still https://github.com/", "jhelwig", props.getProperty("doc.user"));
+        assertEquals(
+                "url is now https://github.com/", "https://github.io/", props.getProperty("url"));
+        assertEquals("user is now https://github.com/", "jhelwig", props.getProperty("user"));
+    }
+}


### PR DESCRIPTION
…R env property

Resolves #1747

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [X] tests are included
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Client wished to place all properties in a single set of properties files that would work in test, and prod. To support this, a system environment variable `UP_CLUSTER` can be set. If properties are found that start with that value plus `.`, then those key/value pairs will be added back, overwriting existing values, without the prefix.

For example if `UP_CLUSTER=prod` is set in the System environment, an initial properties set of:

```
url=www.github.com
dev.url=github.com
prod.url=www.mycompany.com
```
will then become the following, post-processed:

```
url=www.mycompany.com
dev.url=github.com
prod.url=www.mycompany.com
```
Also, `-Dcluster=prod` added to `CATALINA_OPTS`, `JAVA_OPTS`, etc. will also work.

N.B. `UP_CLUSTER` takes precedent over the `-Dcluster` JVM argument.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
