### PR TITLE
fix: catch expected runtime exception when race condition of cookie...

### DIFF
--- a/uPortal-web/build.gradle
+++ b/uPortal-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile project(':uPortal-rendering')
 
     compile "com.google.visualization:visualization-datasource:${googleVisualizationVersion}"
+    compile "joda-time:joda-time:${jodaTimeVersion}"
 
     testCompile "org.apache.portals.pluto:pluto-container-api:${plutoVersion}"
     testCompile "${servletApiDependency}"

--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/container/services/PortletCookieServiceImpl.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/container/services/PortletCookieServiceImpl.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.orm.hibernate3.HibernateOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.util.WebUtils;
@@ -178,7 +177,7 @@ public class PortletCookieServiceImpl implements IPortletCookieService, ServletC
             try {
                 this.portletCookieDao.updatePortalCookieExpiration(
                         portalCookie, cookie.getMaxAge());
-            } catch (HibernateOptimisticLockingFailureException e) {
+            } catch (RuntimeException e) {
                 // Especially with ngPortal UI multiple requests for individual portlet content may
                 // come at
                 // the same time.  Sometimes another thread updated the portal cookie between our


### PR DESCRIPTION
… updates

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
During portlet cookie processing, there is a known potential for a race-condition where more than one portlet thread is updating the user's portlet cookie. The code previously caught the optimistic locking exception and continued. The exception was changed in Spring/Hibernate but the uPortal code was not updated. This caused failed pages (uncaught runtime exception) on occasion.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
