### PR TITLE
Feat/lucene enhancements

### DIFF
--- a/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
+++ b/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
@@ -42,6 +42,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class PortalSearchIndexer {
 
+    public static final String LUCENE_DOC_ID_FIELD = "id";
+
     @Autowired private IPortletDefinitionRegistry portletRegistry;
 
     @Autowired private Directory directory;
@@ -90,10 +92,9 @@ public class PortalSearchIndexer {
         // Unique identifier, hashed to eliminate special character concerns, such as hyphens
         final String fnameHash =
                 Hashing.sha256().hashString(portlet.getFName(), StandardCharsets.UTF_8).toString();
-        final String fnameHashKey = "id";
         try {
             final Document doc = new Document();
-            doc.add(new TextField(fnameHashKey, fnameHash, Field.Store.YES));
+            doc.add(new TextField(LUCENE_DOC_ID_FIELD, fnameHash, Field.Store.YES));
             doc.add(
                     new TextField(
                             SearchField.FNAME.getValue(), portlet.getFName(), Field.Store.YES));
@@ -120,7 +121,7 @@ public class PortalSearchIndexer {
                 doc.add(new TextField(SearchField.CONTENT.getValue(), content, Field.Store.YES));
             }
 
-            indexWriter.updateDocument(new Term(fnameHashKey, fnameHash), doc);
+            indexWriter.updateDocument(new Term(LUCENE_DOC_ID_FIELD, fnameHash), doc);
         } catch (IOException ioe) {
             logger.warn(
                     "Unable to index portlet with fname='{}' and hash='{}'",

--- a/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
+++ b/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
@@ -14,7 +14,9 @@
  */
 package org.apereo.portal.index;
 
+import com.google.common.hash.Hashing;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -85,10 +87,16 @@ public class PortalSearchIndexer {
     }
 
     private void indexPortlet(IPortletDefinition portlet, IndexWriter indexWriter) {
-        final String fname = portlet.getFName(); // Unique identifier
+        // Unique identifier, hashed to eliminate special character concerns, such as hyphens
+        final String fnameHash =
+                Hashing.sha256().hashString(portlet.getFName(), StandardCharsets.UTF_8).toString();
+        final String fnameHashKey = "id";
         try {
             final Document doc = new Document();
-            doc.add(new TextField(SearchField.FNAME.getValue(), fname, Field.Store.YES));
+            doc.add(new TextField(fnameHashKey, fnameHash, Field.Store.YES));
+            doc.add(
+                    new TextField(
+                            SearchField.FNAME.getValue(), portlet.getFName(), Field.Store.YES));
             doc.add(new TextField(SearchField.NAME.getValue(), portlet.getName(), Field.Store.YES));
             doc.add(
                     new TextField(
@@ -111,12 +119,16 @@ public class PortalSearchIndexer {
             if (StringUtils.isNotBlank(content)) {
                 doc.add(new TextField(SearchField.CONTENT.getValue(), content, Field.Store.YES));
             }
-            indexWriter.updateDocument(new Term("fname", fname), doc);
+
+            indexWriter.updateDocument(new Term(fnameHashKey, fnameHash), doc);
         } catch (IOException ioe) {
-            logger.warn("Unable to index portlet with fname='{}'", fname);
+            logger.warn(
+                    "Unable to index portlet with fname='{}' and hash='{}'",
+                    portlet.getFName(),
+                    fnameHash);
             return;
         }
-        logger.debug("Indexed portlet '{}'", fname);
+        logger.debug("Indexed portlet '{}' (hash='{}')", portlet.getFName(), fnameHash);
     }
 
     private String extractContent(IPortletDefinition portlet) {

--- a/uPortal-webapp/src/main/resources/properties/i18n/Messages.properties
+++ b/uPortal-webapp/src/main/resources/properties/i18n/Messages.properties
@@ -606,6 +606,7 @@ search.results=Search Results
 search.submit=Search
 search.stuff.add=Search for stuff to add
 search.terms=Search Terms
+search.score=Relevance
 select=Select
 select.cache.to.view.stats.and.clear.content=Select a cache to view statistics or clear its contents.
 select.categories=Select Categories

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
@@ -131,6 +131,7 @@
 <spring:message var="i18n_telephoneNumber" code="attribute.displayName.telephoneNumber" />
 <spring:message var="i18n_name" code="name" />
 <spring:message var="i18n_description" code="description" />
+<spring:message var="i18n_score" code="search.score" />
 
 <script language="javascript" type="text/javascript">
 // This metadata object tells us which avatar (icon) and which
@@ -154,7 +155,8 @@ var i18n = {
     'mail': '${i18n_mail}',
     'telephoneNumber': '${i18n_telephoneNumber}',
     'name': '${i18n_name}',
-    'description': '${i18n_description}'
+    'description': '${i18n_description}',
+    'score': '${i18n_score}'
 };
 
 fetch('${searchApiUrl}', {credentials: 'same-origin'})


### PR DESCRIPTION
##### Checklist
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [x] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
Exposes the Lucene score to the end user. 

This can be disabled with the boolean property `org.apereo.portal.rest.search.PortletsSearchStrategy.displayScore`.

Also resolves duplicate documents in the Lucene index - #1809