### PR TITLE
fix(oracle): Fix typo that breaks layout imports for Oracle > 12

### DIFF
--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/PortalDialectResolver.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/utils/PortalDialectResolver.java
@@ -44,7 +44,7 @@ public class PortalDialectResolver extends AbstractDialectResolver {
         }
 
         // Ensure long varchar columns are forced to clob instead of long.
-        if ("Oracle".equals(databaseName) && 12 >= databaseMajorVersion) {
+        if ("Oracle".equals(databaseName) && databaseMajorVersion >= 12) {
             return new Oracle12ForceClobDialect();
         }
 


### PR DESCRIPTION
Fix for https://github.com/Jasig/uPortal/issues/1764
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement] is signed
-   [ ] commit message follows [commit guidelines][]


##### Description of change
There was a typo where a previous bugfix didn't apply to versions of Oracle greater than 12. This resulted in all layout data-imports failing when using Oracle 18c.
