### PR TITLE
#2141 smartLDAP - minor adjustments and remove default context-mapper

### DIFF
--- a/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SimpleAttributesMapper.java
+++ b/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SimpleAttributesMapper.java
@@ -77,7 +77,10 @@ public final class SimpleAttributesMapper implements AttributesMapper {
         LdapRecord rslt;
 
         try {
-
+			if (log.isDebugEnabled()) {
+			    log.debug("Attribute data set: " + attr);
+				log.debug("Attribute's value of keyAttributeName: " + attr.get(keyAttributeName));
+			}
             String key = (String) attr.get(keyAttributeName).get();
             String groupName = (String) attr.get(groupNameAttributeName).get();
 

--- a/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SimpleAttributesMapper.java
+++ b/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SimpleAttributesMapper.java
@@ -77,10 +77,10 @@ public final class SimpleAttributesMapper implements AttributesMapper {
         LdapRecord rslt;
 
         try {
-			if (log.isDebugEnabled()) {
-			    log.debug("Attribute data set: " + attr);
-				log.debug("Attribute's value of keyAttributeName: " + attr.get(keyAttributeName));
-			}
+            if (log.isDebugEnabled()) {
+                log.debug("Attribute data set: " + attr);
+                log.debug("Attribute's value of keyAttributeName: " + attr.get(keyAttributeName));
+            }
             String key = (String) attr.get(keyAttributeName).get();
             String groupName = (String) attr.get(groupNameAttributeName).get();
 

--- a/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
+++ b/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
@@ -260,17 +260,17 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
                     group.getName());
             getParentGroups(group.getLocalKey(), rslt);
         } else if (!gm.isGroup() && gm.getLeafType().equals(root.getLeafType())) {
-			if((groupsTree != null) && (groupsTree.getGroups() != null)) {
-		        Object[] groupKeys = getPersonGroupMemberKeys(gm);
-		        for (Object o : groupKeys) {
-		            String s = (String) o;
-		            IEntityGroup group = groupsTree.getGroups().get(s);
-		            rslt.add(group);
-		            rslt.addAll(getParentGroups(s, new HashSet<>()));
-		        }
-			} else if (log.isDebugEnabled()) {
-				log.debug("Unable to find groups for member: [{}]", gm.getKey());
-			}
+            if ((groupsTree != null) && (groupsTree.getGroups() != null)) {
+                Object[] groupKeys = getPersonGroupMemberKeys(gm);
+                for (Object o : groupKeys) {
+                    String s = (String) o;
+                    IEntityGroup group = groupsTree.getGroups().get(s);
+                    rslt.add(group);
+                    rslt.addAll(getParentGroups(s, new HashSet<>()));
+                }
+            } else if (log.isDebugEnabled()) {
+                log.debug("Unable to find groups for member: [{}]", gm.getKey());
+            }
         }
         return rslt.iterator();
     }
@@ -496,18 +496,19 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
         }
 
         List<EntityIdentifier> rslt = new ArrayList<>();
-		if(groupsTree != null) {
-			for (Map.Entry<String, List<String>> y : groupsTree.getKeysByUpperCaseName().entrySet()) {
-			    if (y.getKey().matches(regex)) {
-			        List<String> keys = y.getValue();
-			        for (String k : keys) {
-			            rslt.add(new EntityIdentifier(k, IEntityGroup.class));
-			        }
-			    }
-			}
-		} else if (log.isDebugEnabled()) {
-			log.debug("Unable to find groups for query: [{}]", query);
-		}
+        if (groupsTree != null) {
+            for (Map.Entry<String, List<String>> y :
+                    groupsTree.getKeysByUpperCaseName().entrySet()) {
+                if (y.getKey().matches(regex)) {
+                    List<String> keys = y.getValue();
+                    for (String k : keys) {
+                        rslt.add(new EntityIdentifier(k, IEntityGroup.class));
+                    }
+                }
+            }
+        } else if (log.isDebugEnabled()) {
+            log.debug("Unable to find groups for query: [{}]", query);
+        }
 
         return rslt.toArray(new EntityIdentifier[rslt.size()]);
     }

--- a/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
+++ b/uPortal-groups/uPortal-groups-smartldap/src/main/java/org/apereo/portal/groups/smartldap/SmartLdapGroupStore.java
@@ -260,13 +260,17 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
                     group.getName());
             getParentGroups(group.getLocalKey(), rslt);
         } else if (!gm.isGroup() && gm.getLeafType().equals(root.getLeafType())) {
-            Object[] groupKeys = getPersonGroupMemberKeys(gm);
-            for (Object o : groupKeys) {
-                String s = (String) o;
-                IEntityGroup group = groupsTree.getGroups().get(s);
-                rslt.add(group);
-                rslt.addAll(getParentGroups(s, new HashSet<>()));
-            }
+			if((groupsTree != null) && (groupsTree.getGroups() != null)) {
+		        Object[] groupKeys = getPersonGroupMemberKeys(gm);
+		        for (Object o : groupKeys) {
+		            String s = (String) o;
+		            IEntityGroup group = groupsTree.getGroups().get(s);
+		            rslt.add(group);
+		            rslt.addAll(getParentGroups(s, new HashSet<>()));
+		        }
+			} else if (log.isDebugEnabled()) {
+				log.debug("Unable to find groups for member: [{}]", gm.getKey());
+			}
         }
         return rslt.iterator();
     }
@@ -492,14 +496,18 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
         }
 
         List<EntityIdentifier> rslt = new ArrayList<>();
-        for (Map.Entry<String, List<String>> y : groupsTree.getKeysByUpperCaseName().entrySet()) {
-            if (y.getKey().matches(regex)) {
-                List<String> keys = y.getValue();
-                for (String k : keys) {
-                    rslt.add(new EntityIdentifier(k, IEntityGroup.class));
-                }
-            }
-        }
+		if(groupsTree != null) {
+			for (Map.Entry<String, List<String>> y : groupsTree.getKeysByUpperCaseName().entrySet()) {
+			    if (y.getKey().matches(regex)) {
+			        List<String> keys = y.getValue();
+			        for (String k : keys) {
+			            rslt.add(new EntityIdentifier(k, IEntityGroup.class));
+			        }
+			    }
+			}
+		} else if (log.isDebugEnabled()) {
+			log.debug("Unable to find groups for query: [{}]", query);
+		}
 
         return rslt.toArray(new EntityIdentifier[rslt.size()]);
     }
@@ -718,7 +726,7 @@ public final class SmartLdapGroupStore implements IEntityGroupStore {
                 log.warn(
                         "Both attributesMapper and contextMapper are set -- attributesMapper will be used");
             }
-            req.setAttribute("mapperType", "attributes");
+            req.setAttribute("mapperType", "attribute");
             req.setAttribute("attributesMapper", attributesMapper);
         } else if (contextMapper != null) {
             req.setAttribute("mapperType", "context");

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/groups/smartldap/init.crn
@@ -18,6 +18,7 @@
     under the License.
 
 -->
+<!-- If using a ContextMapper, include an attribute of `context-mapper` without an `attributes-mapper` -->
 <with-attribute key="FOLDERS" value="${groovy([:])}">
     <ldap-search
         context-source="${ldapContext}"
@@ -26,7 +27,6 @@
         scope="${groovy(javax.naming.directory.SearchControls.SUBTREE_SCOPE)}"
         mapper-type="${mapperType}"
         attributes-mapper="${attributesMapper}"
-        context-mapper="${contextMapper}"
         resolveMemberGroups="${resolveMemberGroups}"
         attribute-name="record"
         >


### PR DESCRIPTION
History in #2141

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
- Changed the default smartLDAP to use a `attribute-mapper`.  Users wanting a `context-mapper` will need to override the `init.crn`.
- Added some logging to aid in troubleshooting
- Minor changes to make the smartLDAP start up smoother


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
