### PR TITLE
Fix/1691 aggregation break past now

### DIFF
--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImpl.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImpl.java
@@ -82,10 +82,9 @@ public class PortalRawEventsAggregatorImpl extends BaseAggrEventsJpaDao
     private AggregationIntervalHelper intervalHelper;
     private EventSessionDao eventSessionDao;
     private DateDimensionDao dateDimensionDao;
-    private Set<IntervalAwarePortalEventAggregator>
-            intervalAwarePortalEventAggregators = Collections.emptySet();
-    private Set<SimplePortalEventAggregator> simplePortalEventAggregators =
+    private Set<IntervalAwarePortalEventAggregator> intervalAwarePortalEventAggregators =
             Collections.emptySet();
+    private Set<SimplePortalEventAggregator> simplePortalEventAggregators = Collections.emptySet();
     private List<ApplicationEventFilter<PortalEvent>> applicationEventFilters =
             Collections.emptyList();
 
@@ -150,17 +149,13 @@ public class PortalRawEventsAggregatorImpl extends BaseAggrEventsJpaDao
 
     @Autowired
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public void setPortalEventAggregators(
-            Set<IPortalEventAggregator> portalEventAggregators) {
-        final com.google.common.collect.ImmutableSet.Builder<
-                        IntervalAwarePortalEventAggregator>
+    public void setPortalEventAggregators(Set<IPortalEventAggregator> portalEventAggregators) {
+        final com.google.common.collect.ImmutableSet.Builder<IntervalAwarePortalEventAggregator>
                 intervalAwarePortalEventAggregatorsBuilder = ImmutableSet.builder();
-        final com.google.common.collect.ImmutableSet.Builder<
-                        SimplePortalEventAggregator>
+        final com.google.common.collect.ImmutableSet.Builder<SimplePortalEventAggregator>
                 simplePortalEventAggregatorsBuilder = ImmutableSet.builder();
 
-        for (final IPortalEventAggregator portalEventAggregator :
-                portalEventAggregators) {
+        for (final IPortalEventAggregator portalEventAggregator : portalEventAggregators) {
             if (portalEventAggregator instanceof IntervalAwarePortalEventAggregator) {
                 intervalAwarePortalEventAggregatorsBuilder.add(
                         (IntervalAwarePortalEventAggregator) portalEventAggregator);
@@ -170,7 +165,9 @@ public class PortalRawEventsAggregatorImpl extends BaseAggrEventsJpaDao
                         (SimplePortalEventAggregator) portalEventAggregator);
                 logger.debug("Found a simple aggregator - {}", portalEventAggregator);
             } else {
-                logger.debug("Found an unknown type of aggregator, not including - {}", portalEventAggregator);
+                logger.debug(
+                        "Found an unknown type of aggregator, not including - {}",
+                        portalEventAggregator);
             }
         }
 

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImpl.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImpl.java
@@ -82,9 +82,9 @@ public class PortalRawEventsAggregatorImpl extends BaseAggrEventsJpaDao
     private AggregationIntervalHelper intervalHelper;
     private EventSessionDao eventSessionDao;
     private DateDimensionDao dateDimensionDao;
-    private Set<IntervalAwarePortalEventAggregator<PortalEvent>>
+    private Set<IntervalAwarePortalEventAggregator>
             intervalAwarePortalEventAggregators = Collections.emptySet();
-    private Set<SimplePortalEventAggregator<PortalEvent>> simplePortalEventAggregators =
+    private Set<SimplePortalEventAggregator> simplePortalEventAggregators =
             Collections.emptySet();
     private List<ApplicationEventFilter<PortalEvent>> applicationEventFilters =
             Collections.emptyList();
@@ -151,22 +151,26 @@ public class PortalRawEventsAggregatorImpl extends BaseAggrEventsJpaDao
     @Autowired
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void setPortalEventAggregators(
-            Set<IPortalEventAggregator<PortalEvent>> portalEventAggregators) {
+            Set<IPortalEventAggregator> portalEventAggregators) {
         final com.google.common.collect.ImmutableSet.Builder<
-                        IntervalAwarePortalEventAggregator<PortalEvent>>
+                        IntervalAwarePortalEventAggregator>
                 intervalAwarePortalEventAggregatorsBuilder = ImmutableSet.builder();
         final com.google.common.collect.ImmutableSet.Builder<
-                        SimplePortalEventAggregator<PortalEvent>>
+                        SimplePortalEventAggregator>
                 simplePortalEventAggregatorsBuilder = ImmutableSet.builder();
 
-        for (final IPortalEventAggregator<PortalEvent> portalEventAggregator :
+        for (final IPortalEventAggregator portalEventAggregator :
                 portalEventAggregators) {
             if (portalEventAggregator instanceof IntervalAwarePortalEventAggregator) {
                 intervalAwarePortalEventAggregatorsBuilder.add(
                         (IntervalAwarePortalEventAggregator) portalEventAggregator);
+                logger.debug("Found an interval aware aggregator - {}", portalEventAggregator);
             } else if (portalEventAggregator instanceof SimplePortalEventAggregator) {
                 simplePortalEventAggregatorsBuilder.add(
                         (SimplePortalEventAggregator) portalEventAggregator);
+                logger.debug("Found a simple aggregator - {}", portalEventAggregator);
+            } else {
+                logger.debug("Found an unknown type of aggregator, not including - {}", portalEventAggregator);
             }
         }
 

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/action/SearchRequestAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/action/SearchRequestAggregator.java
@@ -28,7 +28,9 @@ import org.apereo.portal.events.aggr.EventAggregationContext;
 import org.apereo.portal.events.aggr.TimeDimension;
 import org.apereo.portal.events.aggr.groups.AggregatedGroupMapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class SearchRequestAggregator
         extends BaseIntervalAwarePortalEventAggregator<
                 PortletActionExecutionEvent,

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/concuser/ConcurrentUserAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/concuser/ConcurrentUserAggregator.java
@@ -24,11 +24,13 @@ import org.apereo.portal.events.aggr.EventAggregationContext;
 import org.apereo.portal.events.aggr.TimeDimension;
 import org.apereo.portal.events.aggr.groups.AggregatedGroupMapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Event aggregator that uses {@link ConcurrentUserAggregationPrivateDao} to aggregate concurrent
  * user data
  */
+@Component
 public class ConcurrentUserAggregator
         extends BaseIntervalAwarePortalEventAggregator<
                 PortalEvent, ConcurrentUserAggregationImpl, ConcurrentUserAggregationKey> {

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/login/LoginPortalEventAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/login/LoginPortalEventAggregator.java
@@ -25,8 +25,10 @@ import org.apereo.portal.events.aggr.EventAggregationContext;
 import org.apereo.portal.events.aggr.TimeDimension;
 import org.apereo.portal.events.aggr.groups.AggregatedGroupMapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /** Event aggregator that uses {@link LoginAggregationPrivateDao} to aggregate login events */
+@Component
 public class LoginPortalEventAggregator
         extends BaseIntervalAwarePortalEventAggregator<
                 LoginEvent, LoginAggregationImpl, LoginAggregationKey> {

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/portletexec/PortletExecutionAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/portletexec/PortletExecutionAggregator.java
@@ -126,4 +126,8 @@ public class PortletExecutionAggregator
                 mappedPortlet,
                 executionType);
     }
+
+    public String toString() {
+        return "PortletExecutionAggregator: type=" + this.executionType;
+    }
 }

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/portletlayout/PortletLayoutAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/portletlayout/PortletLayoutAggregator.java
@@ -32,10 +32,12 @@ import org.apereo.portal.events.aggr.groups.AggregatedGroupMapping;
 import org.apereo.portal.events.aggr.portlets.AggregatedPortletLookupDao;
 import org.apereo.portal.events.aggr.portlets.AggregatedPortletMapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Event aggregator that uses {@link PortletLayoutAggregationPrivateDao} to aggregate portlet adds
  */
+@Component
 public class PortletLayoutAggregator
         extends BaseIntervalAwarePortalEventAggregator<
                 PortletLayoutPortalEvent,

--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/tabrender/TabRenderAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/tabrender/TabRenderAggregator.java
@@ -29,8 +29,10 @@ import org.apereo.portal.events.aggr.groups.AggregatedGroupMapping;
 import org.apereo.portal.events.aggr.tabs.AggregatedTabLookupDao;
 import org.apereo.portal.events.aggr.tabs.AggregatedTabMapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /** Event aggregator that uses {@link TabRenderAggregationPrivateDao} to aggregate tab renders */
+@Component
 public class TabRenderAggregator
         extends BaseIntervalAwarePortalEventAggregator<
                 PortalRenderEvent, TabRenderAggregationImpl, TabRenderAggregationKey> {

--- a/uPortal-events/src/main/java/org/apereo/portal/events/tincan/TinCanPortalEventAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/tincan/TinCanPortalEventAggregator.java
@@ -26,8 +26,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 /** Event aggregator that processes events and converts them to xAPI events. */
+@Component
 public class TinCanPortalEventAggregator extends BasePortalEventAggregator<PortalEvent>
         implements SimplePortalEventAggregator<PortalEvent> {
     private static final Logger log = LoggerFactory.getLogger(TinCanPortalEventAggregator.class);

--- a/uPortal-webapp/src/main/resources/properties/contexts/eventHandlerContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/eventHandlerContext.xml
@@ -137,10 +137,6 @@
     <!-- Useful for debugging, logs each event as it is processed by the aggregation system 
     <bean id="loggingPortalEventAggregator" class="org.apereo.portal.events.aggr.LoggingPortalEventAggregator" />
      -->
-    <bean id="loginPortalEventAggregator" class="org.apereo.portal.events.aggr.login.LoginPortalEventAggregator"/>
-    <bean id="concurrentUserAggregator" class="org.apereo.portal.events.aggr.concuser.ConcurrentUserAggregator"/>
-    <bean id="tabRenderAggregator" class="org.apereo.portal.events.aggr.tabrender.TabRenderAggregator"/>
-    <bean id="portletAddAggregator" class="org.apereo.portal.events.aggr.portletlayout.PortletLayoutAggregator"/>
     <bean id="portletExecutionAggregatorAll" class="org.apereo.portal.events.aggr.portletexec.PortletExecutionAggregator"/>
     <bean id="portletExecutionAggregatorAction" class="org.apereo.portal.events.aggr.portletexec.PortletExecutionAggregator">
         <property name="executionType" value="ACTION" />
@@ -153,9 +149,5 @@
     </bean>
     <bean id="portletExecutionAggregatorResource" class="org.apereo.portal.events.aggr.portletexec.PortletExecutionAggregator">
         <property name="executionType" value="RESOURCE" />
-    </bean>
-    <bean id="searchRequestAggregator" class="org.apereo.portal.events.aggr.action.SearchRequestAggregator"/>
-    <bean id="tinCanEventAggregator" class="org.apereo.portal.events.tincan.TinCanPortalEventAggregator">
-        <property name="tinCanEventScheduler" ref="tinCanEventScheduler"/>
     </bean>
 </beans>


### PR DESCRIPTION
Backing ticket #1691 

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

Event aggregators were not being wired in properly to uPortal, so this drops the specificity of the `IPortalEventAggregator` to allow all of the event aggregrators to be pulled in.

I also switched the standard event aggregators not needing configuration to use `@Component` to clean up the `eventHandlerContext.xml` file.