### PR TITLE
feat: made encodeServiceUrl a property that can be set via properties

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/securityContext.xml
@@ -119,7 +119,7 @@
      +-->
     <bean name="ticketValidationFilter" class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter">
         <property name="serverName" value="${portal.allServerNames}" />
-        <property name="encodeServiceUrl" value="true" />
+        <property name="encodeServiceUrl" value="${cas.ticketValidationFilter.encodeServiceUrl:true}" />
         <property name="proxyReceptorUrl" value="${cas.ticketValidationFilter.proxyReceptorUrl:}" />
         <property name="ticketValidator">
             <bean class="org.jasig.cas.client.validation.Cas20ServiceTicketValidator">
@@ -151,6 +151,6 @@
         <property name="casServerLoginUrl" value="${cas.authenticationFilter.cas.login.url}" />
         <property name="service" value="${cas.authenticationFilter.service}" />
         <property name="gateway" value="false" />
-        <property name="encodeServiceUrl" value="true" />
+        <property name="encodeServiceUrl" value="${cas.ticketValidationFilter.encodeServiceUrl:true}" />
     </bean>
 </beans>

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -76,6 +76,13 @@ cas.authenticationFilter.cas.login.url=${cas.protocol.server.context}/login
 #cas.ticketValidationFilter.proxyReceptorUrl=/CasProxyServlet
 #cas.ticketValidationFilter.ticketValidator.proxyCallbackUrl=${portal.protocol}://${portal.lbServerName}${portal.context}${cas.ticketValidationFilter.proxyReceptorUrl}
 
+## Some CAS servers, like the CAS server in uPortal-start can not handle encoded service URLs.
+## Set the following property to false to disable encoding of service URLs.
+## See https://groups.google.com/a/apereo.org/d/msg/uportal-user/44Uw1YP8_Mg/hLaTlEVZFAAJ
+## for the discussion regarding this property
+#
+#cas.ticketValidationFilter.encodeServiceUrl=true
+
 ## Simple (database)
 #
 org.apereo.portal.security.provider.SimpleSecurityContextFactory.enabled=false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
Follow up to #1822 where `encodeServiceUrl` has been made into a property (`cas.ticketValidationFilter.encodeServiceUrl`) that can be set from `uPortal.properties`

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
