### PR TITLE
fix(pags): InvertedRegexTester against multivalued attributes

### DIFF
--- a/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/AbstractStringTester.java
+++ b/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/AbstractStringTester.java
@@ -26,7 +26,7 @@ public abstract class AbstractStringTester extends BaseAttributeTester {
     }
 
     @Override
-    public final boolean test(IPerson person) {
+    public boolean test(IPerson person) {
         boolean result = false;
         Object[] atts = person.getAttributeValues(getAttributeName());
         if (atts != null) {

--- a/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/InvertedRegexTester.java
+++ b/uPortal-groups/uPortal-groups-pags/src/main/java/org/apereo/portal/groups/pags/testers/InvertedRegexTester.java
@@ -14,8 +14,8 @@
  */
 package org.apereo.portal.groups.pags.testers;
 
-import java.util.regex.Pattern;
 import org.apereo.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
+import org.apereo.portal.security.IPerson;
 
 /**
  * A tester for matching the possibly multiple values of an attribute against a regular expression
@@ -49,27 +49,15 @@ import org.apereo.portal.groups.pags.dao.IPersonAttributesGroupTestDefinition;
  * </table>
  * </code>
  */
-public class InvertedRegexTester extends AbstractStringTester {
-
-    protected Pattern pattern;
+public class InvertedRegexTester extends RegexTester {
 
     /** @since 4.3 */
     public InvertedRegexTester(IPersonAttributesGroupTestDefinition definition) {
         super(definition);
-        this.pattern = Pattern.compile(definition.getTestValue());
-    }
-
-    /**
-     * Sets the pattern string to use for the regex test.
-     *
-     * @param patternString regex pattern string
-     */
-    protected void setPattern(String patternString) {
-        pattern = Pattern.compile(patternString);
     }
 
     @Override
-    public boolean test(String att) {
-        return !pattern.matcher(att).matches();
+    public boolean test(IPerson person) {
+        return !super.test(person);
     }
 }

--- a/uPortal-groups/uPortal-groups-pags/src/test/java/org/apereo/portal/groups/pags/testers/InvertedRegexTesterTest.java
+++ b/uPortal-groups/uPortal-groups-pags/src/test/java/org/apereo/portal/groups/pags/testers/InvertedRegexTesterTest.java
@@ -14,23 +14,63 @@
  */
 package org.apereo.portal.groups.pags.testers;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apereo.portal.groups.pags.TestPersonAttributesGroupTestDefinition;
+import org.apereo.portal.security.IPerson;
+import org.apereo.portal.security.provider.PersonImpl;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class InvertedRegexTesterTest {
 
+    IPerson person;
+    String strAttributeName = "mail";
+
+    @Before
+    public void setUp() {
+        person = new PersonImpl();
+        person.setUserName("testuser");
+
+        List<Object> emailAddresses = new ArrayList<Object>();
+        emailAddresses.add("testuser1@somewhere.com");
+        emailAddresses.add("testuser1@elsewhere.com");
+        person.setAttribute(strAttributeName, emailAddresses);
+    }
+
     @Test
-    public void testRegexPatterns() {
+    public void testMultivaluedAttrsRegex() {
         InvertedRegexTester tester =
                 new InvertedRegexTester(
                         new TestPersonAttributesGroupTestDefinition(
-                                "fakeAttribute", "^02([A-D])*"));
-        Assert.assertFalse(tester.test("02A"));
-        Assert.assertFalse(tester.test("02ABCD"));
-        Assert.assertTrue(tester.test("A02D"));
-        Assert.assertFalse(tester.test("02"));
-        Assert.assertTrue(tester.test("02MisMatch"));
-        Assert.assertTrue(tester.test("PatternWillNeverMatch"));
+                                strAttributeName, "testuser1@elsewhere.com"));
+        Assert.assertFalse(tester.test(person));
+
+        tester =
+                new InvertedRegexTester(
+                        new TestPersonAttributesGroupTestDefinition(
+                                strAttributeName, "testnone@notmatch.com"));
+        Assert.assertTrue(tester.test(person));
+    }
+
+    @Test
+    public void testRegexPatterns() {
+        final String fakeAttribute = "fakeAttribute";
+        InvertedRegexTester tester =
+                new InvertedRegexTester(
+                        new TestPersonAttributesGroupTestDefinition(fakeAttribute, "^02([A-D])*"));
+        person.setAttribute(fakeAttribute, "02A");
+        Assert.assertFalse(tester.test(person));
+        person.setAttribute(fakeAttribute, "02ABCD");
+        Assert.assertFalse(tester.test(person));
+        person.setAttribute(fakeAttribute, "A02D");
+        Assert.assertTrue(tester.test(person));
+        person.setAttribute(fakeAttribute, "02");
+        Assert.assertFalse(tester.test(person));
+        person.setAttribute(fakeAttribute, "02MisMatch");
+        Assert.assertTrue(tester.test(person));
+        person.setAttribute(fakeAttribute, "PatternWillNeverMatch");
+        Assert.assertTrue(tester.test(person));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
InvertedRegexTester doesn't provide a logical test result against a multivalued attribute.

The Inverted response should be done against the final result and not for each value test (this case work only on a monovalued attribute). The problem is on the foreach attribute values, when it find a not match it returns true without testing all other values, and so it return always true expect if a single matching result appear.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
