### PR TITLE
fix(search): fix partial searching and run indexer at startup

### DIFF
--- a/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/PortletsSearchStrategy.java
+++ b/uPortal-api/uPortal-api-rest/src/main/java/org/apereo/portal/rest/search/PortletsSearchStrategy.java
@@ -86,12 +86,12 @@ public class PortletsSearchStrategy implements ISearchStrategy {
 
     @Override
     public List<?> search(String query, HttpServletRequest request) {
-
+        logger.debug("Entering search() with query={}", query);
         final List<Object> rslt = new ArrayList<>();
 
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-
-            final Query q = queryParser.parse(query);
+            final String queryString = query.endsWith(" ") ? query : query + "*";
+            final Query q = queryParser.parse(queryString);
             final IndexSearcher searcher = new IndexSearcher(indexReader);
             final TopDocs topDocs = searcher.search(q, 50);
             Arrays.stream(topDocs.scoreDocs)

--- a/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
+++ b/uPortal-index/src/main/java/org/apereo/portal/index/PortalSearchIndexer.java
@@ -58,10 +58,14 @@ public class PortalSearchIndexer {
         logger.info(
                 "Search indexing is {} based on presence or absence of a Directory",
                 isEnabled() ? "ENABLED" : "DISABLED");
+        if (isEnabled()) {
+            updateIndex();
+        }
     }
 
     /** Called by Quatrz. */
     public void updateIndex() {
+        logger.debug("Updating Lucene index files ...");
 
         if (!isEnabled()) {
             return;

--- a/uPortal-webapp/src/main/resources/properties/contexts/schedulerContext.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/schedulerContext.xml
@@ -63,7 +63,7 @@
         <task:scheduled ref="portalEventDaoQueuingEventHandler" method="flush" fixed-delay="997"/> <!-- ~1 second period -->
         <task:scheduled ref="cacheManagerExpiredElementEvictor" method="evictExpiredElements" fixed-delay="61900"/> <!-- ~1 minute period -->
         <task:scheduled ref="cacheHealthReporterService" method="generateReports" fixed-delay="60013"/> <!-- ~1 minute period -->
-        <task:scheduled ref="portalSearchIndexer" method="updateIndex" fixed-delay="${org.apereo.portal.index.portalSearchIndexer.updateIndexPeriod:180001}"/> <!-- ~3 minute period -->
+        <task:scheduled ref="portalSearchIndexer" method="updateIndex" fixed-delay="${org.apereo.portal.index.portalSearchIndexer.updateIndexPeriod:58001}"/> <!-- ~1 minute period -->
 
         <!-- clustered tasks -->
         <task:scheduled ref="portletCookieService" method="purgeExpiredCookies" fixed-delay="${org.apereo.portal.portlet.container.services.PortletCookieServiceImpl.purgeExpiredCookiesPeriod}"/>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Lucene indexing was not supporting partial term searching without wildcard, which is how search had been working. Also, Lucene indexer needed to run before results were returned (exception broken results).

1. Wildcard is added automatically with this PR
2. Indexer is run at startup
3. Indexer is run every minute by default now

Resolves Issue #2006
<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
