### PR TITLE
fix(wcag-aa): increase contrast in customize drawer

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/gallery.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/gallery.less
@@ -43,7 +43,7 @@
 @galleryBarBackground           : transparent url("./common/images/gallery-bar.png") top left repeat-x;
 @galleryMenuBackground          : @grayscale9;
 @galleryMenuItemBackground      : @grayscale8;
-@galleryMenuItemLink            : @grayscale3;
+@galleryMenuItemLink            : @white;
 @galleryMenuItemBackgroundHover : @color1-darker;
 @galleryMenuItemLinkHover       : @white;
 @galleryMenuItemActiveBackground: @grayscale10;
@@ -63,10 +63,11 @@
 @galleryFilterSubtitle          : @grayscale2;
 @galleryFilterSubtitleLine      : 1px dotted @grayscale9;
 @galleryFSearchInputBackground  : @grayscale8;
-@galleryFSearchInputText        : @grayscale10;
+@galleryFSearchInputText        : @white;
 @galleryFSearchInputPadding     : 0.3em;
 @galleryFSearchInputHover       : @grayscale7;
-@galleryFSearchInputFocus       : @white;
+@galleryFSearchInputFocusText   : @black;
+@galleryFSearchInputFocusBackground : @white;
 @galleryCatLink                 : @grayscale3;
 @galleryCatLinkHover            : @color1;
 @galleryCatActiveLink           : @white;
@@ -347,7 +348,8 @@
           }
 
           &:focus {
-            background: @galleryFSearchInputFocus;
+            color: @galleryFSearchInputFocusText;
+            background: @galleryFSearchInputFocusBackground;
           }
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Contrast in the customizer drawer needed to be increased. 

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
