### PR TITLE
Unescape portlet and tab names in sitemap.

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
@@ -111,7 +111,7 @@
                 var tabHeader = document.importNode(tabTemplate.content, true).querySelector('div');
                 // Add content to tab header template
                 var tabHeaderLink = tabHeader.querySelector('a');
-                tabHeaderLink.textContent = tab.name;
+                tabHeaderLink.textContent = _.unescape(tab.name);
                 tabHeaderLink.href = '${portalContextPath}/f/' + tab.ID + '/normal/render.uP';
                 var portletList = tabHeader.querySelector('ul');
 
@@ -130,7 +130,7 @@
                         var portletListItem = document.importNode(portletTemplate.content, true).querySelector('li');
                         // Add content to portlet template
                         var portletTitle = portletListItem.querySelector('span');
-                        portletTitle.textContent = portlet.name;
+                        portletTitle.textContent = _.unescape(portlet.name);
                         var portletLink = portletListItem.querySelector('a');
                         portletLink.href = '${portalContextPath}/f/' + tab.ID + '/p/' + portlet.fname + '.' + portlet.ID + '/max/render.uP';
                         // Add portlet to tab list


### PR DESCRIPTION
https://github.com/Jasig/uPortal/issues/1766

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

<!-- Provide a description of the change below this comment. -->
Unescape the portlet and tab names that display in the sitemap. This prevents portlets from showing up like "Courses &amp; Grades" and shows them correctly as "Courses & Grades".
