### PR TITLE
Use tab's externalId for sitemap links. Fixes GH-1801 and GH-1802.

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
@@ -102,7 +102,7 @@
             var tabRowTemplate = document.getElementById('sitemap-tab-row-template');
             var tabRow = document.importNode(tabRowTemplate.content, true).querySelector('div');
             _.forEach(response.layout.navigation.tabs, function (tab, tabIndex) {
-                if (sitemapJsonCheck(tab, ['name','ID','content'], "Missing required object path [layout.navigation.tabs] > ")) {
+                if (sitemapJsonCheck(tab, ['name','externalId','content'], "Missing required object path [layout.navigation.tabs] > ")) {
                     return;
                 }
 
@@ -112,7 +112,7 @@
                 // Add content to tab header template
                 var tabHeaderLink = tabHeader.querySelector('a');
                 tabHeaderLink.textContent = _.unescape(tab.name);
-                tabHeaderLink.href = '${portalContextPath}/f/' + tab.ID + '/normal/render.uP';
+                tabHeaderLink.href = '${portalContextPath}/f/' + tab.externalId + '/normal/render.uP';
                 var portletList = tabHeader.querySelector('ul');
 
                 _.forEach(tab.content, function (parentContent, parentContentIndex) {
@@ -132,7 +132,7 @@
                         var portletTitle = portletListItem.querySelector('span');
                         portletTitle.textContent = _.unescape(portlet.name);
                         var portletLink = portletListItem.querySelector('a');
-                        portletLink.href = '${portalContextPath}/f/' + tab.ID + '/p/' + portlet.fname + '.' + portlet.ID + '/max/render.uP';
+                        portletLink.href = '${portalContextPath}/f/' + tab.externalId + '/p/' + portlet.fname + '.' + portlet.ID + '/max/render.uP';
                         // Add portlet to tab list
                         portletList.appendChild(portletListItem);
                     });


### PR DESCRIPTION
-   [ x ] the [individual contributor license agreement][] is signed
-   [ x ] commit message follows [commit guidelines][]

Use tab's externalId for sitemap links. Fixes GH-1801 and GH-1802.

This fixes 1801 because using the externalId doesn't redirect the user to log in to the portal. This fixes 1802 because the transient tab doesn't have an externalId, so it will never show up in the sitemap at all.