### PR TITLE
fix: do not escape submit URL in confirmRemove.jsp

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/portlet-manager/confirmRemove.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/portlet-manager/confirmRemove.jsp
@@ -21,7 +21,7 @@
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 
 <!-- START: VALUES BEING PASSED FROM BACKEND -->
-<portlet:actionURL var="submitUrl">
+<portlet:actionURL var="submitUrl" escapeXml="false">
 	<portlet:param name="execution" value="${flowExecutionKey}" />
 </portlet:actionURL>
 <!-- END: VALUES BEING PASSED FROM BACKEND -->


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
For some deployments the '&' is not escaped for the submit URL. Explicitly setting `escapeXml="false"` to address.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
