### PR TITLE
ci: setup github actions

### DIFF
--- a/.github/WORKFLOWS/CI.yml
+++ b/.github/WORKFLOWS/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build-and-test:
+    name: '${{ matrix.platform }}: Java ${{ matrix.java-version }}'
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        java-version:
+          - 8.0.275.open-adpt
+          - 8.0.275-amzn
+          - 8.0.265-open
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Java
+        uses: sdkman/sdkman-action@master
+        id: sdkman
+        with:
+          candidate: java
+          version: 15.0.0-amzn
+      - name: Setup Java
+        uses: actions/setup-java@v1
+          id: setup-java
+          with:
+            java-version: 15.0.0
+            jdkFile: ${{ steps.sdkman.outputs.file }}
+      - name: Build and Test
+        run: ./gradlew -S --no-daemon --no-parallel build jacocoAggregateReport coveralls
+      - name: Lint JavaScript
+        run: ./gradlew -S --no-daemon --no-parallel :npm_run_lint-js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

Travis CI has been getting slower for a while.
More recently they have added more limitation on how many builds free/OSS project can run (https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing)
This PR moves the Travis CI build over to GitHub Actions, if successful Travis CI will be dropped in a future PR.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
