### PR TITLE
feat(smartldap): add support for using ContextMapper

### DIFF
--- a/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
+++ b/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
@@ -50,7 +50,6 @@ import org.danann.cernunnos.runtime.ScriptRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.ldap.core.AttributesMapper;
 import org.springframework.ldap.core.ContextMapper;
 import org.springframework.ldap.core.ContextSource;
@@ -716,7 +715,8 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
 
         if (attributesMapper != null) {
             if (contextMapper != null) {
-                log.warn("Both attributesMapper and contextMapper are set -- attributesMapper will be used");
+                log.warn(
+                        "Both attributesMapper and contextMapper are set -- attributesMapper will be used");
             }
             req.setAttribute("mapperType", "attributes");
             req.setAttribute("attributesMapper", attributesMapper);
@@ -724,7 +724,8 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
             req.setAttribute("mapperType", "context");
             req.setAttribute("contextMapper", contextMapper);
         } else {
-            throw new IllegalStateException("Either an AttributesMapper or a ContextMapper must be specified");
+            throw new IllegalStateException(
+                    "Either an AttributesMapper or a ContextMapper must be specified");
         }
 
         runner.run(initTask, req);

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
@@ -24,7 +24,9 @@
         base-dn="${baseGroupDn}"
         filter="${filter}"
         scope="${groovy(javax.naming.directory.SearchControls.SUBTREE_SCOPE)}"
+        mapper-type="${mapperType}"
         attributes-mapper="${attributesMapper}"
+        context-mapper="${contextMapper}"
         resolveMemberGroups="${resolveMemberGroups}"
         attribute-name="record"
         >


### PR DESCRIPTION
instead of AttributesMapper

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
UoI needs to use a context mapper over an attribute mapper for greater access to the processing of LDAP records.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
